### PR TITLE
docs: sprint 1 initial docs

### DIFF
--- a/docs/demo1/API.md
+++ b/docs/demo1/API.md
@@ -1,0 +1,69 @@
+# Demo 1 Preliminary API Contracts
+
+## Purpose
+
+This document collects preliminary API contracts for Sprint 1 Demo 1. Contracts should support frontend, backend, SRS, domain, and testing alignment without becoming final production specifications.
+
+## API Contract Principles (Rudolph)
+
+### Preliminary Contract Baseline
+
+### Request Summary Format
+
+### Response Summary Format
+
+### Common Error Responses
+
+### Domain Entity References
+
+### Requirement and Traceability References
+
+## Base Feature Contracts (Rudolph)
+
+### `POST /auth/register`
+
+### `POST /auth/login`
+
+### General Validation and Error Responses
+
+## UC-01: Simulated Inbox Contracts (Rudolph)
+
+### `GET /simulations/inbox`
+
+### `GET /simulations/emails/:emailId`
+
+### `POST /simulations/emails/:emailId/interactions`
+
+## UC-02: Training Document Contracts (Rudolph)
+
+### `GET /training/assigned`
+
+### `GET /training/:trainingId`
+
+### `POST /training/:trainingId/progress`
+
+## UC-03: Quiz Flow Contracts (Rudolph)
+
+### `GET /quizzes/:quizId`
+
+### `POST /quizzes/:quizId/attempts`
+
+### `POST /quiz-attempts/:attemptId/submit`
+
+### `GET /quiz-attempts/:attemptId/results`
+
+## Supporting Admin/Campaign Context (Rudolph)
+
+### `POST /campaigns`
+
+### `POST /campaigns/:campaignId/assign`
+
+## Cross-References
+
+### SRS
+
+### Domain Diagrams
+
+### Testing
+
+### Traceability

--- a/docs/demo1/DESIGN.md
+++ b/docs/demo1/DESIGN.md
@@ -1,31 +1,121 @@
-# Design Specification for Insightful Phish
+# Demo 1 Design Specification
 
-## Brand Style
+## Purpose
+
+This document collects Demo 1 design guidance, brand direction, UI rules, learner navigation notes, and wireframe references.
+
+## Demo 1 Design Scope
+
+### UC-01: View Emails in Simulated Inbox
+
+### UC-02: View Training Document
+
+### UC-03: Complete Quiz Flow
+
+### Base Feature Screens
+
+## Brand Style Guide (Connor)
 
 ### Colour Palette
 
-### Typography
+### Typography Hierarchy
 
-### Logo and Iconography
+### Logo Usage
 
-### User Interface Component Styling
+### Logo Spacing and Minimum Size
 
-### Accessibility Considerations
+### Do's and Don'ts
 
-## Wireframes
+### Iconography Direction
 
-### Screen Layouts
+### Component Styling Principles
 
-### Navigation Flow
+## First-Pass Wireframe Direction (Zoë)
 
-### Component Placement
+### Register
 
-### User Interaction Points
+### Login
 
-### Annotations and Notes
+### Learner/Employee Dashboard
 
----
+### Simulated Inbox
 
-## Appendix of changes
+### Simulated Email Detail
 
-Initial creation of design document.
+### Training Module List
+
+### Training Material Page
+
+### Quiz Page
+
+### Quiz Submission State
+
+### Quiz Results Page
+
+### Phishing Feedback Page
+
+## Wireframe Refinement and Polish (Connor)
+
+### UI/UX Refinement
+
+### Visual Consistency
+
+### Brand and Style Alignment
+
+### Component Spacing
+
+### Visual Hierarchy
+
+### Final Review Notes
+
+## Feedback, Validation, and Accessibility UI Rules (Zoë)
+
+### Field-Level Validation Messages
+
+### Page-Level Error Banners
+
+### Success Messages
+
+### Warning Messages
+
+### Empty States
+
+### Loading and Submitting States
+
+### Disabled States
+
+### Quiz Feedback Display
+
+### Phishing Feedback Display
+
+### Accessible Message Presentation
+
+### Keyboard Interaction Expectations
+
+### Screen-Reader Feedback Expectations
+
+### Contrast Considerations
+
+## Learner Navigation and Training Screen Behaviour (Connor)
+
+### Dashboard to Training Module List
+
+### Training Module List to Training Material
+
+### Training Material to Quiz Flow
+
+### Return Navigation
+
+### Loading, Empty, Locked, Unavailable, and Error States
+
+## Wireframe References
+
+### `docs/demo1/wireframes/`
+
+## Cross-References
+
+### SRS
+
+### API
+
+### Testing

--- a/docs/demo1/SRS.md
+++ b/docs/demo1/SRS.md
@@ -1,31 +1,153 @@
-# Software Requirements Specification (SRS) for Insightful Phish
+# Demo 1 Software Requirements Specification
 
-## Introduction
+## Purpose
 
-## User Stories
+This document collects Sprint 1 Demo 1 requirements for the Cybersecurity Awareness Training Platform.
 
-## Use Cases
+## Demo 1 Scope
 
-## Functional Requirements
+### UC-01: View Emails in Simulated Inbox
 
-## API Contracts
+### UC-02: View Training Document
 
-## Domain Model
+### UC-03: Complete Quiz Flow
 
-## Architectural Requirements
+## Base Features
 
-### Quality Requirements
+### Login/Register
 
-### Architectural Patterns
+### Themes
 
-### Design Patterns
+### General Form Validation
 
-### Constraints
+## Document Structure and Integration (Johan)
 
-## Technical Requirements
+### Introduction
 
----
+### Project Scope
 
-## Appendix of changes
+### User Characteristics
 
-Initial creation of design document.
+### Assumptions
+
+### Dependencies
+
+### Cross-Reference Structure
+
+## UC-01: Simulated Inbox Requirements (Adriano)
+
+### User Story
+
+### Actor
+
+### Preconditions
+
+### Postconditions
+
+### Main Flow
+
+### Exceptions
+
+### Functional Requirements
+
+### Domain References
+
+### API References
+
+### Traceability References
+
+## UC-02: Training Document Viewing Requirements (Connor)
+
+### User Story
+
+### Actor
+
+### Preconditions
+
+### Postconditions
+
+### Main Flow
+
+### Exceptions
+
+### Functional Requirements
+
+### Domain References
+
+### API References
+
+### Traceability References
+
+## UC-03: Quiz Flow Requirements (Zoë)
+
+### User Story
+
+### Actor
+
+### Preconditions
+
+### Postconditions
+
+### Main Flow
+
+### Exceptions
+
+### Functional Requirements
+
+### Domain References
+
+### API References
+
+### Traceability References
+
+## Validation, Error-State, and Feedback Requirements (Zoë)
+
+### Required Field Validation
+
+### Quiz Answer Validation
+
+### Submission Feedback
+
+### Success Messages
+
+### Error Messages
+
+### Loading States
+
+### Empty States
+
+## Interaction Tracking, Progress, and Reporting Requirements (Adriano)
+
+### Simulated Inbox Interaction Tracking
+
+### Training Progress
+
+### Quiz Attempts
+
+### Quiz Results
+
+### Preliminary Reporting Support
+
+## Admin and Campaign Supporting Context (Rudolph)
+
+### Administrator User Characteristics
+
+### Basic Campaign Concept
+
+### Employee Assignment Context
+
+### Simulation Content Setup
+
+### Training and Quiz Setup
+
+## Supporting Document References
+
+### Domain Model and Diagrams
+
+### API Contracts
+
+### Architecture and Technical Requirements
+
+### Design and Wireframes
+
+### Testing and Traceability

--- a/docs/demo1/architecture.md
+++ b/docs/demo1/architecture.md
@@ -1,0 +1,83 @@
+# Demo 1 Architecture and Technical Requirements
+
+## Purpose
+
+This document collects preliminary Demo 1 architecture, quality requirements, design patterns, technical requirements, constraints, and developer workflow safeguards.
+
+## Architecture Scope (Rudolph)
+
+### UC-01: View Emails in Simulated Inbox
+
+### UC-02: View Training Document
+
+### UC-03: Complete Quiz Flow
+
+## Quality Requirements (Rudolph)
+
+### Security
+
+### Reliability
+
+### Maintainability
+
+### Modularity
+
+### Scalability
+
+### Usability and Accessibility
+
+### Testability
+
+## Architectural Approach (Rudolph)
+
+### System Overview
+
+### Frontend Boundary
+
+### Backend API Boundary
+
+### Database Boundary
+
+### Shared Types and Constants
+
+## Design Patterns and Simulation Modularity (Rudolph)
+
+### Simulation Type Modularity
+
+### Email Simulation
+
+### Future Simulation Types
+
+### Training Module and Quiz Separation
+
+### Interaction Event Tracking
+
+### Progress Tracking
+
+## Technical Requirements and Constraints (Rudolph)
+
+### Frontend Application
+
+### Backend API
+
+### Database and Prisma Usage
+
+### Authentication and Base Features
+
+### Automated Testing
+
+### Safe Simulated Data
+
+### Data Privacy
+
+### Sprint 1 Constraints
+
+## Cross-References
+
+### SRS
+
+### API
+
+### Testing
+
+### Traceability

--- a/docs/demo1/diagrams/README.md
+++ b/docs/demo1/diagrams/README.md
@@ -1,0 +1,41 @@
+# Demo 1 Diagrams
+
+## Purpose
+
+This folder stores or indexes diagram sources and exports for Demo 1 planning documentation.
+
+## Use Case Diagrams (Johan)
+
+### UC-01: View Emails in Simulated Inbox
+
+### UC-02: View Training Document
+
+### UC-03: Complete Quiz Flow
+
+### Base Features
+
+### Supporting Admin Context
+
+## Domain Model Diagrams (Adriano)
+
+### UML Class Diagram
+
+### Domain Model Explanation Support
+
+## Architecture Diagrams (Rudolph)
+
+### High-Level Architecture
+
+### Simulation Modularity
+
+### Interaction and Progress Flow
+
+## References
+
+### SRS Reference
+
+### Architecture Reference
+
+### API Reference
+
+### Traceability Reference

