### PR TITLE
fix: run husky hooks through bash handoff

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,6 +10,8 @@ assignees: ''
 
 What is broken?
 
+**Suggested branch name:**
+
 ## Expected vs Actual
 
 - Expected:

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,13 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  if command -v bash >/dev/null 2>&1; then
+    exec bash "$0" "$@"
+  fi
+
+  echo "Husky commit-msg requires bash. Install Git Bash, WSL, or bash on PATH."
+  exit 127
+fi
 
 set -euo pipefail
 

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,13 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  if command -v bash >/dev/null 2>&1; then
+    exec bash "$0" "$@"
+  fi
+
+  echo "Husky post-checkout requires bash. Install Git Bash, WSL, or bash on PATH."
+  exit 127
+fi
 
 set -euo pipefail
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,13 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  if command -v bash >/dev/null 2>&1; then
+    exec bash "$0" "$@"
+  fi
+
+  echo "Husky pre-commit requires bash. Install Git Bash, WSL, or bash on PATH."
+  exit 127
+fi
 
 set -euo pipefail
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,13 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  if command -v bash >/dev/null 2>&1; then
+    exec bash "$0" "$@"
+  fi
+
+  echo "Husky pre-push requires bash. Install Git Bash, WSL, or bash on PATH."
+  exit 127
+fi
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Updated the Husky hook entry files so they remain compatible with Husky's `sh` launcher while still running the existing Bash-based hook logic correctly.

Husky was invoking hooks through `sh`, which caused Linux environments where `sh` is `dash` to fail on Bash-only syntax like `set -euo pipefail`. The hooks now start with a small POSIX-compatible check that re-runs the hook with `bash` when needed.

Also updated the bug issue template to include:
**Suggested branch name:**
This matches the other issue templates.

## Linked Issue

Closes #43 

## Type of change

- [ ] Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Chore/Maintenance

## Testing

Verified locally:

- Ran `sh -n` on the Husky hook files to confirm thecheck syntax is valid under `sh`.
- Ran `bash -n` on the Husky hooks and `scripts/*.sh` to confirm the existing Bash logic is still valid.

Verified on Linux with a teammate (@ZoeJ72005 who reported issue)
- Checked that Bash is available at `/usr/bin/bash`.
- Pulled `fix/husky-bash-hooks/johan`.
- Ran `sh .husky/commit-msg` with a valid commit message.
- Ran `sh .husky/commit-msg` with an invalid commit message and confirmed it failed for the expected project-rule reason.
- Ran `sh .husky/post-checkout`.
- Ran `sh .husky/pre-push`.
- Ran `sh .husky/pre-commit`.
- Confirmed the original `set: Illegal option -o pipefail` error no longer appears.

## Review Notes
Please focus on the Husky check logic in the tracked hook files:
- `.husky/pre-commit`
- `.husky/commit-msg`
- `.husky/pre-push`
- `.husky/post-checkout`

The goal is to preserve the current hook behavior while ensuring the scripts work when Husky launches them through `sh` on Linux/macOS/Windows Git Bash environments.

## Checklist
- [x] I tested the change locally
- [x] No unrelated changes are included
- [ ] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed