### PR TITLE
Docs/srs validation feedback/zoe

### DIFF
--- a/docs/demo1/API.md
+++ b/docs/demo1/API.md
@@ -26,6 +26,21 @@ This document collects preliminary API contracts for Sprint 1 Demo 1. Contracts 
 
 ### General Validation and Error Responses
 
+These validation and error-response notes are preliminary and exist only to support Demo 1 SRS/design alignment. Final route names, response structures, status codes, and backend validation behaviour remain subject to the API contract owner’s refinement.
+
+For Demo 1, expected validation and error-response categories may include:
+
+- missing or invalid learner input;
+- unanswered required quiz questions;
+- unavailable training or quiz content;
+- failed training document load;
+- failed quiz submission;
+- duplicate quiz submission attempt;
+- failed quiz results or feedback load;
+- unauthorised access to assigned learner content.
+
+These categories support frontend feedback states and should not be treated as final backend implementation detail.
+
 ## UC-01: Simulated Inbox Contracts (Rudolph)
 
 ### `GET /simulations/inbox`

--- a/docs/demo1/DESIGN.md
+++ b/docs/demo1/DESIGN.md
@@ -46,11 +46,56 @@ This document collects Demo 1 design guidance, brand direction, UI rules, learne
 
 ### Training Material Page
 
+The training material page should support the UC-02 learner flow by presenting assigned training content in a readable, focused layout.
+
+Design notes:
+
+- Show a clear page title and training content heading.
+- Use readable spacing, paragraphs, and section breaks so the content is easy to scan.
+- Show a loading state while the document is being retrieved.
+- Show an empty or unavailable-content message if the document cannot be opened.
+- Provide a clear way back to the training list or learner dashboard.
+- If a linked quiz is available, present the quiz action as a clear next step without making quiz completion part of UC-02.
+- Feedback messages on this page should follow the shared validation, error-state, and accessibility rules.
+
 ### Quiz Page
+
+The quiz page should support UC-03 by allowing the learner to answer assigned quiz questions and understand what is required before submission.
+
+Design notes:
+
+- Show the quiz title and a brief instruction explaining that required questions must be answered.
+- Present questions in a clear order with enough spacing between question groups.
+- Required questions should be visually indicated and supported by text, not only colour.
+- Validation messages should appear near the relevant question when an answer is missing or invalid.
+- A page-level validation summary may be shown when multiple required answers are missing.
+- The submit action should be clearly visible after the questions.
+- The learner should be able to correct validation errors without losing existing answers.
 
 ### Quiz Submission State
 
+The quiz submission state should make it clear that the learner’s answers are being processed.
+
+Design notes:
+
+- Show a loading or submitting indicator after the learner submits the quiz.
+- Disable or guard the submit action while processing to prevent duplicate submissions.
+- Keep the learner on the quiz page or transition state until submission completes.
+- Do not show raw technical errors if submission fails.
+- If submission fails, explain the issue in learner-friendly language and provide a retry path where appropriate.
+
 ### Quiz Results Page
+
+The quiz results page should confirm that the quiz attempt was completed and provide educational feedback.
+
+Design notes:
+
+- Show a clear result summary after successful submission.
+- Display feedback in a supportive learning tone.
+- Where answer-level feedback is shown, distinguish correct and incorrect responses using text labels and visual treatment.
+- Avoid relying only on colour to communicate correctness.
+- Provide a clear navigation option back to the training material, module list, or learner dashboard.
+- If results cannot be loaded, show a safe error message and provide a retry or back-navigation option.
 
 ### Phishing Feedback Page
 
@@ -70,31 +115,230 @@ This document collects Demo 1 design guidance, brand direction, UI rules, learne
 
 ## Feedback, Validation, and Accessibility UI Rules (Zoë)
 
+These rules define supporting UI behaviour for Demo 1 validation, feedback, loading, empty, unavailable, and accessibility states. They support the learner-facing flows but do not create a separate Demo 1 use case.
+
+The rules apply mainly to:
+
+- UC-02: View training document
+- UC-03: Complete quiz flow
+- Login/Register as base feature support
+- Phishing feedback only as high-level contextual support
+
+The UI should help learners understand:
+
+- what is required;
+- what is happening;
+- what succeeded;
+- what failed;
+- what they can do next.
+
 ### Field-Level Validation Messages
+
+Field-level validation messages should appear close to the field, question, or input that needs attention.
+
+Rules:
+
+- Use field-level messages for missing required input, invalid answer format, or unsupported selections.
+- Keep messages short and specific.
+- Do not rely only on colour to identify the problem.
+- Required-field messages should explain what the learner needs to provide.
+- Quiz validation messages should appear near the relevant question where possible.
+- Existing learner input should remain visible after validation fails.
+
+Example wording:
+
+- “Please enter your email address.”
+- “Please answer this question before submitting.”
+- “Choose one option for this question.”
 
 ### Page-Level Error Banners
 
+Page-level error banners should be used when an issue affects the whole page, flow, or submission.
+
+Rules:
+
+- Place the banner near the top of the relevant content area.
+- Use plain, learner-friendly wording.
+- Explain the next safe action where possible.
+- Do not show stack traces, raw exception names, or backend implementation details.
+- Keep the learner on the current page when they can correct or retry the action.
+
+Appropriate uses include:
+
+- training document load failure;
+- quiz submission failure;
+- quiz results load failure;
+- unavailable assigned content;
+- authentication failure on login/register base screens.
+
 ### Success Messages
+
+Success messages should confirm that the learner’s action was completed.
+
+Rules:
+
+- Use success messages after meaningful completed actions, such as successful quiz submission.
+- Keep the message brief and calm.
+- Make the next step clear.
+- Avoid implying extra features outside Demo 1 scope.
+
+Example wording:
+
+- “Your quiz was submitted. Your results are ready.”
+- “Your progress has been saved.”
+- “You are signed in.”
 
 ### Warning Messages
 
+Warning messages should be used when the learner can continue but should be aware of a limitation or state.
+
+Rules:
+
+- Use warnings for non-blocking issues or important context.
+- Keep the tone helpful rather than alarming.
+- Explain whether the learner needs to take action.
+- Do not use warnings for normal required-field validation; use field-level validation instead.
+
+Examples:
+
+- “This training document is available, but progress may not be saved right now.”
+- “This quiz is currently unavailable. Please return to the training material.”
+
 ### Empty States
+
+Empty states should explain when there is no relevant content to show.
+
+Rules:
+
+- State clearly what is missing.
+- Avoid making the page look broken.
+- Provide a safe next step, such as returning to the dashboard.
+- Keep the wording learner-friendly.
+
+Applicable Demo 1 examples:
+
+- no assigned training documents;
+- no simulated inbox items;
+- no available quiz content.
 
 ### Loading and Submitting States
 
+Loading and submitting states should show that the system is working.
+
+Rules:
+
+- Use loading states when retrieving training content, quiz content, or results.
+- Use submitting states when sending quiz answers or form data.
+- Prevent duplicate submissions while a request is processing.
+- Avoid blank pages during loading.
+- Keep loading text short and understandable.
+
+Example wording:
+
+- “Loading training material…”
+- “Submitting your quiz…”
+- “Preparing your results…”
+
 ### Disabled States
+
+Disabled states should prevent actions that are temporarily unavailable or unsafe to repeat.
+
+Rules:
+
+- Disable or guard submit buttons while a quiz or form is being submitted.
+- Use disabled states only when the reason is clear from nearby context.
+- Disabled controls should still be visually understandable and accessible.
+- Do not rely only on disabled buttons for validation; show clear validation messages as well.
+
+Applicable Demo 1 examples:
+
+- quiz submit button while submission is processing;
+- login/register submit button while authentication is processing;
+- unavailable quiz action when no quiz is assigned.
 
 ### Quiz Feedback Display
 
+Quiz feedback should help the learner understand their result and learn from the attempt.
+
+Rules:
+
+- Show a clear result summary after successful submission.
+- Use supportive wording for incorrect answers.
+- Distinguish correct and incorrect answers with text labels and visual treatment.
+- Do not rely only on colour to show correctness.
+- Keep feedback educational, not punitive.
+- Provide a clear navigation path after the results.
+
+Example wording:
+
+- “Correct: This is a common sign of a suspicious link.”
+- “Review: This option can be risky because the sender cannot be verified.”
+
 ### Phishing Feedback Display
+
+Phishing feedback is high-level contextual support for Demo 1 and should not be treated as a separate core use case.
+
+Rules:
+
+- Keep phishing feedback focused on safe learning guidance.
+- Explain suspicious email indicators in plain language.
+- Link feedback to the simulated inbox context where relevant.
+- Avoid expanding this into a full phishing-feedback workflow unless separately scoped.
+- Do not include real credential collection, real phishing delivery, or unsafe simulation behaviour.
+
+Example guidance areas:
+
+- suspicious sender details;
+- urgent or threatening wording;
+- unexpected links or attachments;
+- mismatch between sender identity and message content.
 
 ### Accessible Message Presentation
 
+Feedback messages should be accessible and easy to perceive.
+
+Rules:
+
+- Place messages close to the relevant field, question, or content area.
+- Use text labels in addition to colour.
+- Ensure messages are readable at normal zoom levels.
+- Important page-level messages should be noticeable without disrupting the whole flow.
+- Learners should be able to reach recovery actions, such as retry or back navigation, using the keyboard.
+
 ### Keyboard Interaction Expectations
+
+Learners should be able to complete the Demo 1 learner flows using keyboard navigation.
+
+Rules:
+
+- Interactive elements should follow a logical tab order.
+- Buttons, links, quiz options, and recovery actions should be keyboard-accessible.
+- Focus should not be trapped unexpectedly.
+- After validation fails, the learner should be able to navigate to the relevant message or field.
+- Disabled controls should not create confusion in the focus order.
 
 ### Screen-Reader Feedback Expectations
 
+Screen-reader users should be able to understand important validation, loading, error, and success feedback.
+
+Rules:
+
+- Important messages should be written as meaningful text.
+- Messages should identify the relevant field, question, or page state.
+- Status changes such as submitting, success, or failure should be presented clearly.
+- Error summaries should help the learner find what needs attention.
+- Visual-only feedback, such as colour changes without text, should be avoided.
+
 ### Contrast Considerations
+
+Validation, error, success, warning, and feedback states should meet basic readability expectations.
+
+Rules:
+
+- Text must remain readable against its background.
+- Colour should support meaning but should not be the only way meaning is communicated.
+- Error, warning, and success states should have distinguishable labels or icons where appropriate.
+- Final colour choices should align with the Demo 1 brand style guide when available.
 
 ## Learner Navigation and Training Screen Behaviour (Connor)
 

--- a/docs/demo1/DESIGN.md
+++ b/docs/demo1/DESIGN.md
@@ -99,6 +99,10 @@ Design notes:
 
 ### Phishing Feedback Page
 
+This page is included only as high-level Demo 1 feedback context for the simulated phishing learner experience. It should not be treated as a separate core use case or a full phishing-feedback workflow for Demo 1.
+
+The page should summarise safe learning feedback about a simulated phishing interaction, such as suspicious sender details, urgent wording, or risky links. It should provide a clear path back to the learner dashboard, training material, or simulated inbox where relevant.
+
 ## Wireframe Refinement and Polish (Connor)
 
 ### UI/UX Refinement

--- a/docs/demo1/SRS.md
+++ b/docs/demo1/SRS.md
@@ -16,9 +16,40 @@ This document collects Sprint 1 Demo 1 requirements for the Cybersecurity Awaren
 
 ### Login/Register
 
+Login and registration are base features that support access to the Demo 1 learner flows. They are not counted as separate Demo 1 core use cases.
+
+The system should provide basic form validation for login and registration screens so that learners receive clear feedback before attempting to continue. Required fields should be checked before submission, and invalid or incomplete input should be explained using concise, non-technical messages.
+
+For Demo 1, login/register validation should support the following requirements:
+
+- Required input fields must be visibly identified before submission.
+- If a learner submits an incomplete form, the system must show which required fields need attention.
+- Error messages must be learner-friendly and should not expose technical implementation details.
+- While a login or registration request is being processed, the interface should show a loading or submitting state and prevent duplicate submission.
+- If authentication fails, the learner should receive a clear error message and remain on the relevant form so they can correct the issue.
+- If authentication succeeds, the learner should receive appropriate navigation feedback and continue to the relevant learner area.
+- These behaviours are supporting form requirements only and must not be treated as additional Demo 1 use cases.
+
 ### Themes
 
 ### General Form Validation
+
+General form validation is a supporting base feature for Demo 1. It exists to keep learner-facing forms, quiz submissions, and feedback states consistent, but it is not a separate core use case.
+
+Reusable validation rules for Demo 1 should follow these principles:
+
+- Required fields must be validated before submission where possible.
+- Validation messages must appear close to the relevant field, question, or action.
+- Page-level errors may be used when a problem affects the whole screen or submission.
+- Error messages must describe what the learner can do next, such as completing a missing answer or retrying a failed submission.
+- Technical details such as stack traces, raw database errors, or internal exception names must not be shown to learners.
+- Loading and submitting states must clearly indicate that the system is processing an action.
+- Buttons that could create duplicate requests should be disabled while the relevant action is being processed.
+- Success messages should confirm that the learner’s action was completed.
+- Empty and unavailable states should explain the situation and provide a safe next step where possible.
+- Feedback messages should be accessible, readable, and understandable without relying only on colour.
+
+These rules apply as supporting guidance for UC-02 and UC-03, and as base-feature support for login/register and other simple Demo 1 forms.
 
 ## Document Structure and Integration (Johan)
 
@@ -196,11 +227,11 @@ This use case is limited to viewing training content and recording basic interac
 
 ### Actor
 
-#### Primary Actor:
+#### Primary Actor
 
 - Learner
 
-#### Supporting Actors:
+#### Supporting Actors
 
 - System
 - Administrator (as a supporting context for assigning training content via campaigns)
@@ -214,7 +245,7 @@ This use case is limited to viewing training content and recording basic interac
 
 ### Postconditions
 
-#### Successful Postconditions:
+#### Successful Postconditions
 
 - The learner can view a list of assigned training documents.
 - The learner can open and read a selected training document.
@@ -222,7 +253,7 @@ This use case is limited to viewing training content and recording basic interac
 - The learner understands that the content is part of a structured training experience.
 - If a quiz is linked, the system may display a link or button to proceed to the associated quiz.
 
-#### Unsuccessful Postconditions:
+#### Unsuccessful Postconditions
 
 - If no training documents are assigned, the learner sees an appropriate empty state.
 - If a selected training document cannot be found, the learner sees a safe error state.
@@ -273,6 +304,22 @@ If the system cannot record training interaction, the system should not expose t
 | `FR-UC02-08` | The system shall not allow modification of training content by learners.                        | **Must** | Maintains scope boundary.                                                                                                      |
 | `FR-UC02-09` | The system shall treat all training documents as controlled educational content.                | **Must** | Reinforces training context.                                                                                                   |
 | `FR-UC02-10` | The system shall allow the learner to access training content independently of quiz completion. | Should   | Maintains separation between `UC-02` and `UC-03`.                                                                              |
+
+### UC-02 Validation, Error-State, and Feedback Support
+
+The training document view should use the shared validation and feedback rules defined for Demo 1. These rules support the learner experience without expanding UC-02 beyond viewing assigned training content.
+
+For UC-02, the system should provide the following feedback states:
+
+- **Loading state:** When assigned training documents or document details are being loaded, the learner should see a clear loading indication instead of an empty or broken page.
+- **Empty state:** If the learner has no assigned training documents, the system should show a friendly empty-state message explaining that no training is currently available.
+- **Unavailable-content state:** If a selected training document is missing, unavailable, or no longer assigned, the system should explain that the content cannot be opened and provide a safe way to return to the training list or dashboard.
+- **Load-failure state:** If the document cannot be loaded because of a system or network problem, the learner should see a non-technical error message and, where appropriate, a retry or back-navigation option.
+- **Progress feedback:** If the system records that the learner opened or viewed a document, this should happen without interrupting the reading experience. If progress tracking fails, the learner should still be able to read the content.
+- **Quiz-link feedback:** If the document links to a quiz, the interface should make it clear that selecting the quiz link starts or continues the quiz flow under UC-03.
+- **Accessible feedback:** Training feedback messages should be readable, keyboard-accessible, and understandable without relying only on colour.
+
+These feedback rules are limited to supporting the training document viewing flow. They do not add content authoring, admin content management, or quiz completion behaviour to UC-02.
 
 ### Domain References
 
@@ -393,6 +440,27 @@ If the submitted attempt cannot load its results or feedback, the system display
 | FR-UC03-09 | The system shall prevent further editing or duplicate final submission of a completed quiz attempt.                         |     Must | A completed attempt should remain read-only.                                              |
 | FR-UC03-10 | The system shall display safe validation and error states when quiz content, attempt creation, submission, or results fail. |     Must | Messages should be clear, non-technical, and safe for the learner.                        |
 
+### UC-03 Validation, Submission, and Feedback Support
+
+The quiz flow must provide clear validation and feedback so that the learner understands what is required, what is being processed, and what result or next step is available. These rules support UC-03 and do not create a separate validation use case.
+
+For UC-03, the system should support the following behaviours:
+
+- **Required-answer validation:** The learner must be informed when one or more required quiz questions have not been answered before submission.
+- **Answer-format validation:** If an answer is malformed, unsupported, or cannot be accepted, the system should show a clear message explaining what needs to be corrected.
+- **Inline guidance:** Validation messages should appear close to the relevant question where possible, with a page-level summary used only when helpful.
+- **Submission state:** When the learner submits a quiz, the system should show a submitting or processing state.
+- **Duplicate-submission prevention:** The submit action should be disabled or guarded while the submission is being processed.
+- **Submission success feedback:** After a successful submission, the learner should receive confirmation that the attempt was submitted and that results or feedback are available.
+- **Submission failure feedback:** If submission fails, the learner should see a safe, non-technical error message and should not lose their current answers where possible.
+- **Results-loading feedback:** If quiz results or feedback are still loading, the system should indicate that the result is being prepared.
+- **Results failure feedback:** If results cannot be loaded, the learner should receive a retry or safe navigation option.
+- **Educational feedback:** Quiz feedback should explain correct and incorrect answers in a supportive learning tone.
+- **Unavailable quiz state:** If a quiz is unavailable, empty, or no longer assigned, the system should explain the situation and provide a safe way back to the training material or learner dashboard.
+- **Accessible feedback:** Quiz validation, submission, and result messages should be perceivable to keyboard and screen-reader users and should not rely only on colour.
+
+The quiz flow should prioritise clear learner recovery: the learner should know what happened, what needs attention, and what action they can take next.
+
 ### Domain References
 
 Preliminary domain entities linked to UC-03:
@@ -432,65 +500,90 @@ PLEASE NOTE: These contracts are subject to change throughout the course of impl
 
 ## Validation, Error-State, and Feedback Requirements (Zoë)
 
+This section defines supporting validation, error-state, and feedback requirements for Demo 1 learner-facing flows. These requirements support UC-02, UC-03, and base form behaviour, but they are not a separate Demo 1 core use case.
+
+Demo 1 core use cases remain limited to:
+
+- UC-01: View emails in simulated inbox
+- UC-02: View training document
+- UC-03: Complete quiz flow
+
 ### Required Field Validation
 
-For Demo 1, quiz submission should validate that all required questions have an answer before the final submission is accepted. If a required answer is missing, the system should identify the affected question and allow the employee to complete it without losing other answers.
+For Demo 1, required fields and required quiz questions should be validated before final submission is accepted. If required information is missing, the system should identify the affected field or question and allow the learner to complete it without losing other valid input.
+
+For UC-03, quiz submission should validate that all required questions have an answer before the final submission is accepted.
 
 ### Quiz Answer Validation
 
-Quiz answer validation is limited to ensuring that the submitted answer matches the expected input structure for the question type supported in Demo 1. The system should reject malformed or unsupported answer data safely and display a clear correction message to the employee.
+Quiz answer validation is limited to ensuring that submitted answers match the expected input structure for the question types supported in Demo 1. The system should reject malformed or unsupported answer data safely and display a clear correction message to the learner.
+
+This requirement does not define final backend validation logic or final quiz schemas.
 
 ### Submission Feedback
 
-When the employee submits a quiz attempt, the system should show clear progress feedback that the attempt is being processed. If submission fails, the system should explain that the attempt was not completed and allow a safe retry where possible.
+When the learner submits a quiz attempt, the system should show clear progress feedback that the attempt is being processed. During this state, duplicate submission actions should be prevented where possible.
+
+If submission fails, the system should explain that the attempt was not completed and allow a safe retry where possible.
 
 ### Success Messages
 
-After a successful submission, the employee should receive a confirmation that the quiz was submitted and that results are available. Success messaging should be concise, learner-facing, and consistent with the controlled training context.
+After a successful submission, the learner should receive confirmation that the quiz was submitted and that results are available. Success messaging should be concise, learner-facing, and consistent with the controlled training context.
+
+Success messages may also support base features, such as confirming successful login or registration, where relevant.
 
 ### Error Messages
 
-Quiz errors should be presented in plain, non-technical language. Messages should distinguish between loading failures, validation issues, submission failures, and results-loading failures without exposing internal system details.
+Errors should be presented in plain, non-technical language. Messages should distinguish between validation issues, unavailable content, loading failures, submission failures, and results-loading failures without exposing internal system details.
+
+Error messages should explain what happened at a learner-facing level and what action the learner can take next.
 
 ### Loading States
 
-The system should provide a visible loading state when quiz content, submission, results, or feedback are being retrieved or processed. During final submission, duplicate submission actions should be prevented where possible.
+The system should provide a visible loading state when training content, quiz content, submission, results, or feedback are being retrieved or processed. The learner should not be left on a blank or broken page while content is loading.
+
+During final quiz submission, duplicate submission actions should be prevented where possible.
 
 ### Empty States
 
-If a quiz has no available questions, no available results, or no available feedback, the system should present a safe empty or unavailable state with a clear return path for the employee.
+If a learner has no assigned training documents, or if a quiz has no available questions, results, or feedback, the system should present a safe empty or unavailable state with a clear return path.
 
-## Interaction Tracking, Progress, and Reporting Requirements
+Empty states should explain the situation in learner-friendly language and should not make the page appear broken.
 
-### Simulated Inbox Interaction Tracking
+### Unavailable-Content States
 
-For Demo 1, simulated inbox tracking is limited to lightweight learner/employee interaction events that support future traceability and reporting.
+If assigned content cannot be accessed, such as a missing training document or unavailable quiz, the system should explain that the content is not currently available and provide a safe way to return to the training list, quiz page, or learner dashboard.
 
-The primary tracked interaction for UC-01 is opening or viewing a simulated email. This event helps the system later determine whether a learner engaged with a simulated email item.
+Unavailable-content messages should not blame the learner or expose internal system details.
 
-| ID          | Requirement                                                                                                              | Notes                                                                        |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| TRK-UC01-01 | The system should record when a learner opens a simulated email.                                                         | Supports later reporting and campaign analysis.                              |
-| TRK-UC01-02 | The system may record when a learner views the simulated inbox list.                                                     | Optional for Demo 1.                                                         |
-| TRK-UC01-03 | The system should record event metadata such as learner reference, simulated email reference, event type, and timestamp. | Exact implementation fields are preliminary.                                 |
-| TRK-UC01-04 | The system must not record real passwords, real credentials, or sensitive user input as part of UC-01.                   | Important safety and privacy requirement.                                    |
-| TRK-UC01-05 | Interaction tracking failure should not prevent the learner from safely viewing simulated content where possible.        | Avoids blocking the learner experience due to non-critical tracking failure. |
+### Accessibility Considerations
 
-### Training Progress
+Validation, feedback, loading, empty, and error messages should be accessible to learners using keyboard navigation or assistive technologies.
 
-Training progress is primarily covered by UC-02. UC-01 may only reference training progress when a simulated email provides a safe follow-up link or feedback prompt to related training content about the specific email.
+At minimum:
 
-### Quiz Attempts
+- important messages should appear near the relevant content, field, question, or action;
+- feedback should not rely only on colour;
+- recovery actions such as retry, return, or continue should be keyboard-accessible;
+- screen-reader users should be able to understand important validation, submission, success, and error states.
 
-Quiz attempts are covered by UC-03 and are out of scope for UC-01.
+### User-Friendly Wording Guidelines
 
-### Quiz Results
+Feedback wording should be clear, calm, and supportive. The system should avoid harsh, vague, or technical phrasing.
 
-Quiz results are covered by UC-03 and are out of scope for UC-01.
+Preferred examples:
 
-### Preliminary Reporting Support
+- “Please answer all required questions before submitting.”
+- “We could not load this training document. Please try again or return to the training list.”
+- “Your quiz was submitted. Your results are ready.”
+- “This quiz is not currently available.”
 
-UC-01 prepares for future reporting by defining lightweight interaction events. Demo 1 does not require a full reporting dashboard for simulated inbox behaviour.
+Avoid examples:
+
+- “Validation failed.”
+- “Invalid payload.”
+- “Unhandled exception.”
+- “Backend submission error.”
 
 ## Admin and Campaign Supporting Context (Rudolph)
 


### PR DESCRIPTION
## Summary

Added Demo 1 validation, error-state, and feedback documentation for learner-facing flows, with primary focus on UC-03 quiz completion.

This PR documents reusable supporting rules for:

- required-field validation
- quiz answer validation
- submission feedback
- success and error messages
- loading/submitting states
- empty and unavailable-content states
- accessibility considerations
- learner-friendly wording guidelines

It also adds supporting design guidance for validation and feedback UI states, plus a small preliminary API note for expected validation/error response categories.

## Related issue(s)

Closes #4 

## Type of change

- [x] Documentation
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Chore

## Files / Areas changed

- `docs/demo1/SRS.md`
  - Added base-feature validation support for Login/Register and General Form Validation.
  - Added UC-02 support wording for loading, empty, unavailable, error, and accessibility states.
  - Added UC-03 validation, submission, result, and feedback support wording.
  - Clarified that validation and feedback are supporting/cross-cutting requirements, not a new Demo 1 use case.

- `docs/demo1/DESIGN.md`
  - Added practical UI rules for validation messages, error banners, success/warning states, empty states, loading/submitting states, disabled states, quiz feedback, phishing feedback, and accessibility.
  - Added light screen notes for training material, quiz page, quiz submission state, quiz results, and phishing feedback scope.

- `docs/demo1/API.md`
  - Added preliminary validation/error response category notes for Demo 1 alignment.
  - Kept API details high-level and deferred final route names, schemas, status codes, and backend behaviour to the API contract owner.

## Scope notes

Validation and feedback remain supporting/base requirements only.

This PR does **not**:

- add a new Demo 1 use case
- add UC-04
- define backend validation implementation details
- create final UI components
- document every future form
- finalise API routes, schemas, status codes, or backend behaviour
- expand phishing feedback into a full standalone Demo 1 flow

Demo 1 core use cases remain:

- UC-01: View emails in simulated inbox
- UC-02: View training document
- UC-03: Complete quiz flow

## Testing / Verification

Documentation-only change.

Read-only completion check confirmed:

- branch: `docs/srs-validation-feedback/zoe`
- working tree was clean
- SRS content was complete for review
- DESIGN content was mostly complete and aligned with the issue
- API note was high-level and non-invasive
- validation/feedback was not turned into a new core use case

## Notes for reviewers

- `docs/demo1/DESIGN.md` is the actual design file path in the repo; `docs/demo1/design.md` does not exist.
- UC-03 route naming is still inconsistent between `SRS.md` and `API.md`. I did not change route names because API route naming should be aligned later by the API/integration owners.
- API changes are intentionally minimal and preliminary to avoid interfering with Rudolph’s API contract work.

## Checklist

- [x] Documentation only
- [x] UC-02 covered at a high level for validation/error/loading states
- [x] UC-03 covered for quiz validation, submission, feedback, and results states
- [x] Login/Register kept as base-feature support
- [x] Phishing feedback kept high-level
- [x] Validation not treated as a separate Demo 1 use case
- [x] API details kept preliminary
- [x] No code changes