### PR TITLE
docs: align domain api terminology

### DIFF
--- a/docs/demo1/API.md
+++ b/docs/demo1/API.md
@@ -4,6 +4,30 @@
 
 This document collects preliminary API contracts for Sprint 1 Demo 1. Contracts support frontend/backend alignment, SRS use cases, domain terminology, and testing preparation. They provide enough detail to unblock frontend mock development and backend routing without requiring final OpenAPI/Swagger specifications at this stage.
 
+## API and Domain Terminology Alignment
+
+These API contracts use preliminary route names and payload shapes to support planning and frontend/backend alignment. They are not final OpenAPI specifications.
+
+The following terminology should remain aligned with the SRS and domain model:
+
+| API Term / Route Area                       | Aligned Domain Concept                                                   | Related SRS Area                  |
+| ------------------------------------------- | ------------------------------------------------------------------------ | --------------------------------- |
+| `/simulations/inbox`                        | `SimulatedInbox`                                                         | UC-01 simulated inbox             |
+| `/simulations/emails/:emailId`              | `SimulatedEmail`                                                         | UC-01 simulated email detail      |
+| `/simulations/emails/:emailId/interactions` | `InteractionEvent`                                                       | UC-01 simulated email tracking    |
+| `/training/assigned`                        | `LearningPath`, `TrainingModule`, `TrainingDocument`, `TrainingProgress` | UC-02 training document viewing   |
+| `/training/:trainingId`                     | `TrainingDocument`                                                       | UC-02 selected training document  |
+| `/training/:trainingId/progress`            | `TrainingProgress`, `InteractionEvent`                                   | UC-02 training progress           |
+| `/quizzes/:quizId`                          | `Quiz`, `QuizQuestion`                                                   | UC-03 quiz content                |
+| `/quizzes/:quizId/attempts`                 | `QuizAttempt`                                                            | UC-03 quiz attempt creation       |
+| `/quiz-attempts/:attemptId/submit`          | `QuizAttempt`, `AttemptAnswer`                                           | UC-03 quiz submission             |
+| `/quiz-attempts/:attemptId/results`         | `QuizResult`, `FeedbackItem`                                             | UC-03 results and feedback        |
+| `/campaigns`                                | `Campaign`                                                               | Supporting admin/campaign context |
+| `/campaigns/:campaignId/assign`             | `CampaignAssignment`, `User`                                             | Supporting admin/campaign context |
+| Future reporting placeholder                | `ReportSummary`, `RiskIndicator`                                         | Future reporting support          |
+
+Where the API uses practical route names such as `trainingId` or `emailId`, these are preliminary identifiers for the related conceptual domain entities. Final backend route naming, payload fields, and database schema names may change during implementation.
+
 ## Base Feature Contracts
 
 ### `POST /auth/register`
@@ -274,7 +298,7 @@ This document collects preliminary API contracts for Sprint 1 Demo 1. Contracts 
 
 ## Cross-Use-Case Tracking, Progress, and Reporting Support
 
-The following table summaries the preliminary API contracts that support lightweight interaction tracking, progress tracking, quiz attempts, quiz results, and future reporting alignment for Demo 1.
+The following table summarises the preliminary API contracts that support lightweight interaction tracking, progress tracking, quiz attempts, quiz results, and future reporting alignment for Demo 1.
 
 These references do not introduce final analytics dashboards, final risk scoring, production reporting schemas, or database implementation details.
 
@@ -335,11 +359,12 @@ These references do not introduce final analytics dashboards, final risk scoring
 
 ### `POST /campaigns/:campaignId/assign`
 
-- **Purpose**: Links a list of employees to the campaign for training delivery.
+- **Purpose**: Links one or more users to a campaign for training delivery. Organisation-based assignments may target company-linked employees, while premade/general campaigns may target GeneralLearner users.
 - **Related Use Case / Base Feature**: Admin Context (Supporting Context)
 - **Method & Route**: `POST /campaigns/:campaignId/assign`
 - **Expected Request Data**:
-  - `employeeIds` (array of strings, required)
+  - `userIds` (array of strings, required)
+  - `membershipIds` (array of strings, optional; used only where organisation membership context applies)
 - **Expected Response Data**:
   - `200 OK`: `{ "success": true, "assignedCount": 2 }`
 - **Common Error Responses**:

--- a/docs/demo1/SRS.md
+++ b/docs/demo1/SRS.md
@@ -103,6 +103,26 @@ Primary supporting documents:
 - `docs/demo1/traceability.md` for integration placeholders and review traceability.
 - `docs/demo1/diagrams/` for draft diagram sources and exports.
 
+### Terminology Alignment Rules
+
+The SRS, preliminary API contracts, traceability table, and domain model should use consistent terminology for Demo 1 concepts.
+
+For Demo 1 documentation:
+
+- `User` is the domain model entity representing a platform account.
+- `Learner/Employee` is the SRS actor label used for the learner-facing Demo 1 flows.
+- `Employee` and `GeneralLearner` are user types represented by `User.userType` in the domain model.
+- `Administrator` or `Admin` is a supporting user type for campaign/content setup context.
+- `CampaignAssignment` links a `Campaign` to a `User`; for organisation-based campaigns it may also reference `OrganisationMembership`.
+- `SimulatedEmail` is the domain entity used for controlled simulated email content.
+- `TrainingDocument` is the readable training content opened in UC-02.
+- `TrainingModule` groups related training content.
+- `LearningPath` groups training modules and quiz content for either organisation-context or general learning flows.
+- `InteractionEvent`, `TrainingProgress`, `QuizAttempt`, `QuizResult`, and `FeedbackItem` are the main tracking/progress entities used across UC-01, UC-02, and UC-03.
+- `ReportSummary` and `RiskIndicator` are future-facing reporting support concepts and should not be treated as final analytics or risk-scoring implementation details.
+
+API routes and payloads remain preliminary placeholders. Domain entity names are conceptual and should not be treated as final Prisma model names, database table names, or final backend implementation details.
+
 ## UC-01: Simulated Inbox Requirements
 
 [UC-01 use case diagram](./diagrams/demo1-use-cases-uc01-simulated-inbox.svg)
@@ -928,32 +948,53 @@ General Learner/Employee users are not required to belong to an organisation. Th
 
 #### Core Entity Summary
 
-| Entity                   | Role in Demo 1                                                                                                                              |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `User`                   | Represents the person using the platform. A user may act as an Administrator, company-linked Learner/Employee, or general Learner/Employee. |
-| `Organisation`           | Represents a company or organisation using the platform.                                                                                    |
-| `OrganisationMembership` | Links users to organisations and captures whether they act as Administrators or Learner/Employee users in that organisation.                |
-| `CompanyContext`         | Provides optional company-specific context used to support realistic simulations and training.                                              |
-| `Campaign`               | Groups simulations, learning paths, and assignments for company-linked training.                                                            |
-| `CampaignAssignment`     | Links Learner/Employee users or organisation members to a campaign.                                                                         |
-| `LearningPath`           | Groups training and quiz content. It may be company-context or general learning content.                                                    |
-| `Simulation`             | Represents a controlled simulated security-awareness scenario.                                                                              |
-| `SimulatedEmail`         | Represents a safe simulated email shown in the simulated inbox for UC-01.                                                                   |
-| `SimulatedInbox`         | Represents the Learner/Employee-facing inbox view for assigned simulated emails.                                                            |
-| `InteractionEvent`       | Records lightweight Learner/Employee interactions, such as opening a simulated email or viewing training content.                           |
-| `TrainingModule`         | Groups related training content.                                                                                                            |
-| `TrainingDocument`       | Represents readable training material for UC-02.                                                                                            |
-| `TrainingProgress`       | Tracks Learner/Employee progress through assigned training content.                                                                         |
-| `Quiz`                   | Represents an assessment linked to training content.                                                                                        |
-| `QuizQuestion`           | Represents a question inside a quiz.                                                                                                        |
-| `QuizAttempt`            | Represents a Learner/Employee's attempt at completing a quiz.                                                                               |
-| `AttemptAnswer`          | Represents an answer recorded as part of a quiz attempt.                                                                                    |
-| `QuizResult`             | Represents the result summary after a quiz attempt is submitted.                                                                            |
-| `FeedbackItem`           | Represents educational feedback shown after a quiz or simulation-related interaction.                                                       |
-| `ReportSummary`          | Future-facing reporting aggregation concept.                                                                                                |
-| `RiskIndicator`          | Future-facing risk indicator concept for reporting and dashboards.                                                                          |
+| Entity                   | Role in Demo 1                                                                                                                                                                     |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| `User`                   | Represents the person using the platform. A user may act as an Administrator, company-linked Learner/Employee, or general Learner/Employee.                                        |
+| `Organisation`           | Represents a company or organisation using the platform.                                                                                                                           |
+| `OrganisationMembership` | Links users to organisations and captures whether they act as Administrators or Learner/Employee users in that organisation.                                                       |
+| `CompanyContext`         | Provides optional company-specific context used to support realistic simulations and training.                                                                                     |
+| `Campaign`               | Groups simulations, learning paths, quizzes, and assignments. A campaign may be organisation-assigned or premade/general.                                                          |
+| `CampaignAssignment`     | Links a `Campaign` to a `User`. For organisation-based campaigns it may also reference `OrganisationMembership`; for general learners it does not require organisation membership. | `LearningPath` | Groups training and quiz content. It may be company-context or general learning content. |
+| `Simulation`             | Represents a controlled simulated security-awareness scenario.                                                                                                                     |
+| `SimulatedEmail`         | Represents a safe simulated email shown in the simulated inbox for UC-01.                                                                                                          |
+| `SimulatedInbox`         | Represents the Learner/Employee-facing inbox view for assigned simulated emails.                                                                                                   |
+| `InteractionEvent`       | Records lightweight Learner/Employee interactions, such as opening a simulated email or viewing training content.                                                                  |
+| `TrainingModule`         | Groups related training content.                                                                                                                                                   |
+| `TrainingDocument`       | Represents readable training material for UC-02.                                                                                                                                   |
+| `TrainingProgress`       | Tracks Learner/Employee progress through assigned training content.                                                                                                                |
+| `Quiz`                   | Represents an assessment linked to training content.                                                                                                                               |
+| `QuizQuestion`           | Represents a question inside a quiz.                                                                                                                                               |
+| `QuizAttempt`            | Represents a Learner/Employee's attempt at completing a quiz.                                                                                                                      |
+| `AttemptAnswer`          | Represents an answer recorded as part of a quiz attempt.                                                                                                                           |
+| `QuizResult`             | Represents the result summary after a quiz attempt is submitted.                                                                                                                   |
+| `FeedbackItem`           | Represents educational feedback shown after a quiz or simulation-related interaction.                                                                                              |
+| `ReportSummary`          | Future-facing reporting aggregation concept.                                                                                                                                       |
+| `RiskIndicator`          | Future-facing risk indicator concept for reporting and dashboards.                                                                                                                 |
 
-#### Support for UC-01: View Emails in Simulated Inbox
+#### Domain, SRS, and API Alignment Notes
+
+The domain model, SRS feature slices, preliminary API contracts, and traceability table use the following aligned terminology:
+
+| Concept             | Domain Model Name                | SRS Reference                           | Preliminary API Reference                                                               | Notes                                                                                     |
+| ------------------- | -------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Platform account    | `User`                           | Learner/Employee, Admin, GeneralLearner | Auth context / `userId` fields                                                          | `Learner/Employee` is the SRS actor label; `User` is the domain entity.                   |
+| Campaign wrapper    | `Campaign`                       | Admin/Campaign Supporting Context       | `POST /campaigns`                                                                       | Supporting context only for Demo 1; not a full scheduling implementation.                 |
+| Campaign assignment | `CampaignAssignment`             | Campaign assignment context             | `POST /campaigns/:campaignId/assign`                                                    | Links campaigns to users; organisation membership is optional depending on campaign type. |
+| Simulated inbox     | `SimulatedInbox`                 | UC-01 simulated inbox                   | `GET /simulations/inbox`                                                                | Represents the learner-facing controlled inbox view.                                      |
+| Simulated email     | `SimulatedEmail`                 | UC-01 simulated email                   | `GET /simulations/emails/:emailId`                                                      | Represents controlled simulated email content, not a real mailbox email.                  |
+| Interaction event   | `InteractionEvent`               | UC-01/UC-02 tracking                    | `POST /simulations/emails/:emailId/interactions`; `POST /training/:trainingId/progress` | Records lightweight learner actions without sensitive credential storage.                 |
+| Training content    | `TrainingDocument`               | UC-02 training document                 | `GET /training/:trainingId`                                                             | Represents readable training content.                                                     |
+| Training grouping   | `TrainingModule`, `LearningPath` | UC-02 training module/list context      | `GET /training/assigned`                                                                | `LearningPath` groups training/quiz content; `TrainingModule` groups documents.           |
+| Training progress   | `TrainingProgress`               | UC-02 progress tracking                 | `POST /training/:trainingId/progress`                                                   | Tracks high-level progress only.                                                          |
+| Quiz                | `Quiz`                           | UC-03 quiz flow                         | `GET /quizzes/:quizId`                                                                  | Represents an assessment linked to training content.                                      |
+| Quiz question       | `QuizQuestion`                   | UC-03 quiz questions                    | Included in `GET /quizzes/:quizId` response                                             | Represents individual quiz questions.                                                     |
+| Quiz attempt        | `QuizAttempt`                    | UC-03 attempt                           | `POST /quizzes/:quizId/attempts`                                                        | Created when a learner starts a quiz.                                                     |
+| Attempt answer      | `AttemptAnswer`                  | UC-03 submitted answers                 | `POST /quiz-attempts/:attemptId/submit`                                                 | Represents answers submitted for a quiz attempt.                                          |
+| Quiz result         | `QuizResult`                     | UC-03 result summary                    | `GET /quiz-attempts/:attemptId/results`                                                 | Represents a submitted attempt result.                                                    |
+| Feedback            | `FeedbackItem`                   | UC-03 educational feedback              | `GET /quiz-attempts/:attemptId/results`                                                 | Represents learner-facing feedback.                                                       |
+| Reporting summary   | `ReportSummary`                  | Future reporting support                | Future reporting placeholder                                                            | Future-facing only.                                                                       |
+| Risk indicator      | `RiskIndicator`                  | Future risk support                     | Future reporting placeholder                                                            | No final risk scoring formula is defined for Demo 1.                                      |
 
 UC-01 is supported by:
 

--- a/docs/demo1/traceability.md
+++ b/docs/demo1/traceability.md
@@ -63,6 +63,36 @@ This section links lightweight Demo 1 tracking and progress requirements to the 
 - No new UI screen is required for this tracking/progress issue.
 - No change is required to the current domain model diagram for this issue.
 
+## Domain, SRS, and API Alignment Review
+
+This section records the Demo 1 alignment pass between the SRS feature slices, preliminary API contracts, traceability references, and domain model terminology.
+
+| Alignment Area           | SRS Term                            | API Reference                                         | Domain Model Term                                    | Status  | Notes                                                                                            |
+| ------------------------ | ----------------------------------- | ----------------------------------------------------- | ---------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| Learner-facing account   | Learner/Employee                    | Auth context / `userId`                               | `User`                                               | Aligned | `Learner/Employee` is the SRS actor label; `User` is the conceptual domain entity.               |
+| User types               | Admin, Employee, GeneralLearner     | Auth/user context                                     | `User.userType`                                      | Aligned | User type naming remains conceptual and not a final role implementation.                         |
+| Campaign wrapper         | Campaign                            | `POST /campaigns`                                     | `Campaign`                                           | Aligned | Supporting context only for Demo 1.                                                              |
+| Campaign assignment      | Campaign assignment context         | `POST /campaigns/:campaignId/assign`                  | `CampaignAssignment`                                 | Aligned | Assignment links a `Campaign` to a `User`; organisation membership is optional where applicable. |
+| Simulated inbox          | Simulated inbox                     | `GET /simulations/inbox`                              | `SimulatedInbox`                                     | Aligned | Represents controlled platform inbox content only.                                               |
+| Simulated email          | Simulated email                     | `GET /simulations/emails/:emailId`                    | `SimulatedEmail`                                     | Aligned | Does not represent real mailbox email delivery.                                                  |
+| Simulated email tracking | Email opened/viewed interaction     | `POST /simulations/emails/:emailId/interactions`      | `InteractionEvent`                                   | Aligned | Used for lightweight UC-01 interaction tracking.                                                 |
+| Training list/content    | Training document / training module | `GET /training/assigned`, `GET /training/:trainingId` | `LearningPath`, `TrainingModule`, `TrainingDocument` | Aligned | `LearningPath` and `TrainingModule` group content; `TrainingDocument` is the readable item.      |
+| Training progress        | Training progress                   | `POST /training/:trainingId/progress`                 | `TrainingProgress`, `InteractionEvent`               | Aligned | Records high-level progress only.                                                                |
+| Quiz content             | Quiz                                | `GET /quizzes/:quizId`                                | `Quiz`, `QuizQuestion`                               | Aligned | Supports UC-03 quiz display.                                                                     |
+| Quiz attempt             | Quiz attempt                        | `POST /quizzes/:quizId/attempts`                      | `QuizAttempt`                                        | Aligned | Created when quiz starts.                                                                        |
+| Quiz submission          | Submitted quiz attempt              | `POST /quiz-attempts/:attemptId/submit`               | `QuizAttempt`, `AttemptAnswer`                       | Aligned | Records final answers and submitted state.                                                       |
+| Quiz results/feedback    | Quiz results and feedback           | `GET /quiz-attempts/:attemptId/results`               | `QuizResult`, `FeedbackItem`                         | Aligned | Supports result summary and educational feedback.                                                |
+| Future reporting         | Reporting support                   | Future reporting placeholder                          | `ReportSummary`                                      | Aligned | Future-facing only; no dashboard implementation.                                                 |
+| Future risk              | Risk support                        | Future reporting placeholder                          | `RiskIndicator`                                      | Aligned | Future-facing only; no final risk scoring formula.                                               |
+
+### Alignment Scope Notes
+
+- This alignment pass does not introduce new Demo 1 use cases.
+- API contracts remain preliminary placeholders and should not be treated as final backend implementation details.
+- Domain model entities remain conceptual and should not be treated as final database tables or Prisma models.
+- Reporting and risk terminology remains future-facing and should not expand the Demo 1 scope.
+- The current domain model diagram already contains the main entities needed for UC-01, UC-02, UC-03, tracking/progress, and future reporting support.
+
 ## Integration Notes (Johan)
 
 ### SRS References


### PR DESCRIPTION
## Summary

Reviewed and aligned the Demo 1 domain model terminology with the SRS feature slices, preliminary API contracts, and traceability references.

This PR adds alignment notes to make entity names, API resource naming, requirement references, and traceability terminology more consistent across UC-01, UC-02, UC-03, and tracking/progress support.

Main alignment areas covered:

- `User`, `Learner/Employee`, `Employee`, `GeneralLearner`, and `Admin` terminology
- `Campaign` and `CampaignAssignment` usage
- UC-01 simulated inbox and simulated email terminology
- UC-02 training document, training module, learning path, and progress terminology
- UC-03 quiz, quiz question, quiz attempt, attempt answer, quiz result, and feedback terminology
- Tracking/progress entities such as `InteractionEvent`, `TrainingProgress`, and `QuizAttempt`
- Future-facing reporting/risk concepts such as `ReportSummary` and `RiskIndicator`

The changes clarify that API contracts are preliminary placeholders and that domain model entities are conceptual, not final Prisma models or database schema definitions.

## Linked Issue

Closes #11

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Chore/Maintenance

## Testing

Documentation-only change.

Verified locally:

- Reviewed the SRS terminology alignment notes.
- Reviewed API/domain terminology mapping.
- Reviewed traceability alignment table for consistency with UC-01, UC-02, UC-03, and tracking/progress requirements.
- Confirmed the work does not introduce implementation details, database migrations, Prisma models, or final backend route commitments.
- Confirmed reporting and risk concepts remain future-facing.
- Confirmed no secrets, credentials, or sensitive values were included.

## Review Notes

Please focus on:

- Whether terminology is consistent across `SRS.md`, `API.md`, `traceability.md`, and the existing domain model.
- Whether `Learner/Employee` is clearly distinguished from the domain entity `User`.
- Whether `CampaignAssignment` is described correctly as linking a `Campaign` to a `User`, with organisation membership only applying where relevant.
- Whether API route names are clearly marked as preliminary placeholders.
- Whether reporting and risk concepts remain future-facing and do not expand Demo 1 scope.

Files to review:

- `docs/demo1/SRS.md`
- `docs/demo1/API.md`
- `docs/demo1/traceability.md`

No diagram changes were required because the current domain model already contains the main entities needed for UC-01, UC-02, UC-03, tracking/progress, and future reporting support.

## Checklist

- [x] I tested the change locally
- [x] No unrelated changes are included
- [ ] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed