### PR TITLE
chore: automatic burndown generation 2

### DIFF
--- a/.github/workflows/burndown.yml
+++ b/.github/workflows/burndown.yml
@@ -16,7 +16,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       REPOSITORY: ${{ github.repository }}
-      SHOW_PROJECT_BURNDOWN: 'false' # Set to true to render the project burndown chart.
+      BURNDOWN_ASSET_BRANCH: automation/burndown-assets
+      SHOW_PROJECT_BURNDOWN: 'false'
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -28,8 +29,39 @@ jobs:
       - name: Generate Burndown charts
         run: python scripts/generate-burndown.py
 
-      - name: Commit updated burndown files
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
-        with:
-          commit_message: 'docs: automatically update burndown charts'
-          file_pattern: 'docs/burndown/** docs/demo*/burndown/** README.md'
+      - name: Publish burndown assets
+        run: |
+          if [ ! -d docs/burndown ]; then
+            echo "No burndown assets were generated."
+            exit 0
+          fi
+
+          asset_worktree="$(mktemp -d)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin "$BURNDOWN_ASSET_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BURNDOWN_ASSET_BRANCH"
+            git worktree add "$asset_worktree" "origin/$BURNDOWN_ASSET_BRANCH"
+            cd "$asset_worktree"
+            git checkout -B "$BURNDOWN_ASSET_BRANCH"
+          else
+            git worktree add --detach "$asset_worktree"
+            cd "$asset_worktree"
+            git checkout --orphan "$BURNDOWN_ASSET_BRANCH"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p docs
+          rm -rf docs/burndown
+          cp -R "$GITHUB_WORKSPACE/docs/burndown" docs/burndown
+
+          if [ -z "$(git status --porcelain -- docs/burndown)" ]; then
+            echo "No burndown asset changes to publish."
+            exit 0
+          fi
+
+          git add docs/burndown
+          git commit -m "docs: automatically update burndown assets"
+          git push origin "HEAD:$BURNDOWN_ASSET_BRANCH"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,23 @@ By focusing on human behaviour, the most common source of security breaches, the
 
 <!-- BURNDOWN:START -->
 
-Burndown charts are generated automatically from GitHub sprint milestones and issue Story Points.
+### Latest Sprint Burndown
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/COS301-SE-2026/Cybersecurity-Awareness-Training-Platform/automation/burndown-assets/docs/burndown/latest-sprint-burndown-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/COS301-SE-2026/Cybersecurity-Awareness-Training-Platform/automation/burndown-assets/docs/burndown/latest-sprint-burndown-light.svg">
+  <img alt="Latest Sprint Burndown" src="https://raw.githubusercontent.com/COS301-SE-2026/Cybersecurity-Awareness-Training-Platform/automation/burndown-assets/docs/burndown/latest-sprint-burndown-light.svg">
+</picture>
+
+### Project Burndown
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/COS301-SE-2026/Cybersecurity-Awareness-Training-Platform/automation/burndown-assets/docs/burndown/project-burndown-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/COS301-SE-2026/Cybersecurity-Awareness-Training-Platform/automation/burndown-assets/docs/burndown/project-burndown-light.svg">
+  <img alt="Project Burndown" src="https://raw.githubusercontent.com/COS301-SE-2026/Cybersecurity-Awareness-Training-Platform/automation/burndown-assets/docs/burndown/project-burndown-light.svg">
+</picture>
+
+[Burndown process](docs/demo1/burndown/PROCESS.md)
 
 <!-- BURNDOWN:END -->
 

--- a/docs/demo1/burndown/PROCESS.md
+++ b/docs/demo1/burndown/PROCESS.md
@@ -40,9 +40,8 @@ Issues larger than 5 points should be split into sub-issues.
 
 ## Rules
 
-- Every sprint issue must be assigned to the correct milestone.
-- Every sprint issue must be on the GitHub Project board.
-- Every sprint issue must have a Story Points value.
+- Every sprint issue must be assigned to the correct sprint milestone.
+- Every sprint issue must have a Story Points value in the issue description.
 - Story points must not be changed after an issue enters a sprint.
 - Closed issues burn down their full point value on the day they are closed.
 - Partially completed issues do not reduce remaining work.
@@ -50,10 +49,13 @@ Issues larger than 5 points should be split into sub-issues.
 
 ## Outputs
 
-Latest sprint charts are stored under:
+The workflow publishes generated burndown assets to the unprotected `automation/burndown-assets` branch.
+The README on `dev` links to stable raw GitHub URLs from that branch, so `dev` does not need daily generated commits.
 
-`docs/demoM/burndown/`
+Latest sprint assets are published under:
 
-The project-wide burndown chart is stored under:
+`docs/burndown/latest-sprint-burndown-*`
 
-`docs/burndown/`
+Project-wide burndown assets are published under:
+
+`docs/burndown/project-burndown-*`

--- a/scripts/generate-burndown.py
+++ b/scripts/generate-burndown.py
@@ -57,7 +57,9 @@ def get_env(name: str, default: str | None = None) -> str:
 TOKEN = os.environ.get("GITHUB_TOKEN")
 REPO = get_env("REPOSITORY")
 README_PATH = Path(os.environ.get("README_PATH", "README.md"))
-SHOW_PROJECT_BURNDOWN = os.environ.get("SHOW_PROJECT_BURNDOWN", "false").lower() == "true"
+SHOW_PROJECT_BURNDOWN = os.environ.get("SHOW_PROJECT_BURNDOWN", "true").lower() == "true"
+ASSET_BRANCH = os.environ.get("BURNDOWN_ASSET_BRANCH", "automation/burndown-assets")
+RAW_ASSET_BASE = f"https://raw.githubusercontent.com/{REPO}/{ASSET_BRANCH}/docs/burndown"
 
 
 def request_json(url: str, body: dict[str, Any] | None = None) -> Any:
@@ -391,7 +393,7 @@ def write_themed_svgs(path_without_suffix: Path, title: str, rows: list[dict[str
     return {"light": str(light_path.relative_to(ROOT)), "dark": str(dark_path.relative_to(ROOT))}
 
 
-def update_readme(latest_charts: dict[str, str], warnings: list[str]) -> None:
+def update_readme(warnings: list[str]) -> None:
     # Input
     readme = ROOT / README_PATH
 
@@ -408,21 +410,21 @@ def update_readme(latest_charts: dict[str, str], warnings: list[str]) -> None:
 ### Latest Sprint Burndown
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="{latest_charts["dark"]}">
-  <source media="(prefers-color-scheme: light)" srcset="{latest_charts["light"]}">
-  <img alt="Latest Sprint Burndown" src="{latest_charts["light"]}">
+  <source media="(prefers-color-scheme: dark)" srcset="{RAW_ASSET_BASE}/latest-sprint-burndown-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="{RAW_ASSET_BASE}/latest-sprint-burndown-light.svg">
+  <img alt="Latest Sprint Burndown" src="{RAW_ASSET_BASE}/latest-sprint-burndown-light.svg">
 </picture>
 """
 
     project_block = ""
     if SHOW_PROJECT_BURNDOWN:
-        project_block = """
+        project_block = f"""
 ### Project Burndown
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/burndown/project-burndown-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="docs/burndown/project-burndown-light.svg">
-  <img alt="Project Burndown" src="docs/burndown/project-burndown-light.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="{RAW_ASSET_BASE}/project-burndown-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="{RAW_ASSET_BASE}/project-burndown-light.svg">
+  <img alt="Project Burndown" src="{RAW_ASSET_BASE}/project-burndown-light.svg">
 </picture>
 """
 
@@ -579,7 +581,22 @@ def write_project_outputs(generated_sprints: list[dict[str, Any]], today: date, 
         write_themed_svgs(ROOT / "docs/burndown/project-burndown", "Project Burndown", project_rows)
 
     latest = max(generated_sprints, key=lambda sprint: (sprint["end"], sprint["demo_no"], sprint["sprint_no"]))
-    update_readme(latest["charts"], warnings)
+    latest_rows = sprint_series(latest["issues"], latest["start"], latest["end"], as_of=today)
+    write_csv(ROOT / "docs/burndown/latest-sprint-burndown.csv", latest_rows)
+    write_json(
+        ROOT / "docs/burndown/latest-sprint-burndown.json",
+        {
+            "sprint_no": latest["sprint_no"],
+            "demo_no": latest["demo_no"],
+            "milestone": latest["milestone"],
+            "start": str(latest["start"]),
+            "end": str(latest["end"]),
+            "issues": latest["issues"],
+            "series": latest_rows,
+        },
+    )
+    write_themed_svgs(ROOT / "docs/burndown/latest-sprint-burndown", f"{latest['milestone']} Burndown", latest_rows)
+    update_readme(warnings)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Updated burndown chart creation to now generate burndown charts in the appropriate `automation/` branch and to point the readme on dev to the assets stored in that branch.

## Linked Issue

Closes #46 (again)

## Type of change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [x] Chore/Maintenance