--- a/docs/demo1/testing.md
+++ b/docs/demo1/testing.md
@@ -1,0 +1,75 @@
+# Demo 1 QA and Testing Plan
+
+## Purpose
+
+This document collects the Sprint 1 Demo 1 QA/testing plan for the three core use cases and required base features.
+
+## Testing Scope (Zoë)
+
+### UC-01: View Emails in Simulated Inbox
+
+### UC-02: View Training Document
+
+### UC-03: Complete Quiz Flow
+
+### Base Feature: Login/Register
+
+### Base Feature: Themes
+
+### Base Feature: General Form Validation
+
+## UC-01 Test Planning: Simulated Inbox (Zoë)
+
+### Success Scenarios
+
+### Negative and Error Scenarios
+
+### Suggested Automated Test Level
+
+### Manual Demo Verification Notes
+
+## UC-02 Test Planning: Training Document View (Zoë)
+
+### Success Scenarios
+
+### Negative and Error Scenarios
+
+### Suggested Automated Test Level
+
+### Manual Demo Verification Notes
+
+## UC-03 Test Planning: Quiz Flow (Zoë)
+
+### Success Scenarios
+
+### Negative and Error Scenarios
+
+### Suggested Automated Test Level
+
+### Manual Demo Verification Notes
+
+## Base Feature Test Planning (Zoë)
+
+### Login/Register
+
+### Themes
+
+### General Form Validation
+
+## Suggested Test Levels
+
+### Unit
+
+### Integration
+
+### Frontend
+
+### Backend
+
+### End-to-End
+
+## Traceability References
+
+### SRS Requirements
+
+### Traceability Rows

--- a/docs/demo1/traceability.md
+++ b/docs/demo1/traceability.md
@@ -1,0 +1,44 @@
+# Demo 1 Traceability Table
+
+## Purpose
+
+This document links Demo 1 user stories, use cases, functional requirements, API contracts, domain entities, design artefacts, and QA/test planning.
+
+## Traceability Scope (Johan)
+
+### UC-01: View Emails in Simulated Inbox
+
+### UC-02: View Training Document
+
+### UC-03: Complete Quiz Flow
+
+### Base Feature: Login/Register
+
+### Base Feature: Themes
+
+### Base Feature: General Form Validation
+
+## Traceability Table
+
+| Area                     | User Story | Use Case     | Functional Requirements | API Contracts | Domain Entities | Design/Wireframes | QA/Test References | Owner   | Status  |
+| ------------------------ | ---------- | ------------ | ----------------------- | ------------- | --------------- | ----------------- | ------------------ | ------- | ------- |
+| UC-01: Simulated Inbox   | Pending    | UC-01        | Pending                 | Pending       | Pending         | Pending           | Pending            | Adriano | Pending |
+| UC-02: Training Document | Pending    | UC-02        | Pending                 | Pending       | Pending         | Pending           | Pending            | Connor  | Pending |
+| UC-03: Quiz Flow         | Pending    | UC-03        | Pending                 | Pending       | Pending         | Pending           | Pending            | Zoë     | Pending |
+| Base: Login/Register     | Pending    | Base feature | Pending                 | Pending       | Pending         | Pending           | Pending            | Pending | Pending |
+| Base: Themes             | Pending    | Base feature | Pending                 | Pending       | Pending         | Pending           | Pending            | Pending | Pending |
+| Base: General Validation | Pending    | Base feature | Pending                 | Pending       | Pending         | Pending           | Pending            | Zoë     | Pending |
+
+## Integration Notes (Johan)
+
+### SRS References
+
+### API References
+
+### Domain References
+
+### Design and Wireframe References
+
+### Testing References
+
+### Missing Reference Owners

--- a/docs/demo1/wireframes/README.md
+++ b/docs/demo1/wireframes/README.md
@@ -1,0 +1,45 @@
+# Demo 1 Wireframes
+
+## Purpose
+
+This folder stores or indexes wireframe sources, exports, or links for Demo 1 screens.
+
+## First-Pass Wireframes (Zoë)
+
+Zoë owns the initial Figma frames and first-pass user-flow coverage.
+
+### Register
+
+### Login
+
+### Learner/Employee Dashboard
+
+### Simulated Inbox
+
+### Simulated Email Detail
+
+### Training Module List
+
+### Training Material Page
+
+### Quiz Page
+
+### Quiz Submission State
+
+### Quiz Results Page
+
+### Phishing Feedback Page
+
+## Refinement and Polish (Connor)
+
+Connor owns the quality sweep after Zoë's first-pass wireframes are available.
+
+### UI/UX Refinement
+
+### Visual Consistency
+
+### Brand and Style Alignment
+
+### Spacing and Hierarchy
+
+### Final Review Polish


### PR DESCRIPTION
## Summary

Added initial skeleton documentation files for Sprint 1 (Demo 1) under `docs/demo1/`. These files establish a consistent structure for SRS, API contracts, architecture, testing, traceability, and design, with clear headings and ownership per team member.

The goal is to unblock parallel work by giving everyone a predefined place to contribute their feature slices, while ensuring consistency and easier integration later in the sprint.