### PR TITLE
chore: policy updates

### DIFF
--- a/.github/workflows/burndown.yml
+++ b/.github/workflows/burndown.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Wait for linked issue to be closed
+        run: sleep 30
+
       - name: Generate Burndown charts
         run: python scripts/generate-burndown.py
 

--- a/.github/workflows/burndown.yml
+++ b/.github/workflows/burndown.yml
@@ -1,16 +1,19 @@
 name: Burndown Charts
 
 on:
+  push:
+    branches:
+      - dev
   schedule:
-    - cron: '0 22 * * *' # Runs at midnight SAST
+    - cron: '0 23 * * *' # Runs at 1AM SAST
   workflow_dispatch:
-
-permissions:
-  contents: write
 
 jobs:
   generate:
+    name: Generate Burndown Charts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 5
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/insightful_phish_test?schema=public
 
     steps:
       - name: Checkout repository
@@ -108,6 +110,8 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/insightful_phish_test?schema=public
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Continuous Integration
 
 on:
   pull_request:
@@ -13,17 +13,41 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-test:
-    name: Build and test
+  formatting-check:
+    name: Formatting Check
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
       contents: read
-    env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/insightful_phish_test?schema=public
+    timeout-minutes: 10
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run formatting check
+        run: pnpm format:check
+
+  lint-and-typecheck:
+    name: Lint and Typecheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Enable Corepack
@@ -39,19 +63,70 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm --filter backend exec prisma generate
+        run: pnpm --filter @insightful-phish/backend exec prisma generate
 
-      - name: Format check
-        run: pnpm format:check
-
-      - name: Lint
+      - name: Run linting
         run: pnpm lint
 
-      - name: Typecheck
+      - name: Run typecheck
         run: pnpm typecheck
 
-      - name: Test
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/insightful_phish_test?schema=public
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @insightful-phish/backend exec prisma generate
+
+      - name: Run tests
         run: pnpm test
 
-      - name: Build
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @insightful-phish/backend exec prisma generate
+
+      - name: Build project
         run: pnpm build

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -14,7 +14,7 @@ name: Policy
 
 jobs:
   env-files:
-    name: Env files
+    name: Check for ENV files
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:


### PR DESCRIPTION
## Summary

Updated the GitHub Actions workflows to make CI feedback clearer and keep burndown charts up to date automatically.

Changes included:

- Added a `push` trigger for the `dev` branch to the burndown workflow: Once a PR is merged into `dev`, the burndown charts will regenerate automatically to be up to date. Burndown charts also regenerate each day at 1AM too.
- Split CI into clearer separate checks:
  - `Formatting Check`
  - `Lint and Typecheck`
  - `Tests`
  - `Build`
- Added `pnpm format:check` as a dedicated formatting validation check.
- Confirmed tests run through `pnpm test`.
- Added explicit job-level permissions and timeouts to workflow jobs.
- Updated Prisma generation steps to use the correct backend workspace filter.

PR failure comments by Gitbub Actions were not added because they were optional in the issue and would require additional workflow permissions plus anti-spam handling.

## Linked Issue

Closes #59

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Chore/Maintenance

## Review Notes

PRs might fail until required actions are updated in github repo settings.

## Checklist

- [x] I tested the change locally
- [x] No unrelated changes are included
- [ ] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed