### PR TITLE
docs: align docs first pass

### DIFF
--- a/docs/demo1/DESIGN.md
+++ b/docs/demo1/DESIGN.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document collects Demo 1 design guidance, brand direction, UI rules, learner navigation notes, and wireframe references.
+This document collects Demo 1 design guidance, brand direction, UI rules, Learner/Employee navigation notes, and wireframe references.
 
 ## Demo 1 Design Scope
 
@@ -46,7 +46,7 @@ This document collects Demo 1 design guidance, brand direction, UI rules, learne
 
 ### Training Material Page
 
-The training material page should support the UC-02 learner flow by presenting assigned training content in a readable, focused layout.
+The training material page should support the UC-02 Learner/Employee flow by presenting assigned training content in a readable, focused layout.
 
 Design notes:
 
@@ -54,13 +54,13 @@ Design notes:
 - Use readable spacing, paragraphs, and section breaks so the content is easy to scan.
 - Show a loading state while the document is being retrieved.
 - Show an empty or unavailable-content message if the document cannot be opened.
-- Provide a clear way back to the training list or learner dashboard.
+- Provide a clear way back to the training list or Learner/Employee dashboard.
 - If a linked quiz is available, present the quiz action as a clear next step without making quiz completion part of UC-02.
 - Feedback messages on this page should follow the shared validation, error-state, and accessibility rules.
 
 ### Quiz Page
 
-The quiz page should support UC-03 by allowing the learner to answer assigned quiz questions and understand what is required before submission.
+The quiz page should support UC-03 by allowing the Learner/Employee to answer assigned quiz questions and understand what is required before submission.
 
 Design notes:
 
@@ -70,19 +70,19 @@ Design notes:
 - Validation messages should appear near the relevant question when an answer is missing or invalid.
 - A page-level validation summary may be shown when multiple required answers are missing.
 - The submit action should be clearly visible after the questions.
-- The learner should be able to correct validation errors without losing existing answers.
+- The Learner/Employee should be able to correct validation errors without losing existing answers.
 
 ### Quiz Submission State
 
-The quiz submission state should make it clear that the learner’s answers are being processed.
+The quiz submission state should make it clear that the Learner/Employee's answers are being processed.
 
 Design notes:
 
-- Show a loading or submitting indicator after the learner submits the quiz.
+- Show a loading or submitting indicator after the Learner/Employee submits the quiz.
 - Disable or guard the submit action while processing to prevent duplicate submissions.
-- Keep the learner on the quiz page or transition state until submission completes.
+- Keep the Learner/Employee on the quiz page or transition state until submission completes.
 - Do not show raw technical errors if submission fails.
-- If submission fails, explain the issue in learner-friendly language and provide a retry path where appropriate.
+- If submission fails, explain the issue in Learner/Employee-friendly language and provide a retry path where appropriate.
 
 ### Quiz Results Page
 
@@ -94,14 +94,14 @@ Design notes:
 - Display feedback in a supportive learning tone.
 - Where answer-level feedback is shown, distinguish correct and incorrect responses using text labels and visual treatment.
 - Avoid relying only on colour to communicate correctness.
-- Provide a clear navigation option back to the training material, module list, or learner dashboard.
+- Provide a clear navigation option back to the training material, module list, or Learner/Employee dashboard.
 - If results cannot be loaded, show a safe error message and provide a retry or back-navigation option.
 
 ### Phishing Feedback Page
 
-This page is included only as high-level Demo 1 feedback context for the simulated phishing learner experience. It should not be treated as a separate core use case or a full phishing-feedback workflow for Demo 1.
+This page is included only as high-level Demo 1 feedback context for the simulated phishing Learner/Employee experience. It should not be treated as a separate core use case or a full phishing-feedback workflow for Demo 1.
 
-The page should summarise safe learning feedback about a simulated phishing interaction, such as suspicious sender details, urgent wording, or risky links. It should provide a clear path back to the learner dashboard, training material, or simulated inbox where relevant.
+The page should summarise safe learning feedback about a simulated phishing interaction, such as suspicious sender details, urgent wording, or risky links. It should provide a clear path back to the Learner/Employee dashboard, training material, or simulated inbox where relevant.
 
 ## Wireframe Refinement and Polish (Connor)
 
@@ -119,7 +119,7 @@ The page should summarise safe learning feedback about a simulated phishing inte
 
 ## Feedback, Validation, and Accessibility UI Rules (Zoë)
 
-These rules define supporting UI behaviour for Demo 1 validation, feedback, loading, empty, unavailable, and accessibility states. They support the learner-facing flows but do not create a separate Demo 1 use case.
+These rules define supporting UI behaviour for Demo 1 validation, feedback, loading, empty, unavailable, and accessibility states. They support the Learner/Employee-facing flows but do not create a separate Demo 1 use case.
 
 The rules apply mainly to:
 
@@ -128,7 +128,7 @@ The rules apply mainly to:
 - Login/Register as base feature support
 - Phishing feedback only as high-level contextual support
 
-The UI should help learners understand:
+The UI should help Learner/Employee users understand:
 
 - what is required;
 - what is happening;
@@ -145,9 +145,9 @@ Rules:
 - Use field-level messages for missing required input, invalid answer format, or unsupported selections.
 - Keep messages short and specific.
 - Do not rely only on colour to identify the problem.
-- Required-field messages should explain what the learner needs to provide.
+- Required-field messages should explain what the Learner/Employee needs to provide.
 - Quiz validation messages should appear near the relevant question where possible.
-- Existing learner input should remain visible after validation fails.
+- Existing Learner/Employee input should remain visible after validation fails.
 
 Example wording:
 
@@ -162,10 +162,10 @@ Page-level error banners should be used when an issue affects the whole page, fl
 Rules:
 
 - Place the banner near the top of the relevant content area.
-- Use plain, learner-friendly wording.
+- Use plain, Learner/Employee-friendly wording.
 - Explain the next safe action where possible.
 - Do not show stack traces, raw exception names, or backend implementation details.
-- Keep the learner on the current page when they can correct or retry the action.
+- Keep the Learner/Employee on the current page when they can correct or retry the action.
 
 Appropriate uses include:
 
@@ -177,7 +177,7 @@ Appropriate uses include:
 
 ### Success Messages
 
-Success messages should confirm that the learner’s action was completed.
+Success messages should confirm that the Learner/Employee's action was completed.
 
 Rules:
 
@@ -194,13 +194,13 @@ Example wording:
 
 ### Warning Messages
 
-Warning messages should be used when the learner can continue but should be aware of a limitation or state.
+Warning messages should be used when the Learner/Employee can continue but should be aware of a limitation or state.
 
 Rules:
 
 - Use warnings for non-blocking issues or important context.
 - Keep the tone helpful rather than alarming.
-- Explain whether the learner needs to take action.
+- Explain whether the Learner/Employee needs to take action.
 - Do not use warnings for normal required-field validation; use field-level validation instead.
 
 Examples:
@@ -217,7 +217,7 @@ Rules:
 - State clearly what is missing.
 - Avoid making the page look broken.
 - Provide a safe next step, such as returning to the dashboard.
-- Keep the wording learner-friendly.
+- Keep the wording Learner/Employee-friendly.
 
 Applicable Demo 1 examples:
 
@@ -262,7 +262,7 @@ Applicable Demo 1 examples:
 
 ### Quiz Feedback Display
 
-Quiz feedback should help the learner understand their result and learn from the attempt.
+Quiz feedback should help the Learner/Employee understand their result and learn from the attempt.
 
 Rules:
 
@@ -307,18 +307,18 @@ Rules:
 - Use text labels in addition to colour.
 - Ensure messages are readable at normal zoom levels.
 - Important page-level messages should be noticeable without disrupting the whole flow.
-- Learners should be able to reach recovery actions, such as retry or back navigation, using the keyboard.
+- Learner/Employee users should be able to reach recovery actions, such as retry or back navigation, using the keyboard.
 
 ### Keyboard Interaction Expectations
 
-Learners should be able to complete the Demo 1 learner flows using keyboard navigation.
+Learner/Employee users should be able to complete the Demo 1 Learner/Employee flows using keyboard navigation.
 
 Rules:
 
 - Interactive elements should follow a logical tab order.
 - Buttons, links, quiz options, and recovery actions should be keyboard-accessible.
 - Focus should not be trapped unexpectedly.
-- After validation fails, the learner should be able to navigate to the relevant message or field.
+- After validation fails, the Learner/Employee should be able to navigate to the relevant message or field.
 - Disabled controls should not create confusion in the focus order.
 
 ### Screen-Reader Feedback Expectations
@@ -330,7 +330,7 @@ Rules:
 - Important messages should be written as meaningful text.
 - Messages should identify the relevant field, question, or page state.
 - Status changes such as submitting, success, or failure should be presented clearly.
-- Error summaries should help the learner find what needs attention.
+- Error summaries should help the Learner/Employee find what needs attention.
 - Visual-only feedback, such as colour changes without text, should be avoided.
 
 ### Contrast Considerations
@@ -344,7 +344,7 @@ Rules:
 - Error, warning, and success states should have distinguishable labels or icons where appropriate.
 - Final colour choices should align with the Demo 1 brand style guide when available.
 
-## Learner Navigation and Training Screen Behaviour (Connor)
+## Learner/Employee Navigation and Training Screen Behaviour (Connor)
 
 ### Dashboard to Training Module List
 

--- a/docs/demo1/SRS.md
+++ b/docs/demo1/SRS.md
@@ -2,50 +2,56 @@
 
 ## Purpose
 
-This document collects Sprint 1 Demo 1 requirements for the Cybersecurity Awareness Training Platform.
+This document contains Demo 1 requirements for the Cybersecurity Awareness Training Platform.
 
 ## Demo 1 Scope
 
+Demo 1 focuses on a controlled Learner/Employee-facing cybersecurity awareness journey supported by basic access features and preliminary administrative setup context.
+
+The core Demo 1 use cases are:
+
 ### UC-01: View Emails in Simulated Inbox
+
+The Learner/Employee views assigned simulated emails in a safe platform inbox. This use case covers listing simulated email summaries, opening a simulated email detail view, and preserving the boundary that no real mailbox is accessed.
 
 ### UC-02: View Training Document
 
+The Learner/Employee views assigned training material. This use case covers finding available training material, opening a selected training document, reading the content, and optionally navigating toward a related quiz without making quiz completion part of UC-02.
+
 ### UC-03: Complete Quiz Flow
+
+The Learner/Employee completes an assigned quiz. This use case covers opening quiz content, answering questions, submitting an attempt, and viewing result or feedback states.
 
 ## Base Features
 
 ### Login/Register
 
-Login and registration are base features that support access to the Demo 1 learner flows. They are not counted as separate Demo 1 core use cases.
+Login and registration are rudimentary base features that support access to the Demo 1 Learner/Employee flows. They exist to showcase the design and implementation of UC-01, UC-02, and UC-03, rather than to demonstrate a complete authentication feature set.
 
-The system should provide basic form validation for login and registration screens so that learners receive clear feedback before attempting to continue. Required fields should be checked before submission, and invalid or incomplete input should be explained using concise, non-technical messages.
+For Demo 1, login/register behaviour should remain minimal and sufficient for navigating into the core use cases. The screens may show the intended visual direction and basic validation behaviour, but full authentication workflows, production account management, password recovery, role administration, and security hardening are outside our Demo 1 scope.
 
-For Demo 1, login/register validation should support the following requirements:
+Rudimentary login/register support should include:
 
 - Required input fields must be visibly identified before submission.
-- If a learner submits an incomplete form, the system must show which required fields need attention.
-- Error messages must be learner-friendly and should not expose technical implementation details.
-- While a login or registration request is being processed, the interface should show a loading or submitting state and prevent duplicate submission.
-- If authentication fails, the learner should receive a clear error message and remain on the relevant form so they can correct the issue.
-- If authentication succeeds, the learner should receive appropriate navigation feedback and continue to the relevant learner area.
+- If a Learner/Employee submits an incomplete form, the system must show which required fields need attention.
+- Error messages must be Learner/Employee-friendly and should not expose technical implementation details.
+- If authentication succeeds, the Learner/Employee should receive appropriate navigation feedback and continue to the relevant Learner/Employee area.
 - These behaviours are supporting form requirements only and must not be treated as additional Demo 1 use cases.
-
-### Themes
 
 ### General Form Validation
 
-General form validation is a supporting base feature for Demo 1. It exists to keep learner-facing forms, quiz submissions, and feedback states consistent, but it is not a separate core use case.
+General form validation is a supporting base feature for Demo 1. It exists to keep Learner/Employee-facing forms, quiz submissions, and feedback states consistent, but it is not a separate core use case.
 
 Reusable validation rules for Demo 1 should follow these principles:
 
 - Required fields must be validated before submission where possible.
 - Validation messages must appear close to the relevant field, question, or action.
 - Page-level errors may be used when a problem affects the whole screen or submission.
-- Error messages must describe what the learner can do next, such as completing a missing answer or retrying a failed submission.
-- Technical details such as stack traces, raw database errors, or internal exception names must not be shown to learners.
+- Error messages must describe what the Learner/Employee can do next, such as completing a missing answer or retrying a failed submission.
+- Technical details such as stack traces, raw database errors, or internal exception names must not be shown to Learner/Employee users.
 - Loading and submitting states must clearly indicate that the system is processing an action.
 - Buttons that could create duplicate requests should be disabled while the relevant action is being processed.
-- Success messages should confirm that the learner’s action was completed.
+- Success messages should confirm that the Learner/Employee's action was completed.
 - Empty and unavailable states should explain the situation and provide a safe next step where possible.
 - Feedback messages should be accessible, readable, and understandable without relying only on colour.
 
@@ -55,91 +61,123 @@ These rules apply as supporting guidance for UC-02 and UC-03, and as base-featur
 
 ### Introduction
 
+This SRS integrates the individual Demo 1 feature slices into one consistent requirements document.
+
 ### Project Scope
+
+This SRS does not finalise production implementation details, final database schema, final diagrams, full reporting, real email integration, adaptive learning, AI-generated simulations, or an expanded use case list.
 
 ### User Characteristics
 
+The primary actor is the **Learner/Employee**. This actor represents a user who accesses assigned simulated emails, training content, and quizzes through the platform.
+
+The **Administrator** is documented as supporting context. The Administrator configures or assigns campaigns, simulated emails, training material, and quizzes, but full administrative workflows are not core Demo 1 use cases.
+
+The **System** supports authentication, content retrieval, validation, tracking placeholders, and safe feedback states.
+
 ### Assumptions
+
+- Demo 1 uses seeded or preconfigured safe content for simulated emails, training documents, and quizzes: Future use cases will allow adding, modifying and removing this content.
+- The Learner/Employee is authenticated before accessing UC-01, UC-02, or UC-03.
+- Administrative setup exists as preliminary supporting context for assigning content, but full admin workflows are not core Demo 1 flows.
+- API contracts are preliminary planning references and may change during implementation.
+- Domain model references are conceptual and should not be treated as final Prisma models or database migrations.
 
 ### Dependencies
 
+- First drafts of the UC-01, UC-02, and UC-03 SRS feature slices.
+- Preliminary API contracts in `docs/demo1/API.md`.
+- Domain model references and diagrams in `docs/demo1/diagrams/`.
+- Architecture and technical guidance in `docs/demo1/architecture.md`.
+- Design and wireframe notes in `docs/demo1/DESIGN.md` and `docs/demo1/wireframes/`.
+- QA and traceability planning in `docs/demo1/testing.md` and `docs/demo1/traceability.md`.
+
 ### Cross-Reference Structure
+
+Primary supporting documents:
+
+- `docs/demo1/API.md` for preliminary API contracts.
+- `docs/demo1/architecture.md` for preliminary architecture and technical requirements.
+- `docs/demo1/DESIGN.md` for design scope, wireframe direction, feedback states, and accessibility rules.
+- `docs/demo1/testing.md` for QA planning and future test references.
+- `docs/demo1/traceability.md` for integration placeholders and review traceability.
+- `docs/demo1/diagrams/` for draft diagram sources and exports.
 
 ## UC-01: Simulated Inbox Requirements
 
 ### User Story
 
-As an employee, I want to view my simulated emails in a controlled inbox(rather than my own) so that i can recognize potentially suspicious messages in a safe training environment before encountering similar effects/threats in real life.
+As a Learner/Employee, I want to view my simulated emails in a controlled inbox rather than my own mailbox so that I can recognise potentially suspicious messages in a safe training environment before encountering similar threats in real life.
 
 ### Purpose
 
-UC-01 defines the Demo 1 simulated inbox feature slice. The simulated inbox allows an employee to view a list of safe, preconfigured simulated emails, open an email to inspect its details, and receive clear simulated-phishing context where relevant.
+UC-01 defines the Demo 1 simulated inbox feature slice. The simulated inbox allows a Learner/Employee to view a list of safe, preconfigured simulated emails, open an email to inspect its details, and receive clear simulated-phishing context where relevant.
 
-This use case is limited to viewing simulated content. It does not include real email delivery, live corporate email integration, advanced campaign scheduling, AI-generated phishing content, or full reporting dashboards and email level difficulty(for gamification).
+This use case is limited to viewing simulated content. It does not include real email delivery, live corporate email integration, advanced campaign scheduling, AI-generated phishing content, or full reporting dashboards and email level difficulty (for gamification).
 
 ### Actor
 
 Primary Actor:
 
-- Employee
+- Learner/Employee
 
 Supporting Actors:
 
 - System
-- Admins (as a future supporting context for preparing simulated content)
+- Administrator (as future supporting context)
 
 ### Preconditions
 
-- The employee is authenticated and registered.
-- **The employee has access to at least one assigned simulated email inbox (assigned via an admin-managed campaign, see Admin Supporting Context).**
-- **Simulated emails exist as controlled training content inside the platform (configured by an Admin, see FR-ADM-03).**
-- The simulated inbox is available from the learner/employee dashboard or equivalent employee navigation path.
+- The Learner/Employee is authenticated and registered.
+- The Learner/Employee has a simulated inbox, with available simulated emails determined by preliminary administrator-managed campaign assignment context.
+- Simulated emails exist as controlled training content inside the platform.
+- The simulated inbox is available from the Learner/Employee dashboard or equivalent navigation path.
 
 ### Postconditions
 
 Successful Post conditions:
 
-- The employee can view simulated email summaries.
-- The employee can open a selected simulated email and view its details.
-- The system may record a lightweight interaction event when the employee opens or views a simulated email.
-- The employee can identify that the email exists in a controlled training context.
+- The Learner/Employee can view a list of simulated emails in their simulated inbox.
+- The Learner/Employee can open a selected simulated email and view its details.
+- The system may record a lightweight interaction event when the Learner/Employee opens or views a simulated email.
+- The Learner/Employee can identify that the email exists in a controlled training context.
 - If the email represents a phishing scenario, the system may show safe contextual information or a placeholder link to training feedback.
 
 Unsuccessful Post conditions:
 
-- If no simulated emails are assigned, the employee sees an appropriate empty state.
-- If a selected simulated email cannot be found, the employee sees a safe error state.
-- If interaction tracking fails, the employee should still be able to view the email where possible, while the system handles the tracking failure safely.
+- If no simulated emails are assigned, the Learner/Employee sees an appropriate empty state.
+- If a selected simulated email cannot be found, the Learner/Employee sees a safe error state.
+- If interaction tracking fails, the Learner/Employee should still be able to view the email where possible, while the system handles the tracking failure safely.
 
 ### Main Flow
 
-1. The employee navigates to the simulated inbox from the learner/employee dashboard or navigation menu.
-2. The system displays a list of simulated email summaries assigned to the employee.
+1. The Learner/Employee navigates to the simulated inbox from the Learner/Employee dashboard or navigation menu.
+2. The system displays a list of simulated email summaries assigned to the Learner/Employee.
 3. Each summary shows enough information for safe review, such as sender label, subject, preview text, received date/status, and simulated/safety indicator where applicable.
-4. The employee selects one simulated email from the inbox list.
+4. The Learner/Employee selects one simulated email from the inbox list.
 5. The system opens the simulated email detail view.
 6. The system displays the selected email content, including sender information, subject, body text, and any safe simulated-phishing context.
 7. The system records a lightweight interaction event that the email was opened or viewed.
-8. The employee reviews the email and may return to the simulated inbox list.
+8. The Learner/Employee reviews the email and may return to the simulated inbox list.
 9. If a training follow-up exists, the system may display a placeholder link or prompt to related training feedback without starting the full training or quiz flow inside this use case.
 
 ### Exceptions
 
 #### EX-UC01-01: No Simulated Emails Assigned
 
-If the employee has no simulated emails assigned, the system displays an empty state explaining that no simulated emails are currently available.
+If the Learner/Employee has no simulated emails assigned, the system displays an empty state explaining that no simulated emails are currently available.
 
 #### EX-UC01-02: Simulated Email Not Found
 
-If the employee tries to open an email that does not exist or is no longer assigned to them, the system displays an error state and allows the employee to return to the inbox list.
+If the Learner/Employee tries to open an email that does not exist or is no longer assigned to them, the system displays an error state and allows the Learner/Employee to return to the inbox list.
 
 #### EX-UC01-03: Simulated Inbox Loading Failure
 
-If the system cannot load the simulated inbox, it displays a safe error message and allows the employee to retry or return to the dashboard.
+If the system cannot load the simulated inbox, it displays a safe error message and allows the Learner/Employee to retry or return to the dashboard.
 
 #### EX-UC01-04: Interaction Tracking Failure
 
-If the system cannot record the email-open interaction, the system should not expose technical error details to the employee. The email may still be displayed if it is otherwise available.
+If the system cannot record the email-open interaction, the system should not expose technical error details to the Learner/Employee. The email may still be displayed if it is otherwise available.
 
 #### EX-UC01-05: Attempted Real Email Access
 
@@ -147,49 +185,49 @@ If any flow attempts to access real external email infrastructure, the system mu
 
 ### Functional Requirements
 
-| ID         | Requirement                                                                                                                            | Priority | Notes                                                                                                                   |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------: | ----------------------------------------------------------------------------------------------------------------------- |
-| FR-UC01-01 | The system shall allow an employee to view a list of assigned simulated email summaries.                                               |     Must | Summary content may include subject, sender label, preview text, received date/status, and simulated content indicator. |
-| FR-UC01-02 | The system shall allow an employee to open a selected simulated email from the inbox list.                                             |     Must | The detailed view should show the simulated email content in a readable format.                                         |
-| FR-UC01-03 | The system shall clearly treat all inbox content as simulated, controlled training content.                                            |     Must | Demo 1 must not imply access to a real mailbox.                                                                         |
-| FR-UC01-04 | The system shall record a lightweight interaction event when an employee opens or views a simulated email.                             |   Should | This supports later reporting and traceability without requiring a full reporting dashboard in Demo 1.                  |
-| FR-UC01-05 | The system shall provide safe simulated-phishing context where relevant.                                                               |   Should | This may include warning context, educational feedback, or a placeholder link to training.                              |
-| FR-UC01-06 | The system shall display an empty state when no simulated emails are assigned to the employee.                                         |     Must | The message should be clear and non-technical.                                                                          |
-| FR-UC01-07 | The system shall display a safe error state when a selected simulated email cannot be loaded.                                          |     Must | The employee should be able to return to the inbox list or dashboard.                                                   |
-| FR-UC01-08 | The system shall not connect to or send messages through real external email infrastructure for Demo 1 UC-01.                          |     Must | Real email delivery is out of scope for this feature slice.                                                             |
-| FR-UC01-09 | The system shall avoid collecting or storing sensitive credential input through the simulated inbox view.                              |     Must | Credential-submission simulations are future scope and must be handled safely if introduced later.                      |
-| FR-UC01-10 | The system shall keep UC-01 separate from the full training document and quiz flows except for optional follow-up links or references. |   Should | Training and quiz flows remain covered by UC-02 and UC-03.                                                              |
+| ID         | Requirement                                                                                                                            | Notes                                                                                                                   |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| FR-UC01-01 | The system shall allow a Learner/Employee to view a list of assigned simulated email summaries.                                        | Summary content may include subject, sender label, preview text, received date/status, and simulated content indicator. |
+| FR-UC01-02 | The system shall allow a Learner/Employee to open a selected simulated email from the inbox list.                                      | The detailed view should show the simulated email content in a readable format.                                         |
+| FR-UC01-03 | The system shall clearly treat all inbox content as simulated, controlled training content.                                            | Demo 1 must not imply access to a real mailbox.                                                                         |
+| FR-UC01-04 | The system shall record a lightweight interaction event when a Learner/Employee opens or views a simulated email.                      | This supports later reporting and traceability without requiring a full reporting dashboard in Demo 1.                  |
+| FR-UC01-05 | The system shall provide safe simulated-phishing context where relevant.                                                               | This may include warning context, educational feedback, or a placeholder link to training.                              |
+| FR-UC01-06 | The system shall display an empty state when no simulated emails are assigned to the Learner/Employee.                                 | The message should be clear and non-technical.                                                                          |
+| FR-UC01-07 | The system shall display a safe error state when a selected simulated email cannot be loaded.                                          | The Learner/Employee should be able to return to the inbox list or dashboard.                                           |
+| FR-UC01-08 | The system shall not connect to or send messages through real external email infrastructure for Demo 1 UC-01.                          | Real email delivery is out of scope for this feature slice.                                                             |
+| FR-UC01-09 | The system shall avoid collecting or storing sensitive credential input through the simulated inbox view.                              | Credential-submission simulations are future scope and must be handled safely if introduced later.                      |
+| FR-UC01-10 | The system shall keep UC-01 separate from the full training document and quiz flows except for optional follow-up links or references. | Training and quiz flows remain covered by UC-02 and UC-03.                                                              |
 
 ### Non-Functional requirements and Safety Concerns
 
 | ID          | Requirement                                                                                                            | Notes                                                                      |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| NFR-UC01-01 | The simulated inbox interface should be clear and usable for non-technical employees.                                  | Supports the platform goal of accessible cybersecurity awareness training. |
+| NFR-UC01-01 | The simulated inbox interface should be clear and usable for non-technical Learner/Employee users.                     | Supports the platform goal of accessible cybersecurity awareness training. |
 | NFR-UC01-02 | Simulated email content should be visually distinct enough to avoid confusion with real mailbox systems during Demo 1. | Helps maintain ethical and safe simulation boundaries.                     |
 | NFR-UC01-03 | Interaction tracking should minimise personal data collection.                                                         | Track the action/event, not unnecessary sensitive content.                 |
-| NFR-UC01-04 | Error messages should avoid exposing technical implementation details.                                                 | Keeps the learner experience safe and understandable.                      |
+| NFR-UC01-04 | Error messages should avoid exposing technical implementation details.                                                 | Keeps the Learner/Employee experience safe and understandable.             |
 
 ### Interaction Tracking Requirements
 
-| ID          | Tracking Requirement                                                                                  | Event Example                                     | Notes                                   |
-| ----------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------------------------------------- |
-| TRK-UC01-01 | The system should record when an employee opens a simulated email.                                    | `EMAIL_OPENED`                                    | Used for later progress/risk reporting. |
-| TRK-UC01-02 | The system may record when an employee views the simulated inbox list.                                | `INBOX_VIEWED`                                    | Optional for Demo 1.                    |
-| TRK-UC01-03 | The system should associate interaction events with the simulated email and employee/user reference.  | `employeeId`, `emailId`, `eventType`, `timestamp` | Exact field names are preliminary.      |
-| TRK-UC01-04 | The system should not store real credential values or sensitive user input as part of UC-01 tracking. | Not applicable                                    | Important safety boundary.              |
+| ID          | Tracking Requirement                                                                                  | Event Example                                 | Notes                                   |
+| ----------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------- |
+| TRK-UC01-01 | The system should record when a Learner/Employee opens a simulated email.                             | `EMAIL_OPENED`                                | Used for later progress/risk reporting. |
+| TRK-UC01-02 | The system may record when a Learner/Employee views the simulated inbox list.                         | `INBOX_VIEWED`                                | Optional for Demo 1.                    |
+| TRK-UC01-03 | The system should associate interaction events with the simulated email and user reference.           | `userId`, `emailId`, `eventType`, `timestamp` | Exact field names are preliminary.      |
+| TRK-UC01-04 | The system should not store real credential values or sensitive user input as part of UC-01 tracking. | Not applicable                                | Important safety boundary.              |
 
 ### Domain References
 
 Preliminary domain entities linked to UC-01:
 
-| ID         | Entity            | Description                                                                                      |
-| ---------- | ----------------- | ------------------------------------------------------------------------------------------------ |
-| DE-UC01-01 | Employee/User     | The learner who views assigned simulated emails.                                                 |
-| DE-UC01-02 | SimulatedInbox    | The controlled inbox view containing simulated email summaries.                                  |
-| DE-UC01-03 | SimulatedEmail    | A safe, preconfigured email used for training or phishing-awareness simulation.                  |
-| DE-UC01-04 | InteractionEvent  | A lightweight record of learner interaction, such as opening a simulated email.                  |
-| DE-UC01-05 | SimulationContext | Supporting context explaining why the email is simulated or what learning objective it supports. |
-| DE-UC01-06 | TrainingReference | Optional reference to related training feedback or follow-up content.                            |
+| ID         | Entity                | Description                                                                                      |
+| ---------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| DE-UC01-01 | Learner/Employee/User | The user who views assigned simulated emails.                                                    |
+| DE-UC01-02 | SimulatedInbox        | The controlled inbox view containing simulated email summaries.                                  |
+| DE-UC01-03 | SimulatedEmail        | A safe, preconfigured email used for training or phishing-awareness simulation.                  |
+| DE-UC01-04 | InteractionEvent      | A lightweight record of Learner/Employee interaction, such as opening a simulated email.         |
+| DE-UC01-05 | SimulationContext     | Supporting context explaining why the email is simulated or what learning objective it supports. |
+| DE-UC01-06 | TrainingReference     | Optional reference to related training feedback or follow-up content.                            |
 
 ### API References
 
@@ -197,7 +235,7 @@ Preliminary API placeholders linked to UC-01:
 
 | ID          | Contract                                         | Purpose                                                                                 |
 | ----------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| API-UC01-01 | `GET /simulations/inbox`                         | Retrieve assigned simulated email summaries for the employee.                           |
+| API-UC01-01 | `GET /simulations/inbox`                         | Retrieve assigned simulated email summaries for the Learner/Employee.                   |
 | API-UC01-02 | `GET /simulations/emails/:emailId`               | Retrieve details for a selected simulated email.                                        |
 | API-UC01-03 | `POST /simulations/emails/:emailId/interactions` | Record a lightweight interaction event, such as opening or viewing the simulated email. |
 
@@ -205,117 +243,117 @@ PLEASE NOTE: These contracts are subject to change throughout the course of impl
 
 ### Traceability References
 
-| Traceability ID | Linked Item                                               |
-| --------------- | --------------------------------------------------------- |
-| TRACE-UC01-01   | UC-01 to FR-UC01-01, API-UC01-01, DE-UC01-02, DES-UC01-01 |
-| TRACE-UC01-02   | UC-01 to FR-UC01-02, API-UC01-02, DE-UC01-03, DES-UC01-02 |
-| TRACE-UC01-03   | UC-01 to FR-UC01-04, API-UC01-03, DE-UC01-04              |
-| TRACE-UC01-04   | UC-01 to FR-UC01-05, DE-UC01-05, DES-UC01-03              |
-| TRACE-UC01-05   | UC-01 to FR-UC01-08 and Demo 1 simulation safety boundary |
+| Traceability ID | Linked Item                                                                                         |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| TRACE-UC01-01   | UC-01 to FR-UC01-01, API-UC01-01, DE-UC01-02, `docs/demo1/DESIGN.md` Simulated Inbox section        |
+| TRACE-UC01-02   | UC-01 to FR-UC01-02, API-UC01-02, DE-UC01-03, `docs/demo1/DESIGN.md` Simulated Email Detail section |
+| TRACE-UC01-03   | UC-01 to FR-UC01-04, API-UC01-03, DE-UC01-04                                                        |
+| TRACE-UC01-04   | UC-01 to FR-UC01-05, DE-UC01-05, `docs/demo1/DESIGN.md` Phishing Feedback Page section              |
+| TRACE-UC01-05   | UC-01 to FR-UC01-08 and Demo 1 simulation safety boundary                                           |
 
-## UC-02: Training Document Viewing Requirements
+## UC-02: Training Document Requirements
 
 ### User Story
 
-As a learner, I want to view training documents assigned to me so that I can learn how to recognise and respond to cyber threats in a controlled educational environment.
+As a Learner/Employee, I want to view training documents assigned to me so that I can learn how to recognise and respond to cyber threats in a controlled educational environment.
 
 ### Purpose
 
-UC-02 defines the Demo 1 "training document viewing feature" slice. The feature allows a learner to access a list of assigned training materials, open a selected training document, and view its contents in a structured and readable format.
+UC-02 defines the Demo 1 training document viewing feature slice. The feature allows a Learner/Employee to access a list of assigned training materials, open a selected training document, and view its contents in a structured and readable format.
 
 This use case is limited to viewing training content and recording basic interaction tracking. It does not include training content creation, editing, campaign management, or full quiz execution.
 
 ### Actor
 
-#### Primary Actor
+Primary Actor:
 
-- Learner
+- Learner/Employee
 
-#### Supporting Actors
+Supporting Actors:
 
 - System
 - Administrator (as a supporting context for assigning training content via campaigns)
 
 ### Preconditions
 
-- The learner is authenticated and registered.
-- The learner has access to at least one assigned training document (via an administrator-managed campaign, see `FR-ADM-04`).
+- The Learner/Employee is authenticated and registered.
+- The Learner/Employee has access to at least one assigned training document through preliminary administrator-managed campaign context.
 - Training documents exist as controlled educational content within the platform.
-- The training module list is accessible from the learner dashboard or equivalent navigation path.
+- The training module list is accessible from the Learner/Employee dashboard or equivalent navigation path.
 
 ### Postconditions
 
-#### Successful Postconditions
+Successful Post conditions:
 
-- The learner can view a list of assigned training documents.
-- The learner can open and read a selected training document.
+- The Learner/Employee can view a list of assigned training documents.
+- The Learner/Employee can open and read a selected training document.
 - The system records a basic interaction event.
-- The learner understands that the content is part of a structured training experience.
+- The Learner/Employee understands that the content is part of a structured training experience.
 - If a quiz is linked, the system may display a link or button to proceed to the associated quiz.
 
-#### Unsuccessful Postconditions
+Unsuccessful Post conditions:
 
-- If no training documents are assigned, the learner sees an appropriate empty state.
-- If a selected training document cannot be found, the learner sees a safe error state.
-- If interaction tracking fails, the learner can still view the training content.
+- If no training documents are assigned, the Learner/Employee sees an appropriate empty state.
+- If a selected training document cannot be found, the Learner/Employee sees a safe error state.
+- If interaction tracking fails, the Learner/Employee can still view the training content.
 
 ### Main Flow
 
-1. The learner navigates to the training module list from the dashboard or navigation menu.
-2. The system retrieves and displays a list of training documents assigned to the learner.
+1. The Learner/Employee navigates to the training module list from the dashboard or navigation menu.
+2. The system retrieves and displays a list of training documents assigned to the Learner/Employee.
 3. Each training item displays summary information such as title, description, and basic interaction status (if available).
-4. The learner selects a training document from the list.
+4. The Learner/Employee selects a training document from the list.
 5. The system retrieves the selected training document.
 6. The system displays the training content in a structured and readable format (e.g., text, sections, or embedded media).
 7. The system records a basic interaction event (e.g., training viewed or started).
-8. The learner reviews the training material.
+8. The Learner/Employee reviews the training material.
 9. If a related quiz exists, the system may display a link or button to proceed to the quiz (covered in UC-03).
-10. The learner may return to the training module list or dashboard.
+10. The Learner/Employee may return to the training module list or dashboard.
 
 ### Exceptions
 
-#### `EX-UC02-01`: No Training Documents Assigned
+#### EX-UC02-01: No Training Documents Assigned
 
-If the learner has no training documents assigned, the system displays an empty state indicating that no training content is currently available.
+If the Learner/Employee has no training documents assigned, the system displays an empty state indicating that no training content is currently available.
 
-#### `EX-UC02-02`: Training Document Not Found
+#### EX-UC02-02: Training Document Not Found
 
-If the learner attempts to open a training document that does not exist or is no longer assigned, the system displays an error state and allows the learner to return to the training list.
+If the Learner/Employee attempts to open a training document that does not exist or is no longer assigned, the system displays an error state and allows the Learner/Employee to return to the training list.
 
-#### `EX-UC02-03`: Training Content Loading Failure
+#### EX-UC02-03: Training Content Loading Failure
 
-If the system cannot load the training document, it displays a safe error message and allows the learner to retry or return to the dashboard.
+If the system cannot load the training document, it displays a safe error message and allows the Learner/Employee to retry or return to the dashboard.
 
-#### `EX-UC02-04`: Interaction Tracking Failure
+#### EX-UC02-04: Interaction Tracking Failure
 
-If the system cannot record training interaction, the system should not expose technical details to the learner. The training content should still be displayed where possible.
+If the system cannot record training interaction, the system should not expose technical details to the Learner/Employee. The training content should still be displayed where possible.
 
 ### Functional Requirements
 
-| ID           | Requirement                                                                                     | Priority | Notes                                                                                                                          |
-| ------------ | ----------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `FR-UC02-01` | The system shall allow a learner to view a list of assigned training documents.                 | **Must** | Includes summary information such as title, description, and basic interaction status (e.g., not started, started, completed). |
-| `FR-UC02-02` | The system shall allow a learner to open a selected training document.                          | **Must** | Displays full training content.                                                                                                |
-| `FR-UC02-03` | The system shall present training content in a structured and readable format.                  | **Must** | Supports accessibility and clarity.                                                                                            |
-| `FR-UC02-04` | The system shall record a basic interaction event when training is viewed.                      | Should   | Supports more detailed future reporting.                                                                                       |
-| `FR-UC02-05` | The system shall display an empty state when no training documents are assigned.                | **Must** | Clear, non-technical messaging.                                                                                                |
-| `FR-UC02-06` | The system shall display a safe error state when a training document cannot be loaded.          | **Must** | Allow recovery navigation.                                                                                                     |
-| `FR-UC02-07` | The system shall allow navigation to a linked quiz without executing the quiz flow.             | Should   | Quiz handled in `UC-03`.                                                                                                       |
-| `FR-UC02-08` | The system shall not allow modification of training content by learners.                        | **Must** | Maintains scope boundary.                                                                                                      |
-| `FR-UC02-09` | The system shall treat all training documents as controlled educational content.                | **Must** | Reinforces training context.                                                                                                   |
-| `FR-UC02-10` | The system shall allow the learner to access training content independently of quiz completion. | Should   | Maintains separation between `UC-02` and `UC-03`.                                                                              |
+| ID         | Requirement                                                                                              | Notes                                                                                                                          |
+| ---------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| FR-UC02-01 | The system shall allow a Learner/Employee to view a list of assigned training documents.                 | Includes summary information such as title, description, and basic interaction status (e.g., not started, started, completed). |
+| FR-UC02-02 | The system shall allow a Learner/Employee to open a selected training document.                          | Displays full training content.                                                                                                |
+| FR-UC02-03 | The system shall present training content in a structured and readable format.                           | Supports accessibility and clarity.                                                                                            |
+| FR-UC02-04 | The system shall record a basic interaction event when training is viewed.                               | Supports more detailed future reporting.                                                                                       |
+| FR-UC02-05 | The system shall display an empty state when no training documents are assigned.                         | Clear, non-technical messaging.                                                                                                |
+| FR-UC02-06 | The system shall display a safe error state when a training document cannot be loaded.                   | Allow recovery navigation.                                                                                                     |
+| FR-UC02-07 | The system shall allow navigation to a linked quiz without executing the quiz flow.                      | Quiz handled in `UC-03`.                                                                                                       |
+| FR-UC02-08 | The system shall not allow modification of training content by Learner/Employee users.                   | Maintains scope boundary.                                                                                                      |
+| FR-UC02-09 | The system shall treat all training documents as controlled educational content.                         | Reinforces training context.                                                                                                   |
+| FR-UC02-10 | The system shall allow the Learner/Employee to access training content independently of quiz completion. | Maintains separation between `UC-02` and `UC-03`.                                                                              |
 
 ### UC-02 Validation, Error-State, and Feedback Support
 
-The training document view should use the shared validation and feedback rules defined for Demo 1. These rules support the learner experience without expanding UC-02 beyond viewing assigned training content.
+The training document view should use the shared validation and feedback rules defined for Demo 1. These rules support the Learner/Employee experience without expanding UC-02 beyond viewing assigned training content.
 
 For UC-02, the system should provide the following feedback states:
 
-- **Loading state:** When assigned training documents or document details are being loaded, the learner should see a clear loading indication instead of an empty or broken page.
-- **Empty state:** If the learner has no assigned training documents, the system should show a friendly empty-state message explaining that no training is currently available.
+- **Loading state:** When assigned training documents or document details are being loaded, the Learner/Employee should see a clear loading indication instead of an empty or broken page.
+- **Empty state:** If the Learner/Employee has no assigned training documents, the system should show a friendly empty-state message explaining that no training is currently available.
 - **Unavailable-content state:** If a selected training document is missing, unavailable, or no longer assigned, the system should explain that the content cannot be opened and provide a safe way to return to the training list or dashboard.
-- **Load-failure state:** If the document cannot be loaded because of a system or network problem, the learner should see a non-technical error message and, where appropriate, a retry or back-navigation option.
-- **Progress feedback:** If the system records that the learner opened or viewed a document, this should happen without interrupting the reading experience. If progress tracking fails, the learner should still be able to read the content.
+- **Load-failure state:** If the document cannot be loaded because of a system or network problem, the Learner/Employee should see a non-technical error message and, where appropriate, a retry or back-navigation option.
+- **Progress feedback:** If the system records that the Learner/Employee opened or viewed a document, this should happen without interrupting the reading experience. If progress tracking fails, the Learner/Employee should still be able to read the content.
 - **Quiz-link feedback:** If the document links to a quiz, the interface should make it clear that selecting the quiz link starts or continues the quiz flow under UC-03.
 - **Accessible feedback:** Training feedback messages should be readable, keyboard-accessible, and understandable without relying only on colour.
 
@@ -323,43 +361,55 @@ These feedback rules are limited to supporting the training document viewing flo
 
 ### Domain References
 
-| ID           | Entity             | Description                                                     |
-| ------------ | ------------------ | --------------------------------------------------------------- |
-| `DE-UC02-01` | Learner            | The user viewing assigned training documents.                   |
-| `DE-UC02-02` | TrainingDocument   | A structured educational content item (e.g., PDF, HTML module). |
-| `DE-UC02-03` | TrainingAssignment | Links a training document to a learner via a campaign.          |
-| `DE-UC02-04` | TrainingProgress   | A basic record of training interaction or status.               |
-| `DE-UC02-05` | TrainingReference  | Optional link or button to related quiz or follow-up content.   |
+Preliminary domain entities linked to UC-02:
+
+| ID         | Entity            | Description                                                                     |
+| ---------- | ----------------- | ------------------------------------------------------------------------------- |
+| DE-UC02-01 | Learner/Employee  | The user viewing assigned training documents.                                   |
+| DE-UC02-02 | TrainingDocument  | A structured educational content item (e.g., PDF, HTML module).                 |
+| DE-UC02-03 | LearningPath      | Groups training modules and training content available to the Learner/Employee. |
+| DE-UC02-04 | TrainingProgress  | A basic record of training interaction or status.                               |
+| DE-UC02-05 | TrainingReference | Optional link or button to related quiz or follow-up content.                   |
 
 ### API References
 
-| ID            | Contract                              | Purpose                                               |
-| ------------- | ------------------------------------- | ----------------------------------------------------- |
-| `API-UC02-01` | `GET /training/assigned`              | Retrieve assigned training documents for the learner. |
-| `API-UC02-02` | `GET /training/:trainingId`           | Retrieve full training document content.              |
-| `API-UC02-03` | `POST /training/:trainingId/progress` | Record a basic training interaction event.            |
+Preliminary API placeholders linked to UC-02:
+
+| ID          | Contract                              | Purpose                                                        |
+| ----------- | ------------------------------------- | -------------------------------------------------------------- |
+| API-UC02-01 | `GET /training/assigned`              | Retrieve assigned training documents for the Learner/Employee. |
+| API-UC02-02 | `GET /training/:trainingId`           | Retrieve full training document content.                       |
+| API-UC02-03 | `POST /training/:trainingId/progress` | Record a basic training interaction event.                     |
+
+PLEASE NOTE: These contracts are subject to change throughout the course of implementation.
 
 ### Traceability References
 
-| Traceability ID | Linked Item                                                 |
-| --------------- | ----------------------------------------------------------- |
-| `TRACE-UC02-01` | `UC-02 -> FR-UC02-01, API-UC02-01, DE-UC02-02, DES-UC02-01` |
-| `TRACE-UC02-02` | `UC-02 -> FR-UC02-02, API-UC02-02, DE-UC02-02, DES-UC02-02` |
-| `TRACE-UC02-03` | `UC-02 -> FR-UC02-04, API-UC02-03, DE-UC02-04`              |
-| `TRACE-UC02-04` | `UC-02 -> FR-UC02-07, DE-UC02-05, DES-UC02-03`              |
-| `TRACE-UC02-05` | `UC-02 -> FR-UC02-08`                                       |
+| Traceability ID | Linked Item                                                                                         |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| TRACE-UC02-01   | UC-02 to FR-UC02-01, API-UC02-01, DE-UC02-02, `docs/demo1/DESIGN.md` Training Module List section   |
+| TRACE-UC02-02   | UC-02 to FR-UC02-02, API-UC02-02, DE-UC02-02, `docs/demo1/DESIGN.md` Training Material Page section |
+| TRACE-UC02-03   | UC-02 to FR-UC02-04, API-UC02-03, DE-UC02-04                                                        |
+| TRACE-UC02-04   | UC-02 to FR-UC02-07, DE-UC02-05, `docs/demo1/DESIGN.md` Training Material to Quiz Flow section      |
+| TRACE-UC02-05   | UC-02 to FR-UC02-08                                                                                 |
 
-## UC-03: Quiz Flow Requirements (Zoë)
+## UC-03: Quiz Flow Requirements
 
 ### User Story
 
-As an employee, I want to complete a quiz after my training session so that I can verify my understanding of the material and receive feedback on my security knowledge
+As a Learner/Employee, I want to complete a quiz after my training session so that I can verify my understanding of the material and receive feedback on my security knowledge.
+
+### Purpose
+
+UC-03 defines the Demo 1 quiz flow feature slice. The quiz flow allows a Learner/Employee to open assigned quiz content, answer supported questions, submit a quiz attempt, and view results or feedback where available.
+
+This use case is limited to completing a controlled quiz flow and viewing the submitted result or feedback. It does not include quiz authoring, campaign management, adaptive learning, gamified progression, or full reporting dashboards.
 
 ### Actor
 
 Primary Actor:
 
-- Employee
+- Learner/Employee
 
 Supporting Actors:
 
@@ -367,140 +417,139 @@ Supporting Actors:
 
 ### Preconditions
 
-- The employee is authenticated and registered.
-
-- The employee has access to an assigned or available quiz.
+- The Learner/Employee is authenticated and registered.
+- The Learner/Employee has access to an assigned or available quiz.
 - Quiz questions and answer content exist as controlled training content inside the platform.
-- The quiz is available from the learner/employee dashboard, assigned training path, or related training follow-up path.
+- The quiz is available from the Learner/Employee dashboard, assigned training path, or related training follow-up path.
 
 ### Postconditions
 
-Successful postconditions:
+Successful Post conditions:
 
-- The system creates a quiz attempt when the employee starts the quiz.
-- The employee can answer the quiz questions and submit the attempt.
+- The system creates a quiz attempt when the Learner/Employee starts the quiz.
+- The Learner/Employee can answer the quiz questions and submit the attempt.
 - The submitted answers are recorded against the quiz attempt.
 - The system marks the attempt as submitted and makes results available.
-- The employee receives a result summary and educational feedback for the submitted attempt.
+- The Learner/Employee receives a result summary and educational feedback for the submitted attempt.
 
-Unsuccessful postconditions:
+Unsuccessful Post conditions:
 
-- If the quiz cannot be loaded or started, no attempt is completed and the employee sees a safe error state.
-- If submission validation fails, the attempt remains unsubmitted and the employee can correct the highlighted questions.
+- If the quiz cannot be loaded or started, no attempt is completed and the Learner/Employee sees a safe error state.
+- If submission validation fails, the attempt remains unsubmitted and the Learner/Employee can correct the highlighted questions.
 - If submission succeeds but the results or feedback view cannot be loaded, the attempt remains submitted while the system provides a retry or return path.
 
 ### Main Flow
 
-1. The employee navigates to an assigned quiz from the learner/employee dashboard, assigned training path, or related follow-up link.
+1. The Learner/Employee navigates to an assigned quiz from the Learner/Employee dashboard, assigned training path, or related follow-up link.
 2. The system loads the selected quiz and displays the quiz entry view or quiz page.
-3. The employee selects the option to start the quiz.
-4. The system creates a quiz attempt for the employee and opens the active quiz view.
+3. The Learner/Employee selects the option to start the quiz.
+4. The system creates a quiz attempt for the Learner/Employee and opens the active quiz view.
 5. The system displays the quiz questions and the supported answer controls for the selected quiz.
-6. The employee answers the quiz questions and may review or change answers before submission.
-7. The employee submits the quiz attempt.
+6. The Learner/Employee answers the quiz questions and may review or change answers before submission.
+7. The Learner/Employee submits the quiz attempt.
 8. The system validates the submission and, if valid, records the final answers and marks the attempt as submitted.
 9. The system calculates or retrieves the result for the submitted attempt.
 10. The system displays the quiz results, including the result summary and educational feedback where available.
-11. The employee reviews the results and feedback and may return to the relevant learner navigation path.
+11. The Learner/Employee reviews the results and feedback and may return to the relevant navigation path.
 
 ### Exceptions
 
 #### EX-UC03-01: Quiz Not Available
 
-If the selected quiz does not exist, is no longer assigned, or cannot be accessed by the employee, the system displays a safe error state and allows the employee to return to the previous learner path.
+If the selected quiz does not exist, is no longer assigned, or cannot be accessed by the Learner/Employee, the system displays a safe error state and allows the Learner/Employee to return to the previous path.
 
 #### EX-UC03-02: Quiz Start Failure
 
-If the system cannot create or open a quiz attempt after the employee starts the quiz, the system displays a safe error message and allows the employee to retry or return without exposing technical details.
+If the system cannot create or open a quiz attempt after the Learner/Employee starts the quiz, the system displays a safe error message and allows the Learner/Employee to retry or return without exposing technical details.
 
 #### EX-UC03-03: Incomplete or Invalid Submission
 
-If the employee attempts to submit the quiz with missing required answers or invalid answer data, the system prevents submission, highlights the affected questions, and allows the employee to correct the attempt.
+If the Learner/Employee attempts to submit the quiz with missing required answers or invalid answer data, the system prevents submission, highlights the affected questions, and allows the Learner/Employee to correct the attempt.
 
 #### EX-UC03-04: Quiz Submission Failure
 
-If the system cannot record the final submission, the system informs the employee that the submission was not completed and allows a retry without discarding answers where possible.
+If the system cannot record the final submission, the system informs the Learner/Employee that the submission was not completed and allows a retry without discarding answers where possible.
 
 #### EX-UC03-05: Results or Feedback Loading Failure
 
-If the submitted attempt cannot load its results or feedback, the system displays a safe error state and allows the employee to retry or return later to the results view.
+If the submitted attempt cannot load its results or feedback, the system displays a safe error state and allows the Learner/Employee to retry or return later to the results view.
 
 ### Functional Requirements
 
-| ID         | Requirement                                                                                                                 | Priority | Notes                                                                                     |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------- | -------: | ----------------------------------------------------------------------------------------- |
-| FR-UC03-01 | The system shall allow an employee to start an assigned or available quiz.                                                  |     Must | Starting the quiz begins the Demo 1 quiz flow for the learner.                            |
-| FR-UC03-02 | The system shall retrieve and display the selected quiz content, including its questions and answer content.                |     Must | The quiz content should be presented in a clear and readable format.                      |
-| FR-UC03-03 | The system shall create a quiz attempt when the employee starts the quiz.                                                   |     Must | The attempt provides the reference used for submission and results retrieval.             |
-| FR-UC03-04 | The system shall allow the employee to answer supported quiz questions and review or change answers before submission.      |     Must | Demo 1 question formats remain implementation-dependent.                                  |
-| FR-UC03-05 | The system shall validate required quiz answers before accepting a final submission.                                        |     Must | Missing or invalid answers should produce clear correction feedback.                      |
-| FR-UC03-06 | The system shall submit the employee's quiz attempt and record the final answers against that attempt.                      |     Must | The attempt should be marked as submitted once accepted.                                  |
-| FR-UC03-07 | The system shall display the submitted attempt's results to the employee.                                                   |     Must | Results may include score, status, or summary outcome where defined.                      |
-| FR-UC03-08 | The system shall display educational feedback for the submitted attempt.                                                    |     Must | Feedback may include correct/incorrect indicators, explanations, or improvement guidance. |
-| FR-UC03-09 | The system shall prevent further editing or duplicate final submission of a completed quiz attempt.                         |     Must | A completed attempt should remain read-only.                                              |
-| FR-UC03-10 | The system shall display safe validation and error states when quiz content, attempt creation, submission, or results fail. |     Must | Messages should be clear, non-technical, and safe for the learner.                        |
+| ID         | Requirement                                                                                                                    | Notes                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| FR-UC03-01 | The system shall allow a Learner/Employee to start an assigned or available quiz.                                              | Starting the quiz begins the Demo 1 quiz flow for the Learner/Employee.                   |
+| FR-UC03-02 | The system shall retrieve and display the selected quiz content, including its questions and answer content.                   | The quiz content should be presented in a clear and readable format.                      |
+| FR-UC03-03 | The system shall create a quiz attempt when the Learner/Employee starts the quiz.                                              | The attempt provides the reference used for submission and results retrieval.             |
+| FR-UC03-04 | The system shall allow the Learner/Employee to answer supported quiz questions and review or change answers before submission. | Demo 1 question formats remain implementation-dependent.                                  |
+| FR-UC03-05 | The system shall validate required quiz answers before accepting a final submission.                                           | Missing or invalid answers should produce clear correction feedback.                      |
+| FR-UC03-06 | The system shall submit the Learner/Employee's quiz attempt and record the final answers against that attempt.                 | The attempt should be marked as submitted once accepted.                                  |
+| FR-UC03-07 | The system shall display the submitted attempt's results to the Learner/Employee.                                              | Results may include score, status, or summary outcome where defined.                      |
+| FR-UC03-08 | The system shall display educational feedback for the submitted attempt.                                                       | Feedback may include correct/incorrect indicators, explanations, or improvement guidance. |
+| FR-UC03-09 | The system shall prevent further editing or duplicate final submission of a completed quiz attempt.                            | A completed attempt should remain read-only.                                              |
+| FR-UC03-10 | The system shall display safe validation and error states when quiz content, attempt creation, submission, or results fail.    | Messages should be clear, non-technical, and safe for the Learner/Employee.               |
 
 ### UC-03 Validation, Submission, and Feedback Support
 
-The quiz flow must provide clear validation and feedback so that the learner understands what is required, what is being processed, and what result or next step is available. These rules support UC-03 and do not create a separate validation use case.
+The quiz flow must provide clear validation and feedback so that the Learner/Employee understands what is required, what is being processed, and what result or next step is available. These rules support UC-03 and do not create a separate validation use case.
 
 For UC-03, the system should support the following behaviours:
 
-- **Required-answer validation:** The learner must be informed when one or more required quiz questions have not been answered before submission.
+- **Required-answer validation:** The Learner/Employee must be informed when one or more required quiz questions have not been answered before submission.
 - **Answer-format validation:** If an answer is malformed, unsupported, or cannot be accepted, the system should show a clear message explaining what needs to be corrected.
 - **Inline guidance:** Validation messages should appear close to the relevant question where possible, with a page-level summary used only when helpful.
-- **Submission state:** When the learner submits a quiz, the system should show a submitting or processing state.
+- **Submission state:** When the Learner/Employee submits a quiz, the system should show a submitting or processing state.
 - **Duplicate-submission prevention:** The submit action should be disabled or guarded while the submission is being processed.
-- **Submission success feedback:** After a successful submission, the learner should receive confirmation that the attempt was submitted and that results or feedback are available.
-- **Submission failure feedback:** If submission fails, the learner should see a safe, non-technical error message and should not lose their current answers where possible.
+- **Submission success feedback:** After a successful submission, the Learner/Employee should receive confirmation that the attempt was submitted and that results or feedback are available.
+- **Submission failure feedback:** If submission fails, the Learner/Employee should see a safe, non-technical error message and should not lose their current answers where possible.
 - **Results-loading feedback:** If quiz results or feedback are still loading, the system should indicate that the result is being prepared.
-- **Results failure feedback:** If results cannot be loaded, the learner should receive a retry or safe navigation option.
+- **Results failure feedback:** If results cannot be loaded, the Learner/Employee should receive a retry or safe navigation option.
 - **Educational feedback:** Quiz feedback should explain correct and incorrect answers in a supportive learning tone.
-- **Unavailable quiz state:** If a quiz is unavailable, empty, or no longer assigned, the system should explain the situation and provide a safe way back to the training material or learner dashboard.
+- **Unavailable quiz state:** If a quiz is unavailable, empty, or no longer assigned, the system should explain the situation and provide a safe way back to the training material or Learner/Employee dashboard.
 - **Accessible feedback:** Quiz validation, submission, and result messages should be perceivable to keyboard and screen-reader users and should not rely only on colour.
 
-The quiz flow should prioritise clear learner recovery: the learner should know what happened, what needs attention, and what action they can take next.
+The quiz flow should prioritise clear Learner/Employee recovery: the Learner/Employee should know what happened, what needs attention, and what action they can take next.
 
 ### Domain References
 
 Preliminary domain entities linked to UC-03:
 
-| ID         | Entity        | Description                                                                  |
-| ---------- | ------------- | ---------------------------------------------------------------------------- |
-| DE-UC03-01 | Employee/User | The learner who starts, completes, and reviews an assigned quiz.             |
-| DE-UC03-02 | Quiz          | The assigned assessment that the employee can open and complete.             |
-| DE-UC03-03 | QuizQuestion  | An individual question presented to the employee inside the quiz flow.       |
-| DE-UC03-04 | QuizAttempt   | The employee's attempt record for a started or submitted quiz.               |
-| DE-UC03-05 | AttemptAnswer | A recorded answer linked to a question within a specific quiz attempt.       |
-| DE-UC03-06 | QuizResult    | The result summary produced after a quiz attempt is submitted and processed. |
-| DE-UC03-07 | FeedbackItem  | Educational feedback linked to the submitted attempt or its questions.       |
+| ID         | Entity                | Description                                                                    |
+| ---------- | --------------------- | ------------------------------------------------------------------------------ |
+| DE-UC03-01 | Learner/Employee/User | The user who starts, completes, and reviews an assigned quiz.                  |
+| DE-UC03-02 | Quiz                  | The assigned assessment that the Learner/Employee can open and complete.       |
+| DE-UC03-03 | QuizQuestion          | An individual question presented to the Learner/Employee inside the quiz flow. |
+| DE-UC03-04 | QuizAttempt           | The Learner/Employee's attempt record for a started or submitted quiz.         |
+| DE-UC03-05 | AttemptAnswer         | A recorded answer linked to a question within a specific quiz attempt.         |
+| DE-UC03-06 | QuizResult            | The result summary produced after a quiz attempt is submitted and processed.   |
+| DE-UC03-07 | FeedbackItem          | Educational feedback linked to the submitted attempt or its questions.         |
 
 ### API References
 
 Preliminary API placeholders linked to UC-03:
 
-| ID          | Contract                                         | Purpose                                                                         |
-| ----------- | ------------------------------------------------ | ------------------------------------------------------------------------------- |
-| API-UC03-01 | `GET /training/quizzes/:quizId`                  | Retrieve the selected quiz content before or when the employee starts the quiz. |
-| API-UC03-02 | `POST /training/quizzes/:quizId/attempts`        | Create a quiz attempt for the employee when the quiz is started.                |
-| API-UC03-03 | `POST /training/quiz-attempts/:attemptId/submit` | Submit the completed quiz attempt and record the final answers.                 |
-| API-UC03-04 | `GET /training/quiz-attempts/:attemptId/results` | Retrieve the submitted attempt's results and feedback.                          |
+| ID          | Contract                                | Purpose                                                                                 |
+| ----------- | --------------------------------------- | --------------------------------------------------------------------------------------- |
+| API-UC03-01 | `GET /quizzes/:quizId`                  | Retrieve the selected quiz content before or when the Learner/Employee starts the quiz. |
+| API-UC03-02 | `POST /quizzes/:quizId/attempts`        | Create a quiz attempt for the Learner/Employee when the quiz is started.                |
+| API-UC03-03 | `POST /quiz-attempts/:attemptId/submit` | Submit the completed quiz attempt and record the final answers.                         |
+| API-UC03-04 | `GET /quiz-attempts/:attemptId/results` | Retrieve the submitted attempt's results and feedback.                                  |
 
 PLEASE NOTE: These contracts are subject to change throughout the course of implementation.
 
 ### Traceability References
 
-| Traceability ID | Linked Item                                                                                                |
-| --------------- | ---------------------------------------------------------------------------------------------------------- |
-| TRACE-UC03-01   | UC-03 to FR-UC03-01, FR-UC03-02, API-UC03-01, DE-UC03-02, DE-UC03-03, DES-UC03-01, DES-UC03-02             |
-| TRACE-UC03-02   | UC-03 to FR-UC03-03, API-UC03-02, DE-UC03-04, DES-UC03-01                                                  |
-| TRACE-UC03-03   | UC-03 to FR-UC03-04, FR-UC03-05, DE-UC03-05, DES-UC03-02                                                   |
-| TRACE-UC03-04   | UC-03 to FR-UC03-06, FR-UC03-09, API-UC03-03, DE-UC03-04, DES-UC03-03                                      |
-| TRACE-UC03-05   | UC-03 to FR-UC03-07, FR-UC03-08, FR-UC03-10, API-UC03-04, DE-UC03-06, DE-UC03-07, DES-UC03-04, DES-UC03-05 |
+| Traceability ID | Linked Item                                                                                                                        |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| TRACE-UC03-01   | UC-03 to FR-UC03-01, FR-UC03-02, API-UC03-01, DE-UC03-02, DE-UC03-03, `docs/demo1/DESIGN.md` Quiz Page section                     |
+| TRACE-UC03-02   | UC-03 to FR-UC03-03, API-UC03-02, DE-UC03-04, `docs/demo1/DESIGN.md` Quiz Page section                                             |
+| TRACE-UC03-03   | UC-03 to FR-UC03-04, FR-UC03-05, DE-UC03-05, `docs/demo1/DESIGN.md` Quiz Page section                                              |
+| TRACE-UC03-04   | UC-03 to FR-UC03-06, FR-UC03-09, API-UC03-03, DE-UC03-04, `docs/demo1/DESIGN.md` Quiz Submission State section                     |
+| TRACE-UC03-05   | UC-03 to FR-UC03-07, FR-UC03-08, FR-UC03-10, API-UC03-04, DE-UC03-06, DE-UC03-07, `docs/demo1/DESIGN.md` Quiz Results Page section |
 
 ## Validation, Error-State, and Feedback Requirements (Zoë)
 
-This section defines supporting validation, error-state, and feedback requirements for Demo 1 learner-facing flows. These requirements support UC-02, UC-03, and base form behaviour, but they are not a separate Demo 1 core use case.
+This section defines supporting validation, error-state, and feedback requirements for Demo 1 Learner/Employee-facing flows. These requirements support UC-02, UC-03, and base form behaviour, but they are not a separate Demo 1 core use case.
 
 Demo 1 core use cases remain limited to:
 
@@ -510,25 +559,25 @@ Demo 1 core use cases remain limited to:
 
 ### Required Field Validation
 
-For Demo 1, required fields and required quiz questions should be validated before final submission is accepted. If required information is missing, the system should identify the affected field or question and allow the learner to complete it without losing other valid input.
+For Demo 1, required fields and required quiz questions should be validated before final submission is accepted. If required information is missing, the system should identify the affected field or question and allow the Learner/Employee to complete it without losing other valid input.
 
 For UC-03, quiz submission should validate that all required questions have an answer before the final submission is accepted.
 
 ### Quiz Answer Validation
 
-Quiz answer validation is limited to ensuring that submitted answers match the expected input structure for the question types supported in Demo 1. The system should reject malformed or unsupported answer data safely and display a clear correction message to the learner.
+Quiz answer validation is limited to ensuring that submitted answers match the expected input structure for the question types supported in Demo 1. The system should reject malformed or unsupported answer data safely and display a clear correction message to the Learner/Employee.
 
 This requirement does not define final backend validation logic or final quiz schemas.
 
 ### Submission Feedback
 
-When the learner submits a quiz attempt, the system should show clear progress feedback that the attempt is being processed. During this state, duplicate submission actions should be prevented where possible.
+When the Learner/Employee submits a quiz attempt, the system should show clear progress feedback that the attempt is being processed. During this state, duplicate submission actions should be prevented where possible.
 
 If submission fails, the system should explain that the attempt was not completed and allow a safe retry where possible.
 
 ### Success Messages
 
-After a successful submission, the learner should receive confirmation that the quiz was submitted and that results are available. Success messaging should be concise, learner-facing, and consistent with the controlled training context.
+After a successful submission, the Learner/Employee should receive confirmation that the quiz was submitted and that results are available. Success messaging should be concise, Learner/Employee-facing, and consistent with the controlled training context.
 
 Success messages may also support base features, such as confirming successful login or registration, where relevant.
 
@@ -536,29 +585,29 @@ Success messages may also support base features, such as confirming successful l
 
 Errors should be presented in plain, non-technical language. Messages should distinguish between validation issues, unavailable content, loading failures, submission failures, and results-loading failures without exposing internal system details.
 
-Error messages should explain what happened at a learner-facing level and what action the learner can take next.
+Error messages should explain what happened at a Learner/Employee-facing level and what action the Learner/Employee can take next.
 
 ### Loading States
 
-The system should provide a visible loading state when training content, quiz content, submission, results, or feedback are being retrieved or processed. The learner should not be left on a blank or broken page while content is loading.
+The system should provide a visible loading state when training content, quiz content, submission, results, or feedback are being retrieved or processed. The Learner/Employee should not be left on a blank or broken page while content is loading.
 
 During final quiz submission, duplicate submission actions should be prevented where possible.
 
 ### Empty States
 
-If a learner has no assigned training documents, or if a quiz has no available questions, results, or feedback, the system should present a safe empty or unavailable state with a clear return path.
+If a Learner/Employee has no assigned training documents, or if a quiz has no available questions, results, or feedback, the system should present a safe empty or unavailable state with a clear return path.
 
-Empty states should explain the situation in learner-friendly language and should not make the page appear broken.
+Empty states should explain the situation in Learner/Employee-friendly language and should not make the page appear broken.
 
 ### Unavailable-Content States
 
-If assigned content cannot be accessed, such as a missing training document or unavailable quiz, the system should explain that the content is not currently available and provide a safe way to return to the training list, quiz page, or learner dashboard.
+If assigned content cannot be accessed, such as a missing training document or unavailable quiz, the system should explain that the content is not currently available and provide a safe way to return to the training list, quiz page, or Learner/Employee dashboard.
 
-Unavailable-content messages should not blame the learner or expose internal system details.
+Unavailable-content messages should not blame the Learner/Employee or expose internal system details.
 
 ### Accessibility Considerations
 
-Validation, feedback, loading, empty, and error messages should be accessible to learners using keyboard navigation or assistive technologies.
+Validation, feedback, loading, empty, and error messages should be accessible to Learner/Employee users using keyboard navigation or assistive technologies.
 
 At minimum:
 
@@ -588,37 +637,37 @@ Avoid examples:
 ## Admin and Campaign Supporting Context (Rudolph)
 
 > [!NOTE]
-> The following User Stories and Functional Requirements are provided as **supporting context** and **future-facing placeholders** only. They describe the administrative setup required to enable the employee-facing use cases (UC-01, UC-02, and UC-03) and are not part of the core Demo 1 implementation scope.
+> The following User Stories and Functional Requirements are provided as **supporting context** and **future-facing placeholders** only. They describe the administrative setup required to enable the Learner/Employee-facing use cases (UC-01, UC-02, and UC-03) and are not part of the core Demo 1 implementation scope.
 
 ### User Stories (Supporting Context)
 
-| ID        | User Story                                                                                                                                                                   |
-| :-------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| US-ADM-01 | As an Administrator, I want to create a new campaign so that I can group related simulations and training materials for specific security initiatives.                       |
-| US-ADM-02 | As an Administrator, I want to assign specific employees to a campaign so that they receive the targeted training relevant to their role or risk profile.                    |
-| US-ADM-03 | As an Administrator, I want to configure simulated emails and training content for a campaign so that the learner experience is aligned with current organizational threats. |
-| US-ADM-04 | As an Administrator, I want to monitor the progress of a campaign so that I can identify high-risk groups or employees who need additional support.                          |
-| US-ADM-05 | As an Administrator, I want to manage a library of simulation templates so that I can quickly deploy standardized training across different campaigns.                       |
+| ID        | User Story                                                                                                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| US-ADM-01 | As an Administrator, I want to create a new campaign so that I can group related simulations and learning paths for specific security initiatives.                             |
+| US-ADM-02 | As an Administrator, I want to assign specific Learner/Employee users to a campaign so that they receive the targeted training relevant to their role or risk profile.         |
+| US-ADM-03 | As an Administrator, I want to configure simulations and learning paths for a campaign so that the Learner/Employee experience is aligned with current organizational threats. |
+| US-ADM-04 | As an Administrator, I want to monitor the progress of a campaign so that I can identify high-risk groups or Learner/Employee users who need additional support.               |
+| US-ADM-05 | As an Administrator, I want to manage a library of simulation templates so that I can quickly deploy standardized training across different campaigns.                         |
 
 ### Administrator User Characteristics
 
-The Administrator is a specialized user responsible for managing the security awareness program. For Demo 1, the Administrator role is documented as the source of configuration for the employee-facing use cases.
+The Administrator is a specialized user responsible for managing the security awareness program. For Demo 1, the Administrator role is documented as the source of configuration for the Learner/Employee-facing use cases.
 
 - **Goal:** To set up training campaigns that improve the organization's security posture.
 - **Technical Literacy:** Moderate to high; familiar with organizational structure and common cyber threats.
 - **Responsibilities:**
   - **Campaign Management:** Defining start/end dates, target groups, and objectives.
-  - **Content Curation:** Selecting or creating simulated emails, training documents, and quizzes.
-  - **User Orchestration:** Mapping employees to specific training paths.
+  - **Content Curation:** Selecting or creating simulations, learning paths, training documents, and quizzes.
+  - **User Orchestration:** Mapping Learner/Employee users to specific learning paths.
   - **Risk Analysis:** Reviewing interaction data to assess organizational vulnerability.
 
 ### Preliminary Campaign Lifecycle (Supporting Context)
 
 To support the delivery of simulations and training, a preliminary campaign lifecycle is envisioned:
 
-1. **Draft:** The campaign is being configured. No content is visible to employees.
+1. **Draft:** The campaign is being configured. No content is visible to Learner/Employee users.
 2. **Scheduled:** (Future Scope) The campaign is prepared for automatic activation at a specific date.
-3. **Active:** The campaign is live, making assigned content visible to employees.
+3. **Active:** The campaign is live, making assigned content visible to Learner/Employee users.
 4. **Paused:** (Future Scope) Temporary suspension of content accessibility.
 5. **Completed:** The campaign duration has ended. Final status is recorded.
 6. **Archived:** (Future Scope) Historical record storage.
@@ -627,7 +676,7 @@ To support the delivery of simulations and training, a preliminary campaign life
 
 #### Simulation Content Setup (UC-01)
 
-Administrators configure the simulated emails that appear in the employee's inbox.
+Administrators configure simulations that use simulated emails shown in the Learner/Employee's inbox.
 
 - **Sender Metadata:** Setting the display name (e.g., "IT Support") and a spoofed-style email address (e.g., `support@corp-security.com`).
 - **Phishing Indicators:** Configuring specific "red flags" in the email body (e.g., urgent language, suspicious links, grammatical errors) to be used for educational feedback.
@@ -635,7 +684,7 @@ Administrators configure the simulated emails that appear in the employee's inbo
 
 #### Training and Quiz Setup (UC-02, UC-03)
 
-Administrators link educational content and assessments to the campaign.
+Administrators link learning paths and assessments to the campaign context.
 
 - **Document Library:** A central repository of training materials (PDFs, HTML modules).
 - **Quiz Builder:** Configuration of questions, multiple-choice options, and correct answer explanations.
@@ -658,31 +707,31 @@ Administrators must adhere to strict boundaries when configuring campaigns:
 
 ### Admin/Campaign Functional Requirements (Supporting Context)
 
-| ID        | Requirement                                                                        | Priority | Notes                                 |
-| :-------- | :--------------------------------------------------------------------------------- | :------- | :------------------------------------ |
-| FR-ADM-01 | The system shall support a Campaign entity to group simulations and training.      | Should   | Precondition for UC-01, UC-02, UC-03. |
-| FR-ADM-02 | The system shall support assigning a Campaign to Employees.                        | Should   | Precondition for Demo 1 use cases.    |
-| FR-ADM-03 | The system shall support the configuration of Simulated Emails for a Campaign.     | Should   | Precondition for UC-01.               |
-| FR-ADM-04 | The system shall support the linking of Training Documents to a Campaign.          | Should   | Precondition for UC-02.               |
-| FR-ADM-05 | The system shall support the linking of Quizzes to Training Documents.             | Should   | Precondition for UC-03.               |
-| FR-ADM-06 | The system may provide placeholders for recording campaign-level interaction data. | May      | Future reporting support.             |
-| FR-ADM-07 | The system may support a repository for Simulation Templates.                      | May      | Future optimization.                  |
-| FR-ADM-08 | The system should support transition logic to activate a campaign.                 | Should   | Controls visibility to actors.        |
-| FR-ADM-09 | The system may allow previewing simulation content before activation.              | May      | Future quality check.                 |
-| FR-ADM-10 | The system should prevent the collection of sensitive PII through simulated links. | Should   | Safety constraint.                    |
+| ID        | Requirement                                                                                       | Notes                                 |
+| --------- | ------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| FR-ADM-01 | The system shall support a Campaign entity to group simulations, learning paths, and assignments. | Precondition for UC-01, UC-02, UC-03. |
+| FR-ADM-02 | The system shall support assigning a Campaign to Learner/Employee users.                          | Precondition for Demo 1 use cases.    |
+| FR-ADM-03 | The system shall support the configuration of Simulations and Simulated Emails for a Campaign.    | Precondition for UC-01.               |
+| FR-ADM-04 | The system shall support the linking of Learning Paths and training content to a Campaign.        | Precondition for UC-02.               |
+| FR-ADM-05 | The system shall support the linking of Quizzes to Training Documents.                            | Precondition for UC-03.               |
+| FR-ADM-06 | The system may provide placeholders for recording campaign-level interaction data.                | Future reporting support.             |
+| FR-ADM-07 | The system may support a repository for Simulation Templates.                                     | Future optimization.                  |
+| FR-ADM-08 | The system should support transition logic to activate a campaign.                                | Controls visibility to actors.        |
+| FR-ADM-09 | The system may allow previewing simulation content before activation.                             | Future quality check.                 |
+| FR-ADM-10 | The system should prevent the collection of sensitive PII through simulated links.                | Safety constraint.                    |
 
 ### Domain References (Admin Context)
 
-| ID        | Entity             | Description                                                      |
-| :-------- | :----------------- | :--------------------------------------------------------------- |
-| DE-ADM-01 | Administrator      | The user who manages campaigns and content.                      |
-| DE-ADM-02 | Campaign           | The core entity grouping simulations, training, and assignments. |
-| DE-ADM-03 | CampaignAssignment | The link between a Campaign and an Employee.                     |
+| ID        | Entity             | Description                                                            |
+| --------- | ------------------ | ---------------------------------------------------------------------- |
+| DE-ADM-01 | Administrator      | The user who manages campaigns and content.                            |
+| DE-ADM-02 | Campaign           | The core entity grouping simulations, learning paths, and assignments. |
+| DE-ADM-03 | CampaignAssignment | The link between a Campaign and a Learner/Employee.                    |
 
 ### Traceability References (Admin Context)
 
 | Traceability ID | Linked Item                                                        |
-| :-------------- | :----------------------------------------------------------------- |
+| --------------- | ------------------------------------------------------------------ |
 | TRACE-ADM-01    | Admin Context to FR-ADM-01, API Contract ID: API-ADM-01, DE-ADM-02 |
 | TRACE-ADM-02    | Admin Context to FR-ADM-02, API Contract ID: API-ADM-02, DE-ADM-03 |
 | TRACE-ADM-03    | Admin Context to FR-ADM-03, DE-UC01-03                             |
@@ -710,7 +759,7 @@ The model is intended for SRS alignment, terminology consistency, API planning, 
 
 Diagram file:
 
-- `docs/demo1/diagrams/demo1-domain-model.drawio`
+- `docs/demo1/diagrams/demo1-domain-model-(initial).drawio`
 
 #### Domain Model Scope
 
@@ -718,7 +767,7 @@ The model is divided into four main areas:
 
 | Area                            | Purpose                                                                                                                           |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Users and Access Context        | Represents platform users, organisation membership, company context, and general learner access.                                  |
+| Users and Access Context        | Represents platform users, organisation membership, company context, and general Learner/Employee access.                         |
 | Campaign and Simulation Support | Represents the supporting campaign structure used to assign simulations, learning paths, and simulated emails.                    |
 | Training and Quiz Flow          | Represents the core Demo 1 learning entities for training documents, quizzes, attempts, answers, results, feedback, and progress. |
 | Future / Reporting Support      | Represents future-facing reporting and risk concepts without defining a full reporting schema.                                    |
@@ -727,42 +776,42 @@ The model is divided into four main areas:
 
 The model supports three high-level user types:
 
-| User Type        | Description                                                                                                         |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `Admin`          | A company-linked user who manages employees, campaigns, simulations, and training setup.                            |
-| `Employee`       | A company-linked learner who receives company-context simulated emails, training content, and quizzes.              |
-| `GeneralLearner` | A non-company learner who uses the platform for general cybersecurity learning outside a company-specific campaign. |
+| User Type        | Description                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `Admin`          | A company-linked user who manages Learner/Employee users, campaigns, simulations, and training setup.                        |
+| `Employee`       | A company-linked Learner/Employee who receives company-context simulated emails, training content, and quizzes.              |
+| `GeneralLearner` | A non-company Learner/Employee who uses the platform for general cybersecurity learning outside a company-specific campaign. |
 
-Admins and employees are connected to an organisation through `OrganisationMembership`.
+Administrators and Learner/Employee users are connected to an organisation through `OrganisationMembership` when company context applies.
 
-General learners are not required to belong to an organisation. They may access general cybersecurity content through `GeneralLearningAccess` and general `LearningPath` records.
+General Learner/Employee users are not required to belong to an organisation. They may access general cybersecurity content through `GeneralLearningAccess` and general `LearningPath` records.
 
 #### Core Entity Summary
 
-| Entity                   | Role in Demo 1                                                                                           |
-| ------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `User`                   | Represents the person using the platform. A user may be an admin, employee, or general learner.          |
-| `Organisation`           | Represents a company or organisation using the platform.                                                 |
-| `OrganisationMembership` | Links users to organisations and captures whether they act as admins or employees in that organisation.  |
-| `CompanyContext`         | Provides optional company-specific context used to support realistic simulations and training.           |
-| `Campaign`               | Groups simulations, learning paths, and assignments for company-linked training.                         |
-| `CampaignAssignment`     | Links employees or organisation members to a campaign.                                                   |
-| `LearningPath`           | Groups training and quiz content. It may be company-context or general learning content.                 |
-| `Simulation`             | Represents a controlled simulated security-awareness scenario.                                           |
-| `SimulatedEmail`         | Represents a safe simulated email shown in the simulated inbox for UC-01.                                |
-| `SimulatedInbox`         | Represents the learner-facing inbox view for assigned simulated emails.                                  |
-| `InteractionEvent`       | Records lightweight learner interactions, such as opening a simulated email or viewing training content. |
-| `TrainingModule`         | Groups related training content.                                                                         |
-| `TrainingDocument`       | Represents readable training material for UC-02.                                                         |
-| `TrainingProgress`       | Tracks learner progress through assigned training content.                                               |
-| `Quiz`                   | Represents an assessment linked to training content.                                                     |
-| `QuizQuestion`           | Represents a question inside a quiz.                                                                     |
-| `QuizAttempt`            | Represents a learner's attempt at completing a quiz.                                                     |
-| `AttemptAnswer`          | Represents an answer recorded as part of a quiz attempt.                                                 |
-| `QuizResult`             | Represents the result summary after a quiz attempt is submitted.                                         |
-| `FeedbackItem`           | Represents educational feedback shown after a quiz or simulation-related interaction.                    |
-| `ReportSummary`          | Future-facing reporting aggregation concept.                                                             |
-| `RiskIndicator`          | Future-facing risk indicator concept for reporting and dashboards.                                       |
+| Entity                   | Role in Demo 1                                                                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `User`                   | Represents the person using the platform. A user may act as an Administrator, company-linked Learner/Employee, or general Learner/Employee. |
+| `Organisation`           | Represents a company or organisation using the platform.                                                                                    |
+| `OrganisationMembership` | Links users to organisations and captures whether they act as Administrators or Learner/Employee users in that organisation.                |
+| `CompanyContext`         | Provides optional company-specific context used to support realistic simulations and training.                                              |
+| `Campaign`               | Groups simulations, learning paths, and assignments for company-linked training.                                                            |
+| `CampaignAssignment`     | Links Learner/Employee users or organisation members to a campaign.                                                                         |
+| `LearningPath`           | Groups training and quiz content. It may be company-context or general learning content.                                                    |
+| `Simulation`             | Represents a controlled simulated security-awareness scenario.                                                                              |
+| `SimulatedEmail`         | Represents a safe simulated email shown in the simulated inbox for UC-01.                                                                   |
+| `SimulatedInbox`         | Represents the Learner/Employee-facing inbox view for assigned simulated emails.                                                            |
+| `InteractionEvent`       | Records lightweight Learner/Employee interactions, such as opening a simulated email or viewing training content.                           |
+| `TrainingModule`         | Groups related training content.                                                                                                            |
+| `TrainingDocument`       | Represents readable training material for UC-02.                                                                                            |
+| `TrainingProgress`       | Tracks Learner/Employee progress through assigned training content.                                                                         |
+| `Quiz`                   | Represents an assessment linked to training content.                                                                                        |
+| `QuizQuestion`           | Represents a question inside a quiz.                                                                                                        |
+| `QuizAttempt`            | Represents a Learner/Employee's attempt at completing a quiz.                                                                               |
+| `AttemptAnswer`          | Represents an answer recorded as part of a quiz attempt.                                                                                    |
+| `QuizResult`             | Represents the result summary after a quiz attempt is submitted.                                                                            |
+| `FeedbackItem`           | Represents educational feedback shown after a quiz or simulation-related interaction.                                                       |
+| `ReportSummary`          | Future-facing reporting aggregation concept.                                                                                                |
+| `RiskIndicator`          | Future-facing risk indicator concept for reporting and dashboards.                                                                          |
 
 #### Support for UC-01: View Emails in Simulated Inbox
 
@@ -777,7 +826,7 @@ UC-01 is supported by:
 - `InteractionEvent`
 - optional `TrainingDocument` reference
 
-An employee is represented as a `User` connected to an organisation through `OrganisationMembership`. A campaign assignment can determine which simulated emails are available to the employee. The simulated inbox displays assigned `SimulatedEmail` summaries and allows the employee to open a selected email.
+A Learner/Employee is represented as a `User` connected to an organisation through `OrganisationMembership` when company context applies. A campaign assignment can determine which simulated emails are available to the Learner/Employee. The simulated inbox displays assigned `SimulatedEmail` summaries and allows the Learner/Employee to open a selected email.
 
 When an email is opened, the system may record an `InteractionEvent`, such as `EMAIL_OPENED`.
 
@@ -795,9 +844,9 @@ UC-02 is supported by:
 - `InteractionEvent`
 - optional `Quiz` reference
 
-A learner accesses training content through a learning path. A learning path contains training modules, and a training module contains one or more training documents. When a learner opens or views a training document, the system may update `TrainingProgress` or record a lightweight `InteractionEvent`.
+A Learner/Employee accesses training content through a learning path. A learning path contains training modules, and a training module contains one or more training documents. When a Learner/Employee opens or views a training document, the system may update `TrainingProgress` or record a lightweight `InteractionEvent`.
 
-If a quiz is linked to the training document, the learner may navigate to that quiz, but the quiz execution flow remains part of UC-03.
+If a quiz is linked to the training document, the Learner/Employee may navigate to that quiz, but the quiz execution flow remains part of UC-03.
 
 #### Support for UC-03: Complete Quiz Flow
 
@@ -811,7 +860,7 @@ UC-03 is supported by:
 - `QuizResult`
 - `FeedbackItem`
 
-When a learner starts a quiz, the system creates a `QuizAttempt`. The quiz contains one or more `QuizQuestion` records. The learner's submitted responses are represented as `AttemptAnswer` records. Once the attempt is submitted, the system can produce a `QuizResult` and related `FeedbackItem` records.
+When a Learner/Employee starts a quiz, the system creates a `QuizAttempt`. The quiz contains one or more `QuizQuestion` records. The Learner/Employee's submitted responses are represented as `AttemptAnswer` records. Once the attempt is submitted, the system can produce a `QuizResult` and related `FeedbackItem` records.
 
 This supports the Demo 1 quiz flow without requiring adaptive learning, advanced analytics, or a full reporting dashboard.
 

--- a/docs/demo1/diagrams/README.md
+++ b/docs/demo1/diagrams/README.md
@@ -4,38 +4,77 @@
 
 This folder stores or indexes diagram sources and exports for Demo 1 planning documentation.
 
-## Use Case Diagrams (Johan)
+## Use Case Diagrams
+
+Current draft source:
+
+- `use-case-overview-demo1.drawio`
+
+The use-case overview is draft material until the diagram issue is reviewed. It should show UC-01, UC-02, UC-03, base features, and supporting admin context without expanding the Demo 1 use case list.
 
 ### UC-01: View Emails in Simulated Inbox
 
+Learner/Employee core use case.
+
 ### UC-02: View Training Document
+
+Learner/Employee core use case.
 
 ### UC-03: Complete Quiz Flow
 
+Learner/Employee core use case.
+
 ### Base Features
+
+Login/register and general validation are supporting features, not standalone Demo 1 core use cases.
 
 ### Supporting Admin Context
 
+Administrator and campaign setup appear only as supporting context for assigning campaigns that expose simulations and learning paths.
+
 ## Domain Model Diagrams (Adriano)
+
+Current source/export:
+
+- `demo1-domain-model-(initial).drawio`
+- `demo1-domain-model-(initial).drawio.pdf`
 
 ### UML Class Diagram
 
+The domain model is preliminary and conceptual. It supports SRS, API, traceability, and terminology alignment; it is not a final database schema or Prisma migration plan.
+
 ### Domain Model Explanation Support
+
+Domain explanations are integrated in `docs/demo1/SRS.md` under Supporting Document References.
 
 ## Architecture Diagrams (Rudolph)
 
 ### High-Level Architecture
 
+Preliminary architecture guidance is documented in `docs/demo1/architecture.md`. Final architecture diagrams are not required here unless separately completed.
+
 ### Simulation Modularity
 
+Future-facing architecture context only unless the diagram issue finalises this diagram.
+
 ### Interaction and Progress Flow
+
+Future-facing architecture context only unless the diagram issue finalises this diagram.
 
 ## References
 
 ### SRS Reference
 
+`docs/demo1/SRS.md`
+
 ### Architecture Reference
+
+`docs/demo1/architecture.md`
 
 ### API Reference
 
+`docs/demo1/API.md`
+
 ### Traceability Reference
+
+`docs/demo1/traceability.md`

--- a/docs/demo1/testing.md
+++ b/docs/demo1/testing.md
@@ -10,23 +10,19 @@ The purpose of this plan is to align implementation work with what must be demon
 
 ### UC-01: View Emails in Simulated Inbox
 
-Covers the learner/employee viewing a simulated inbox, seeing simulated email summaries, opening a simulated email, and reviewing the email detail content.
+Covers the Learner/Employee viewing a simulated inbox, seeing simulated email summaries, opening a simulated email, and reviewing the email detail content.
 
 ### UC-02: View Training Document
 
-Covers the learner/employee opening training content, reading a training document, and navigating through the training material needed for Demo 1.
+Covers the Learner/Employee opening training content, reading a training document, and navigating through the training material needed for Demo 1.
 
 ### UC-03: Complete Quiz Flow
 
-Covers the learner/employee opening a quiz, answering questions, submitting the quiz, and viewing the submission/result state.
+Covers the Learner/Employee opening a quiz, answering questions, submitting the quiz, and viewing the submission/result state.
 
 ### Base Feature: Login/Register
 
-Covers the basic authentication screens needed to access the Demo 1 learner flow.
-
-### Base Feature: Themes
-
-Covers the agreed visual theme baseline and consistency across Demo 1 screens.
+Covers the basic authentication screens needed to access the Demo 1 Learner/Employee flow.
 
 ### Base Feature: General Form Validation
 
@@ -36,14 +32,14 @@ Covers common validation behaviour for login, registration, quiz submission, and
 
 ### Success Scenarios
 
-- The authenticated learner/employee can open the simulated inbox.
+- The authenticated Learner/Employee can open the simulated inbox.
 - The inbox displays a list of simulated email summaries.
 - Each simulated email summary shows key information such as sender, subject, preview text, and received date/time where available.
 - The user can select an email from the inbox list.
 - The selected email opens in a detail view.
 - The email detail view displays the simulated email content clearly.
 - The user can navigate back from the email detail view to the inbox.
-- The inbox and email detail screens use the agreed Demo 1 layout and theme styling.
+- The inbox and email detail screens use the agreed Demo 1 layout and visual styling.
 
 ### Negative and Error Scenarios
 
@@ -95,13 +91,13 @@ Before Demo 1, manually verify that:
 
 ### Success Scenarios
 
-- The authenticated learner/employee can open the training area.
+- The authenticated Learner/Employee can open the training area.
 - The system displays available Demo 1 training material.
 - The user can open a training document.
 - The training document displays a clear title and readable body content.
 - The user can navigate through or return from the training document as expected.
 - The user can continue from training material toward the quiz flow where applicable.
-- The training material screen uses the agreed Demo 1 layout and theme styling.
+- The training material screen uses the agreed Demo 1 layout and visual styling.
 
 ### Negative and Error Scenarios
 
@@ -143,20 +139,20 @@ Before Demo 1, manually verify that:
 - The training screen layout matches the documented design baseline.
 - Navigation into and out of the training document is clear.
 - The flow does not imply advanced adaptive learning, reporting, or gamified progression.
-- The training document supports the Demo 1 learner journey without expanding scope.
+- The training document supports the Demo 1 Learner/Employee journey without expanding scope.
 
 ## UC-03 Test Planning: Quiz Flow (Zoë)
 
 ### Success Scenarios
 
-- The authenticated learner/employee can open the quiz page.
+- The authenticated Learner/Employee can open the quiz page.
 - The quiz page displays questions and available answer options.
 - The user can select answers.
 - The user can submit the quiz once required answers are provided.
 - The system shows a clear submission/loading state where applicable.
 - The system displays quiz results or completion feedback.
 - The user can understand that the quiz flow has been completed.
-- The quiz flow uses the agreed Demo 1 layout and theme styling.
+- The quiz flow uses the agreed Demo 1 layout and visual styling.
 
 ### Negative and Error Scenarios
 
@@ -214,7 +210,7 @@ Before Demo 1, manually verify that:
 
 - A new user can register with valid information where registration is included in the Demo 1 flow.
 - An existing user can log in with valid credentials.
-- Successful login redirects the user to the appropriate Demo 1 learner area.
+- Successful login redirects the user to the appropriate Demo 1 Learner/Employee area.
 - Authenticated users can access the simulated inbox, training material, and quiz flow.
 - Authentication state is handled consistently during navigation.
 
@@ -247,7 +243,7 @@ Future automated tests should cover:
 - Successful login using seeded demo credentials.
 - Successful registration where applicable.
 - Rejecting invalid login/register requests.
-- Redirecting authenticated users to the Demo 1 learner area.
+- Redirecting authenticated users to the Demo 1 Learner/Employee area.
 - Blocking or redirecting unauthenticated users from protected Demo 1 screens.
 
 #### Manual Demo Verification Notes
@@ -259,52 +255,7 @@ Before Demo 1, manually verify that:
 - Register works only if it is part of the planned demo flow.
 - Authentication errors are understandable.
 - Auth screens follow the agreed visual design baseline.
-- Authentication does not block the main Demo 1 learner journey.
-
-### Themes
-
-#### Success Scenarios
-
-- Demo 1 screens use the agreed theme baseline.
-- Theme styling is consistent across login/register, dashboard, inbox, training, quiz, feedback, and result screens.
-- Text, buttons, cards, and form elements remain readable.
-- Theme behaviour does not interfere with navigation or form use.
-- The UI follows the agreed Demo 1 design and brand guidance.
-
-#### Negative and Error Scenarios
-
-- Theme styles fail to apply.
-- Colours are inconsistent with the agreed design baseline.
-- Text contrast is poor.
-- Theme state is not preserved where persistence is expected.
-- Theme changes cause layout issues.
-- A screen introduces a separate or conflicting colour palette.
-
-#### Suggested Test Levels
-
-- Unit tests for theme utilities or theme state where applicable.
-- Frontend tests for theme rendering and theme toggle behaviour where implemented.
-- Manual verification for visual consistency and readability.
-
-#### Suggested Automated Test Coverage
-
-Future automated tests should cover:
-
-- Rendering key Demo 1 screens with the default theme.
-- Verifying theme provider or theme wrapper renders child content correctly.
-- Verifying theme toggle or selection behaviour where implemented.
-- Verifying persisted theme behaviour where implemented.
-- Confirming major Demo 1 screens do not crash due to missing theme context.
-
-#### Manual Demo Verification Notes
-
-Before Demo 1, manually verify that:
-
-- Demo 1 screens follow the documented design baseline.
-- No screen introduces a new colour palette.
-- Text remains readable on the target demo display.
-- Buttons and forms are visually consistent.
-- Theme support remains a base feature and does not become a separate Demo 1 use case.
+- Authentication does not block the main Demo 1 Learner/Employee journey.
 
 ### General Form Validation
 
@@ -368,7 +319,6 @@ Examples:
 - Form validation helpers.
 - Quiz answer validation.
 - Quiz scoring helpers where applicable.
-- Theme state utilities where applicable.
 - Request/response mapping helpers where applicable.
 
 Unit tests should stay focused and should not duplicate full user flows.
@@ -400,7 +350,6 @@ Examples:
 - Quiz question rendering.
 - Form validation messages.
 - Loading, empty, error, and submission states.
-- Theme rendering across key screens.
 
 Frontend tests should support confidence that the user-visible Demo 1 flow behaves correctly.
 
@@ -424,7 +373,7 @@ End-to-end tests should cover only the most important Demo 1 paths.
 
 Suggested future E2E paths:
 
-- Login and access Demo 1 learner area.
+- Login and access Demo 1 Learner/Employee area.
 - Open simulated inbox and view simulated email detail.
 - Open training material and continue toward quiz.
 - Complete quiz and view result/completion feedback.
@@ -445,7 +394,6 @@ Suggested mapping:
 | UC-02: View Training Document         | `docs/demo1/SRS.md` UC-02 section         | `QA-UC02-01` to `QA-UC02-05`             |
 | UC-03: Complete Quiz Flow             | `docs/demo1/SRS.md` UC-03 section         | `QA-UC03-01` to `QA-UC03-05`             |
 | Login/Register                        | `docs/demo1/SRS.md` base features section | `QA-AUTH-01` to `QA-AUTH-05`             |
-| Themes                                | `docs/demo1/SRS.md` base features section | `QA-THEME-01` to `QA-THEME-04`           |
 | General Form Validation               | `docs/demo1/SRS.md` base features section | `QA-VALIDATION-01` to `QA-VALIDATION-05` |
 
 ### Traceability Rows
@@ -474,10 +422,6 @@ The following rows are placeholders for later integration with actual automated 
 | `QA-AUTH-03`       | Login/Register          | Login/register validation states                   | `apps/frontend/tests/base-auth`                  |
 | `QA-AUTH-04`       | Login/Register          | Authentication error handling                      | `apps/backend/tests/base-auth`                   |
 | `QA-AUTH-05`       | Login/Register          | Protected Demo 1 page access                       | `apps/frontend/tests/e2e/base-auth`              |
-| `QA-THEME-01`      | Themes                  | Default theme application                          | `apps/frontend/tests/base-themes`                |
-| `QA-THEME-02`      | Themes                  | Theme consistency across Demo 1 screens            | `apps/frontend/tests/base-themes`                |
-| `QA-THEME-03`      | Themes                  | Theme toggle or persistence where implemented      | `apps/frontend/tests/base-themes`                |
-| `QA-THEME-04`      | Themes                  | Manual readability and contrast check              | Manual demo verification                         |
 | `QA-VALIDATION-01` | General Form Validation | Required field validation                          | `apps/frontend/tests/base-form-validation`       |
 | `QA-VALIDATION-02` | General Form Validation | Invalid format validation                          | `apps/frontend/tests/base-form-validation`       |
 | `QA-VALIDATION-03` | General Form Validation | Quiz required-answer validation                    | `apps/frontend/tests/uc03-quiz-flow`             |

--- a/docs/demo1/traceability.md
+++ b/docs/demo1/traceability.md
@@ -8,38 +8,64 @@ This document links Demo 1 user stories, use cases, functional requirements, API
 
 ### UC-01: View Emails in Simulated Inbox
 
+Core Demo 1 Learner/Employee flow for viewing simulated inbox content determined by campaign assignment context.
+
 ### UC-02: View Training Document
+
+Core Demo 1 Learner/Employee flow for opening and reading assigned training material.
 
 ### UC-03: Complete Quiz Flow
 
+Core Demo 1 Learner/Employee flow for completing an assigned quiz and viewing results or feedback.
+
 ### Base Feature: Login/Register
 
-### Base Feature: Themes
+Supporting access feature for the Learner/Employee flows.
 
 ### Base Feature: General Form Validation
 
+Supporting validation and feedback behaviour for forms and quiz submission.
+
 ## Traceability Table
 
-| Area                     | User Story             | Use Case                | Functional Requirements  | API Contracts              | Domain Entities          | Design/Wireframes                         | QA/Test References               | Owner   | Status  |
-| ------------------------ | ---------------------- | ----------------------- | ------------------------ | -------------------------- | ------------------------ | ----------------------------------------- | -------------------------------- | ------- | ------- |
-| UC-01: Simulated Inbox   | US-UC01-01             | UC-01                   | FR-UC01-01 to FR-UC01-10 | API-UC01-01 to API-UC01-03 | DE-UC01-01 to DE-UC01-06 | DES-UC01-01 to DES-UC01-03                | QA-UC01-01 to QA-UC01-05         | Adriano | Draft   |
-| UC-02: Training Document | US-UC02-01             | UC-02                   | FR-UC02-01 to FR-UC02-10 | API-UC02-01 to API-UC02-03 | DE-UC02-01 to DE-UC02-05 | Pending                                   | Pending                          | Connor  | Draft   |
-| UC-03: Quiz Flow         | US-UC03-01             | UC-03                   | FR-UC03-01 to FR-UC03-10 | API-UC03-01 to API-UC03-04 | DE-UC03-01 to DE-UC03-07 | Pending - separate design/wireframe issue | Pending - separate testing issue | Zoë     | Draft   |
-| Admin Context            | US-ADM-01 to US-ADM-05 | Supporting context only | FR-ADM-01 to FR-ADM-10   | API-ADM-01 to API-ADM-06   | DE-ADM-01 to DE-ADM-03   | DES-ADM-01 (Placeholder)                  | QA-ADM-01 (Placeholder)          | Rudolph | Draft   |
-| Base: Login/Register     | Pending                | Base feature            | Pending                  | Pending                    | Pending                  | Pending                                   | Pending                          | Pending | Pending |
-| Base: Themes             | Pending                | Base feature            | Pending                  | Pending                    | Pending                  | Pending                                   | Pending                          | Pending | Pending |
-| Base: General Validation | Pending                | Base feature            | Pending                  | Pending                    | Pending                  | Pending                                   | Pending                          | Zoë     | Pending |
+| Area                     | User Story              | Use Case                | Functional Requirements   | API Contracts                             | Domain Entities                  | Design/Wireframes                                            | QA/Test References                       | Owner   | Status             |
+| ------------------------ | ----------------------- | ----------------------- | ------------------------- | ----------------------------------------- | -------------------------------- | ------------------------------------------------------------ | ---------------------------------------- | ------- | ------------------ |
+| UC-01: Simulated Inbox   | UC-01 user story in SRS | UC-01                   | FR-UC01-01 to FR-UC01-10  | API references in SRS/API                 | DE-UC01-01 to DE-UC01-06         | `DESIGN.md` Simulated Inbox and Email Detail sections        | QA-UC01-01 to QA-UC01-05                 | Adriano | Integrated draft   |
+| UC-02: Training Document | UC-02 user story in SRS | UC-02                   | FR-UC02-01 to FR-UC02-10  | API references in SRS/API                 | DE-UC02-01 to DE-UC02-05         | `DESIGN.md` Training Module List and Material sections       | QA-UC02-01 to QA-UC02-05                 | Connor  | Integrated draft   |
+| UC-03: Quiz Flow         | UC-03 user story in SRS | UC-03                   | FR-UC03-01 to FR-UC03-10  | API references in SRS/API                 | DE-UC03-01 to DE-UC03-07         | `DESIGN.md` Quiz Page, Submission, and Results sections      | QA-UC03-01 to QA-UC03-05                 | Zoë     | Integrated draft   |
+| Admin Context            | US-ADM-01 to US-ADM-05  | Supporting context only | FR-ADM-01 to FR-ADM-10    | Admin API placeholders                    | DE-ADM-01 to DE-ADM-03           | Supporting admin context only; no stable design ID           | Supporting/future QA placeholder only    | Rudolph | Supporting context |
+| Base: Login/Register     | Base feature only       | Base feature            | SRS Base Features section | `POST /auth/register`, `POST /auth/login` | Domain model User/access context | `DESIGN.md` Register and Login sections                      | QA-AUTH references in `testing.md`       | Shared  | Supporting context |
+| Base: General Validation | Base feature only       | Base feature            | SRS validation sections   | General validation/error-response notes   | Not domain-specific              | `DESIGN.md` Feedback, Validation, and Accessibility UI Rules | QA-VALIDATION references in `testing.md` | Zoë     | Supporting context |
 
 ## Integration Notes (Johan)
 
 ### SRS References
 
+- `docs/demo1/SRS.md` is the primary integrated requirements source for UC-01, UC-02, UC-03, base features, and supporting admin/campaign context.
+- SRS traceability rows should not reference design IDs unless those IDs are explicitly defined in the design document.
+
 ### API References
+
+- `docs/demo1/API.md` contains preliminary API contracts only.
+- API references should be treated as planning placeholders, not final route or schema commitments.
 
 ### Domain References
 
+- `docs/demo1/diagrams/demo1-domain-model-(initial).drawio` is the current domain model source file.
+- Domain references are conceptual and should not be treated as final database schema or Prisma model names.
+
 ### Design and Wireframe References
+
+- `docs/demo1/DESIGN.md` contains the current design and wireframe notes.
+- `docs/demo1/wireframes/` indexes first-pass wireframe coverage.
+- Use section references where stable design IDs do not exist.
 
 ### Testing References
 
+- `docs/demo1/testing.md` contains QA planning and future test placeholders for UC-01, UC-02, UC-03, and base features.
+
 ### Missing Reference Owners
+
+- Final diagram ownership remains separate until the diagram issue is ready.
+- Final API route/schema ownership remains with the API contract owner.
+- Final implementation tests remain future work unless explicitly added under the testing issue.

--- a/docs/demo1/traceability.md
+++ b/docs/demo1/traceability.md
@@ -63,9 +63,3 @@ Supporting validation and feedback behaviour for forms and quiz submission.
 ### Testing References
 
 - `docs/demo1/testing.md` contains QA planning and future test placeholders for UC-01, UC-02, UC-03, and base features.
-
-### Missing Reference Owners
-
-- Final diagram ownership remains separate until the diagram issue is ready.
-- Final API route/schema ownership remains with the API contract owner.
-- Final implementation tests remain future work unless explicitly added under the testing issue.


### PR DESCRIPTION
## Summary

This PR integrates the Demo 1 SRS feature slices into a more consistent documentation set.

The main focus was documentation alignment, not adding new feature scope or taking ownership of unfinished API, architecture, or diagram work.

### Main changes

- Integrated UC-01, UC-02, and UC-03 in `docs/demo1/SRS.md`.
- Standardised the structure of the three core use cases.
- Standardised actor wording to `Learner/Employee` across Demo 1 docs.
- Kept Login/Register and General Form Validation as supporting base features, separate from the three core Demo 1 use cases.
- Removed `Priority` columns from SRS requirement tables.
- Corrected the UC-02 domain reference from `TrainingAssignment` to `LearningPath`.
- Updated related wording in:
  - `docs/demo1/DESIGN.md`
  - `docs/demo1/traceability.md`
  - `docs/demo1/testing.md`
  - `docs/demo1/diagrams/README.md`

## Linked Issue

Relates to 22 but does not close it.

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Chore/Maintenanc

## Known Follow-up Work

Outside this PR:

- `docs/demo1/API.md` still needs API-owner alignment.
- `docs/demo1/architecture.md` is still WIP and needs final terminology/scope alignment.
- Final use case diagrams are not completed in this PR.
- Admin/campaign flows remain supporting/future-facing and need owner review before being treated as implementation scope.
- Final implementation tests are still future work; current testing references remain planning placeholders.

## Checklist

- [ ] I tested the change locally
- [x] No unrelated changes are included
- [ ] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed