### PR TITLE
Feature/training api/adri4no098

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -6,6 +6,7 @@ import { env } from './config/env.js';
 import { swaggerSpec } from './config/swagger.js';
 import { healthRoutes } from './routes/health.routes.js';
 import { authRouter } from './routes/auth.routes.js';
+import { trainingRouter } from './routes/training.routes.js';
 
 export function createApp() {
   const app = express();
@@ -28,6 +29,7 @@ export function createApp() {
 
   app.use(healthRoutes);
   app.use(authRouter);
+  app.use(trainingRouter);
 
   // Preliminary Demo 1 API Route Placeholders (To be implemented)
   // Base Features
@@ -35,9 +37,6 @@ export function createApp() {
 
   // UC-01: Simulated Inbox
   // app.use('/simulations', simulationRoutes); // GET /simulations/inbox, GET /simulations/emails/:id, POST /simulations/emails/:id/interactions
-
-  // UC-02: Training Document
-  // app.use('/training', trainingRoutes); // GET /training/assigned, GET /training/:id, POST /training/:id/progress
 
   // UC-03: Quiz Flow
   // app.use('/quizzes', quizRoutes); // GET /quizzes/:id, POST /quizzes/:id/attempts

--- a/apps/backend/src/controllers/training.controller.ts
+++ b/apps/backend/src/controllers/training.controller.ts
@@ -1,0 +1,75 @@
+import type { Request, Response } from 'express';
+import {
+  getAssignedTraining,
+  getTrainingDocument,
+  recordTrainingProgress,
+  TrainingDocumentNotFoundError,
+} from '../services/training.service.js';
+
+function getAuthenticatedUserId(req: Request, res: Response) {
+  if (!req.auth) {
+    res.status(401).json({
+      error: 'AUTH_REQUIRED',
+      message: 'Authentication credentials are required',
+    });
+
+    return null;
+  }
+
+  return req.auth.userId;
+}
+
+export async function getAssignedTrainingDocuments(req: Request, res: Response) {
+  const userId = getAuthenticatedUserId(req, res);
+
+  if (!userId) {
+    return;
+  }
+
+  const response = await getAssignedTraining(userId);
+  res.status(200).json(response);
+}
+
+export async function getTrainingDocumentDetail(req: Request, res: Response) {
+  const userId = getAuthenticatedUserId(req, res);
+
+  if (!userId) {
+    return;
+  }
+
+  try {
+    const response = await getTrainingDocument(userId, String(req.params.trainingId));
+    return res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof TrainingDocumentNotFoundError) {
+      return res.status(404).json({
+        error: 'TRAINING_DOCUMENT_NOT_FOUND',
+        message: error.message,
+      });
+    }
+
+    throw error;
+  }
+}
+
+export async function postTrainingProgress(req: Request, res: Response) {
+  const userId = getAuthenticatedUserId(req, res);
+
+  if (!userId) {
+    return;
+  }
+
+  try {
+    const response = await recordTrainingProgress(userId, String(req.params.trainingId), req.body);
+    return res.status(200).json(response);
+  } catch (error) {
+    if (error instanceof TrainingDocumentNotFoundError) {
+      return res.status(404).json({
+        error: 'TRAINING_DOCUMENT_NOT_FOUND',
+        message: error.message,
+      });
+    }
+
+    throw error;
+  }
+}

--- a/apps/backend/src/mappers/training.mapper.ts
+++ b/apps/backend/src/mappers/training.mapper.ts
@@ -1,5 +1,6 @@
 import type {
   GetTrainingDocumentResponseDto,
+  TrainingProgressResultDto,
   TrainingDocumentSummaryDto,
   TrainingProgressStatusDto,
 } from '@insightful-phish/shared';
@@ -27,6 +28,15 @@ interface TrainingDocumentDetailRecord {
   }>;
 }
 
+interface TrainingProgressResultRecord {
+  id: string;
+  trainingDocumentId: string;
+  campaignAssignmentId: string | null;
+  status: TrainingProgressStatusDto;
+  startedAt: Date | null;
+  completedAt: Date | null;
+}
+
 export function toTrainingDocumentSummaryDto(
   document: TrainingDocumentSummaryRecord,
 ): TrainingDocumentSummaryDto {
@@ -49,5 +59,18 @@ export function toGetTrainingDocumentResponseDto(
     contentType: document.contentType,
     contentRef: document.contentRef,
     ...(linkedQuizIds.length > 0 ? { linkedQuizIds } : {}),
+  };
+}
+
+export function toTrainingProgressResultDto(
+  progress: TrainingProgressResultRecord,
+): TrainingProgressResultDto {
+  return {
+    id: progress.id,
+    trainingDocumentId: progress.trainingDocumentId,
+    campaignAssignmentId: progress.campaignAssignmentId,
+    status: progress.status,
+    startedAt: progress.startedAt?.toISOString() ?? null,
+    completedAt: progress.completedAt?.toISOString() ?? null,
   };
 }

--- a/apps/backend/src/mappers/training.mapper.ts
+++ b/apps/backend/src/mappers/training.mapper.ts
@@ -1,0 +1,53 @@
+import type {
+  GetTrainingDocumentResponseDto,
+  TrainingDocumentSummaryDto,
+  TrainingProgressStatusDto,
+} from '@insightful-phish/shared';
+
+interface TrainingProgressSummaryRecord {
+  status: TrainingProgressStatusDto;
+}
+
+interface TrainingDocumentSummaryRecord {
+  id: string;
+  title: string;
+  trainingProgress: TrainingProgressSummaryRecord[];
+  module: {
+    description: string | null;
+  };
+}
+
+interface TrainingDocumentDetailRecord {
+  id: string;
+  title: string;
+  contentType: GetTrainingDocumentResponseDto['contentType'];
+  contentRef: string;
+  quizzes: Array<{
+    id: string;
+  }>;
+}
+
+export function toTrainingDocumentSummaryDto(
+  document: TrainingDocumentSummaryRecord,
+): TrainingDocumentSummaryDto {
+  return {
+    id: document.id,
+    title: document.title,
+    description: document.module.description ?? '',
+    status: document.trainingProgress[0]?.status ?? 'NOT_STARTED',
+  };
+}
+
+export function toGetTrainingDocumentResponseDto(
+  document: TrainingDocumentDetailRecord,
+): GetTrainingDocumentResponseDto {
+  const linkedQuizIds = document.quizzes.map((quiz) => quiz.id);
+
+  return {
+    id: document.id,
+    title: document.title,
+    contentType: document.contentType,
+    contentRef: document.contentRef,
+    ...(linkedQuizIds.length > 0 ? { linkedQuizIds } : {}),
+  };
+}

--- a/apps/backend/src/middleware/validateRequest.ts
+++ b/apps/backend/src/middleware/validateRequest.ts
@@ -23,6 +23,26 @@ export function validateBody<T>(schema: ZodSchema<T>) {
   };
 }
 
+export function validateParams<T>(schema: ZodSchema<T>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.params);
+
+    if (!result.success) {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'Invalid request parameters',
+        details: result.error.issues.map((issue) => ({
+          field: issue.path.join('.'),
+          message: issue.message,
+        })),
+      });
+    }
+
+    req.params = result.data as Request['params'];
+    next();
+  };
+}
+
 // Helper function to check if an error is a ZodError.. if it is we can handle it in a centralized error handler
 export function isZodError(error: unknown): error is ZodError {
   return error instanceof ZodError;

--- a/apps/backend/src/routes/training.routes.ts
+++ b/apps/backend/src/routes/training.routes.ts
@@ -1,0 +1,30 @@
+import {
+  getTrainingDocumentRequestParamsSchema,
+  recordTrainingProgressRequestParamsSchema,
+  recordTrainingProgressRequestSchema,
+} from '@insightful-phish/shared';
+import { Router } from 'express';
+import {
+  getAssignedTrainingDocuments,
+  getTrainingDocumentDetail,
+  postTrainingProgress,
+} from '../controllers/training.controller.js';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { validateBody, validateParams } from '../middleware/validateRequest.js';
+
+export const trainingRouter = Router();
+
+trainingRouter.get('/training/assigned', requireAuth, getAssignedTrainingDocuments);
+trainingRouter.get(
+  '/training/:trainingId',
+  requireAuth,
+  validateParams(getTrainingDocumentRequestParamsSchema),
+  getTrainingDocumentDetail,
+);
+trainingRouter.post(
+  '/training/:trainingId/progress',
+  requireAuth,
+  validateParams(recordTrainingProgressRequestParamsSchema),
+  validateBody(recordTrainingProgressRequestSchema),
+  postTrainingProgress,
+);

--- a/apps/backend/src/services/training.service.ts
+++ b/apps/backend/src/services/training.service.ts
@@ -1,0 +1,255 @@
+import type {
+  GetAssignedTrainingResponseDto,
+  GetTrainingDocumentResponseDto,
+  RecordTrainingProgressRequestDto,
+  RecordTrainingProgressResponseDto,
+} from '@insightful-phish/shared';
+import type { Prisma } from '../generated/prisma/client.js';
+import { prisma } from '../lib/prisma.js';
+import {
+  toGetTrainingDocumentResponseDto,
+  toTrainingDocumentSummaryDto,
+} from '../mappers/training.mapper.js';
+
+export class TrainingDocumentNotFoundError extends Error {
+  constructor(message = 'Training document was not found') {
+    super(message);
+    this.name = 'TrainingDocumentNotFoundError';
+  }
+}
+
+const assignedCampaignWhere = (userId: string) => ({
+  status: 'ACTIVE' as const,
+  assignments: {
+    some: {
+      userId,
+      assignmentStatus: {
+        not: 'CANCELLED' as const,
+      },
+    },
+  },
+});
+
+const assignedTrainingWhere = (userId: string) => ({
+  status: 'AVAILABLE' as const,
+  module: {
+    learningPath: {
+      status: 'ACTIVE' as const,
+      campaign: assignedCampaignWhere(userId),
+    },
+  },
+});
+
+const generalTrainingWhere = () => ({
+  status: 'AVAILABLE' as const,
+  module: {
+    learningPath: {
+      status: 'ACTIVE' as const,
+      campaign: {
+        status: 'ACTIVE' as const,
+        campaignType: 'PREMADE_GENERAL' as const,
+      },
+    },
+  },
+});
+
+async function userHasGeneralLearningAccess(userId: string) {
+  const access = await prisma.generalLearningAccess.findUnique({
+    where: {
+      userId,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return Boolean(access);
+}
+
+async function getAccessibleTrainingDocument(userId: string, trainingDocumentId: string) {
+  const whereClauses: Prisma.TrainingDocumentWhereInput[] = [assignedTrainingWhere(userId)];
+
+  if (await userHasGeneralLearningAccess(userId)) {
+    whereClauses.push(generalTrainingWhere());
+  }
+
+  return prisma.trainingDocument.findFirst({
+    where: {
+      id: trainingDocumentId,
+      OR: whereClauses,
+    },
+    include: {
+      quizzes: {
+        where: {
+          status: 'PUBLISHED',
+        },
+        select: {
+          id: true,
+        },
+        orderBy: {
+          createdAt: 'asc',
+        },
+      },
+      module: {
+        select: {
+          learningPath: {
+            select: {
+              campaign: {
+                select: {
+                  assignments: {
+                    where: {
+                      userId,
+                      assignmentStatus: {
+                        not: 'CANCELLED',
+                      },
+                    },
+                    select: {
+                      id: true,
+                    },
+                    take: 1,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+export async function getAssignedTraining(userId: string): Promise<GetAssignedTrainingResponseDto> {
+  const whereClauses: Prisma.TrainingDocumentWhereInput[] = [assignedTrainingWhere(userId)];
+
+  if (await userHasGeneralLearningAccess(userId)) {
+    whereClauses.push(generalTrainingWhere());
+  }
+
+  const trainingDocuments = await prisma.trainingDocument.findMany({
+    where: {
+      OR: whereClauses,
+    },
+    include: {
+      module: {
+        select: {
+          description: true,
+        },
+      },
+      trainingProgress: {
+        where: {
+          userId,
+        },
+        select: {
+          status: true,
+        },
+        orderBy: {
+          updatedAt: 'desc',
+        },
+        take: 1,
+      },
+    },
+    orderBy: [
+      {
+        module: {
+          order: 'asc',
+        },
+      },
+      {
+        createdAt: 'asc',
+      },
+    ],
+  });
+
+  return {
+    trainingDocuments: trainingDocuments.map(toTrainingDocumentSummaryDto),
+  };
+}
+
+export async function getTrainingDocument(
+  userId: string,
+  trainingDocumentId: string,
+): Promise<GetTrainingDocumentResponseDto> {
+  const document = await getAccessibleTrainingDocument(userId, trainingDocumentId);
+
+  if (!document) {
+    throw new TrainingDocumentNotFoundError();
+  }
+
+  return toGetTrainingDocumentResponseDto(document);
+}
+
+function toStoredProgressStatus(status: RecordTrainingProgressRequestDto['status']) {
+  return status === 'COMPLETED' ? 'COMPLETED' : 'IN_PROGRESS';
+}
+
+function toTrainingInteractionEventType(status: RecordTrainingProgressRequestDto['status']) {
+  return status === 'COMPLETED' ? 'TRAINING_COMPLETED' : 'TRAINING_VIEWED';
+}
+
+export async function recordTrainingProgress(
+  userId: string,
+  trainingDocumentId: string,
+  input: RecordTrainingProgressRequestDto,
+): Promise<RecordTrainingProgressResponseDto> {
+  const document = await getAccessibleTrainingDocument(userId, trainingDocumentId);
+
+  if (!document) {
+    throw new TrainingDocumentNotFoundError();
+  }
+
+  const campaignAssignmentId = document.module.learningPath?.campaign.assignments[0]?.id ?? null;
+  const existingProgress = await prisma.trainingProgress.findFirst({
+    where: {
+      userId,
+      trainingDocumentId,
+      campaignAssignmentId,
+    },
+    select: {
+      id: true,
+      startedAt: true,
+    },
+  });
+  const storedStatus = toStoredProgressStatus(input.status);
+  const now = new Date();
+
+  if (existingProgress) {
+    await prisma.trainingProgress.update({
+      where: {
+        id: existingProgress.id,
+      },
+      data: {
+        status: storedStatus,
+        startedAt: existingProgress.startedAt ?? now,
+        ...(storedStatus === 'COMPLETED' ? { completedAt: now } : {}),
+      },
+    });
+  } else {
+    await prisma.trainingProgress.create({
+      data: {
+        userId,
+        trainingDocumentId,
+        campaignAssignmentId,
+        status: storedStatus,
+        startedAt: now,
+        ...(storedStatus === 'COMPLETED' ? { completedAt: now } : {}),
+      },
+    });
+  }
+
+  await prisma.interactionEvent.create({
+    data: {
+      userId,
+      eventType: toTrainingInteractionEventType(input.status),
+      targetType: 'TRAINING_DOCUMENT',
+      targetId: trainingDocumentId,
+      trainingDocumentId,
+      metadata: {
+        requestedStatus: input.status,
+      },
+    },
+  });
+
+  return {
+    success: true,
+  };
+}

--- a/apps/backend/src/services/training.service.ts
+++ b/apps/backend/src/services/training.service.ts
@@ -8,6 +8,7 @@ import type { Prisma } from '../generated/prisma/client.js';
 import { prisma } from '../lib/prisma.js';
 import {
   toGetTrainingDocumentResponseDto,
+  toTrainingProgressResultDto,
   toTrainingDocumentSummaryDto,
 } from '../mappers/training.mapper.js';
 
@@ -212,29 +213,27 @@ export async function recordTrainingProgress(
   const storedStatus = toStoredProgressStatus(input.status);
   const now = new Date();
 
-  if (existingProgress) {
-    await prisma.trainingProgress.update({
-      where: {
-        id: existingProgress.id,
-      },
-      data: {
-        status: storedStatus,
-        startedAt: existingProgress.startedAt ?? now,
-        ...(storedStatus === 'COMPLETED' ? { completedAt: now } : {}),
-      },
-    });
-  } else {
-    await prisma.trainingProgress.create({
-      data: {
-        userId,
-        trainingDocumentId,
-        campaignAssignmentId,
-        status: storedStatus,
-        startedAt: now,
-        ...(storedStatus === 'COMPLETED' ? { completedAt: now } : {}),
-      },
-    });
-  }
+  const progress = existingProgress
+    ? await prisma.trainingProgress.update({
+        where: {
+          id: existingProgress.id,
+        },
+        data: {
+          status: storedStatus,
+          startedAt: existingProgress.startedAt ?? now,
+          ...(storedStatus === 'COMPLETED' ? { completedAt: now } : {}),
+        },
+      })
+    : await prisma.trainingProgress.create({
+        data: {
+          userId,
+          trainingDocumentId,
+          campaignAssignmentId,
+          status: storedStatus,
+          startedAt: now,
+          ...(storedStatus === 'COMPLETED' ? { completedAt: now } : {}),
+        },
+      });
 
   await prisma.interactionEvent.create({
     data: {
@@ -251,5 +250,6 @@ export async function recordTrainingProgress(
 
   return {
     success: true,
+    progress: toTrainingProgressResultDto(progress),
   };
 }

--- a/apps/backend/tests/unit/training.routes.test.ts
+++ b/apps/backend/tests/unit/training.routes.test.ts
@@ -63,6 +63,34 @@ function assignedTrainingDocument(overrides = {}) {
   };
 }
 
+function expectAssignedAvailableTrainingWhere(where: unknown) {
+  expect(where).toEqual(
+    expect.objectContaining({
+      OR: [
+        expect.objectContaining({
+          status: 'AVAILABLE',
+          module: {
+            learningPath: {
+              status: 'ACTIVE',
+              campaign: {
+                status: 'ACTIVE',
+                assignments: {
+                  some: {
+                    userId: 'learner-1',
+                    assignmentStatus: {
+                      not: 'CANCELLED',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }),
+  );
+}
+
 describe('Training routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,16 +106,19 @@ describe('Training routes', () => {
       .set('Authorization', authHeader());
 
     expect(response.status).toBe(200);
-    expect(prismaMock.trainingDocument.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          OR: [
-            expect.objectContaining({
-              status: 'AVAILABLE',
-            }),
-          ],
+    expect(prismaMock.trainingDocument.findMany).toHaveBeenCalledWith({
+      where: expect.any(Object),
+      include: expect.objectContaining({
+        module: {
+          select: {
+            description: true,
+          },
         },
       }),
+      orderBy: expect.any(Array),
+    });
+    expectAssignedAvailableTrainingWhere(
+      prismaMock.trainingDocument.findMany.mock.calls[0][0].where,
     );
     expect(response.body).toEqual({
       trainingDocuments: [
@@ -111,11 +142,28 @@ describe('Training routes', () => {
     expect(response.status).toBe(200);
     expect(prismaMock.trainingDocument.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          id: 'training-1',
+        include: expect.objectContaining({
+          quizzes: {
+            where: {
+              status: 'PUBLISHED',
+            },
+            select: {
+              id: true,
+            },
+            orderBy: {
+              createdAt: 'asc',
+            },
+          },
         }),
       }),
     );
+    const detailWhere = prismaMock.trainingDocument.findFirst.mock.calls[0][0].where;
+    expect(detailWhere).toEqual(
+      expect.objectContaining({
+        id: 'training-1',
+      }),
+    );
+    expectAssignedAvailableTrainingWhere(detailWhere);
     expect(response.body).toEqual({
       id: 'training-1',
       title: 'Spotting phishing links',
@@ -151,6 +199,17 @@ describe('Training routes', () => {
       error: 'TRAINING_DOCUMENT_NOT_FOUND',
       message: 'Training document was not found',
     });
+  });
+
+  it('returns 401 when training routes are requested without authentication', async () => {
+    const response = await request(createApp()).get('/training/assigned');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      error: 'AUTH_REQUIRED',
+      message: 'Authentication credentials are required',
+    });
+    expect(prismaMock.trainingDocument.findMany).not.toHaveBeenCalled();
   });
 
   it('records training progress and writes an interaction event', async () => {

--- a/apps/backend/tests/unit/training.routes.test.ts
+++ b/apps/backend/tests/unit/training.routes.test.ts
@@ -158,6 +158,11 @@ describe('Training routes', () => {
     prismaMock.trainingProgress.findFirst.mockResolvedValue(null);
     prismaMock.trainingProgress.create.mockResolvedValue({
       id: 'progress-1',
+      trainingDocumentId: 'training-1',
+      campaignAssignmentId: 'assignment-1',
+      status: 'IN_PROGRESS',
+      startedAt: new Date('2026-05-13T10:00:00.000Z'),
+      completedAt: null,
     });
     prismaMock.interactionEvent.create.mockResolvedValue({
       id: 'event-1',
@@ -194,6 +199,14 @@ describe('Training routes', () => {
     });
     expect(response.body).toEqual({
       success: true,
+      progress: {
+        id: 'progress-1',
+        trainingDocumentId: 'training-1',
+        campaignAssignmentId: 'assignment-1',
+        status: 'IN_PROGRESS',
+        startedAt: '2026-05-13T10:00:00.000Z',
+        completedAt: null,
+      },
     });
   });
 

--- a/apps/backend/tests/unit/training.routes.test.ts
+++ b/apps/backend/tests/unit/training.routes.test.ts
@@ -1,0 +1,213 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../src/app.js';
+import { generateAuthToken } from '../../src/services/auth-token.service.js';
+
+const prismaMock = vi.hoisted(() => ({
+  user: {
+    findUnique: vi.fn(),
+  },
+  generalLearningAccess: {
+    findUnique: vi.fn(),
+  },
+  trainingDocument: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+  },
+  trainingProgress: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  interactionEvent: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
+
+const authenticatedUser = {
+  id: 'learner-1',
+  firstName: 'Johan',
+  lastName: 'Nel',
+  email: 'johan@example.com',
+  passwordHash: 'hashed-password',
+  userType: 'COMPANY_LEARNER',
+  authStatus: 'ACTIVE',
+  createdAt: new Date('2026-05-12T06:00:00.000Z'),
+};
+
+function authHeader(userId = 'learner-1') {
+  return `Bearer ${generateAuthToken(userId).token}`;
+}
+
+function assignedTrainingDocument(overrides = {}) {
+  return {
+    id: 'training-1',
+    title: 'Spotting phishing links',
+    contentType: 'MARKDOWN',
+    contentRef: '# Check the sender and the destination URL.',
+    quizzes: [{ id: 'quiz-1' }],
+    module: {
+      description: 'Core phishing awareness material',
+      learningPath: {
+        campaign: {
+          assignments: [{ id: 'assignment-1' }],
+        },
+      },
+    },
+    trainingProgress: [{ status: 'IN_PROGRESS' }],
+    ...overrides,
+  };
+}
+
+describe('Training routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.user.findUnique.mockResolvedValue(authenticatedUser);
+    prismaMock.generalLearningAccess.findUnique.mockResolvedValue(null);
+  });
+
+  it('returns assigned available training documents for the authenticated learner', async () => {
+    prismaMock.trainingDocument.findMany.mockResolvedValue([assignedTrainingDocument()]);
+
+    const response = await request(createApp())
+      .get('/training/assigned')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.trainingDocument.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [
+            expect.objectContaining({
+              status: 'AVAILABLE',
+            }),
+          ],
+        },
+      }),
+    );
+    expect(response.body).toEqual({
+      trainingDocuments: [
+        {
+          id: 'training-1',
+          title: 'Spotting phishing links',
+          description: 'Core phishing awareness material',
+          status: 'IN_PROGRESS',
+        },
+      ],
+    });
+  });
+
+  it('returns training detail with linked quiz ids when the document is assigned', async () => {
+    prismaMock.trainingDocument.findFirst.mockResolvedValue(assignedTrainingDocument());
+
+    const response = await request(createApp())
+      .get('/training/training-1')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.trainingDocument.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'training-1',
+        }),
+      }),
+    );
+    expect(response.body).toEqual({
+      id: 'training-1',
+      title: 'Spotting phishing links',
+      contentType: 'MARKDOWN',
+      contentRef: '# Check the sender and the destination URL.',
+      linkedQuizIds: ['quiz-1'],
+    });
+  });
+
+  it('returns a safe not found error for missing documents', async () => {
+    prismaMock.trainingDocument.findFirst.mockResolvedValue(null);
+
+    const response = await request(createApp())
+      .get('/training/missing-training')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      error: 'TRAINING_DOCUMENT_NOT_FOUND',
+      message: 'Training document was not found',
+    });
+  });
+
+  it('returns a safe not found error for cross-user training access', async () => {
+    prismaMock.trainingDocument.findFirst.mockResolvedValue(null);
+
+    const response = await request(createApp())
+      .get('/training/training-owned-by-another-learner')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      error: 'TRAINING_DOCUMENT_NOT_FOUND',
+      message: 'Training document was not found',
+    });
+  });
+
+  it('records training progress and writes an interaction event', async () => {
+    prismaMock.trainingDocument.findFirst.mockResolvedValue(assignedTrainingDocument());
+    prismaMock.trainingProgress.findFirst.mockResolvedValue(null);
+    prismaMock.trainingProgress.create.mockResolvedValue({
+      id: 'progress-1',
+    });
+    prismaMock.interactionEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+
+    const response = await request(createApp())
+      .post('/training/training-1/progress')
+      .set('Authorization', authHeader())
+      .send({
+        status: 'VIEWED',
+      });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.trainingProgress.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'learner-1',
+        trainingDocumentId: 'training-1',
+        campaignAssignmentId: 'assignment-1',
+        status: 'IN_PROGRESS',
+        startedAt: expect.any(Date),
+      }),
+    });
+    expect(prismaMock.interactionEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'learner-1',
+        eventType: 'TRAINING_VIEWED',
+        targetType: 'TRAINING_DOCUMENT',
+        targetId: 'training-1',
+        trainingDocumentId: 'training-1',
+        metadata: {
+          requestedStatus: 'VIEWED',
+        },
+      }),
+    });
+    expect(response.body).toEqual({
+      success: true,
+    });
+  });
+
+  it('rejects invalid progress statuses with a validation error', async () => {
+    const response = await request(createApp())
+      .post('/training/training-1/progress')
+      .set('Authorization', authHeader())
+      .send({
+        status: 'IN_PROGRESS',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    expect(prismaMock.trainingProgress.create).not.toHaveBeenCalled();
+    expect(prismaMock.interactionEvent.create).not.toHaveBeenCalled();
+  });
+});

--- a/docs/demo1/API.md
+++ b/docs/demo1/API.md
@@ -213,9 +213,24 @@ Where the API uses practical route names such as `trainingId` or `emailId`, thes
 - **Related Use Case / Base Feature**: UC-02: View Training Document
 - **Method & Route**: `POST /training/:trainingId/progress`
 - **Expected Request Data**:
-  - `status` (enum: "IN_PROGRESS", "COMPLETED", required)
+  - `status` (enum: "STARTED", "VIEWED", "COMPLETED", required)
+  - API inputs `STARTED` and `VIEWED` are stored internally as `IN_PROGRESS`.
+  - API input `COMPLETED` is stored internally as `COMPLETED`.
 - **Expected Response Data**:
-  - `201 Created`: `{ "success": true }`
+  - `200 OK`:
+    ```json
+    {
+      "success": true,
+      "progress": {
+        "id": "progress-001",
+        "trainingDocumentId": "train-001",
+        "campaignAssignmentId": "assignment-001",
+        "status": "IN_PROGRESS",
+        "startedAt": "2026-05-01T10:00:00Z",
+        "completedAt": null
+      }
+    }
+    ```
 - **Common Error Responses**:
   - `404 Not Found`
 - **Linked Domain Entities**: `TrainingProgress`, `InteractionEvent`

--- a/packages/shared/src/training.ts
+++ b/packages/shared/src/training.ts
@@ -43,4 +43,15 @@ export type RecordTrainingProgressRequestParamsDto = z.infer<
 
 export type RecordTrainingProgressRequestDto = z.infer<typeof recordTrainingProgressRequestSchema>;
 
-export interface RecordTrainingProgressResponseDto extends SuccessResponseDto {}
+export interface TrainingProgressResultDto {
+  id: string;
+  trainingDocumentId: string;
+  campaignAssignmentId?: string | null;
+  status: TrainingProgressStatusDto;
+  startedAt?: string | null;
+  completedAt?: string | null;
+}
+
+export interface RecordTrainingProgressResponseDto extends SuccessResponseDto {
+  progress: TrainingProgressResultDto;
+}

--- a/packages/shared/src/validation/training.schemas.test.ts
+++ b/packages/shared/src/validation/training.schemas.test.ts
@@ -5,7 +5,13 @@ describe('training validation schemas', () => {
   it('accepts progress states learners can record', () => {
     expect(
       recordTrainingProgressRequestSchema.safeParse({
-        status: 'IN_PROGRESS',
+        status: 'STARTED',
+      }).success,
+    ).toBe(true);
+
+    expect(
+      recordTrainingProgressRequestSchema.safeParse({
+        status: 'VIEWED',
       }).success,
     ).toBe(true);
 
@@ -19,6 +25,14 @@ describe('training validation schemas', () => {
   it('rejects NOT_STARTED for progress recording', () => {
     const result = recordTrainingProgressRequestSchema.safeParse({
       status: 'NOT_STARTED',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects internal storage states for progress recording', () => {
+    const result = recordTrainingProgressRequestSchema.safeParse({
+      status: 'IN_PROGRESS',
     });
 
     expect(result.success).toBe(false);

--- a/packages/shared/src/validation/training.schemas.ts
+++ b/packages/shared/src/validation/training.schemas.ts
@@ -3,7 +3,7 @@ import { idParamSchema } from './common.schemas.js';
 
 export const trainingProgressStatusSchema = z.enum(['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED']);
 
-export const recordTrainingProgressStatusSchema = z.enum(['IN_PROGRESS', 'COMPLETED']);
+export const recordTrainingProgressStatusSchema = z.enum(['STARTED', 'VIEWED', 'COMPLETED']);
 
 export const getTrainingDocumentRequestParamsSchema = z.object({
   trainingId: idParamSchema,


### PR DESCRIPTION
## Summary

Implemented the backend UC-02 training document APIs for authenticated trainees.

This PR adds support for:

- `GET /training/assigned`
- `GET /training/:trainingId`
- `POST /training/:trainingId/progress`

The implementation allows a trainee to retrieve assigned training material, view training document details, receive linked quiz identifiers where relevant, and record training progress events.

## Linked Issue

Closes #80 

## Type of change

- [x] Feature
- [ ] Bug Fix
- [x] Documentation
- [x] Chore/Maintenance

## What Changed

### Training API endpoints

Added backend support for:

#### `GET /training/assigned`

Returns the authenticated trainee’s assigned and available training documents.

The endpoint filters training documents by:

- authenticated user access
- active campaign assignment
- active learning path/campaign context
- available training document status

This prevents trainees from seeing unassigned or unavailable documents.

#### `GET /training/:trainingId`

Returns training document detail for an assigned and available document.

The response includes:

- document title/details
- `contentType`
- `contentRef`
- current progress information where relevant
- linked quiz identifiers where a quiz follows the training document

Missing, unavailable, or unauthorised documents return a safe not-found style response.

#### `POST /training/:trainingId/progress`

Records progress for the authenticated trainee.

Accepted request statuses:

- `STARTED`
- `VIEWED`
- `COMPLETED`

Storage mapping:

- `STARTED` and `VIEWED` are stored internally as `IN_PROGRESS`
- `COMPLETED` is stored as `COMPLETED`

The endpoint also records interaction events:

- `TRAINING_VIEWED`
- `TRAINING_COMPLETED`

Invalid progress statuses are rejected with a validation error.

### Shared DTO alignment

Updated/used shared training DTOs so backend responses match the shared contract.

The progress response now returns:

```json
{
  "success": true,
  "progress": {
    "id": "...",
    "trainingDocumentId": "...",
    "campaignAssignmentId": "...",
    "status": "IN_PROGRESS",
    "startedAt": "...",
    "completedAt": null
  }
}