### PR TITLE
feat: implement campaign item training api

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -6,6 +6,7 @@ import { env } from './config/env.js';
 import { swaggerSpec } from './config/swagger.js';
 import { healthRoutes } from './routes/health.routes.js';
 import { authRouter } from './routes/auth.routes.js';
+import { traineeTrainingRouter } from './routes/trainee-training.routes.js';
 
 export function createApp() {
   const app = express();
@@ -28,6 +29,7 @@ export function createApp() {
 
   app.use(healthRoutes);
   app.use(authRouter);
+  app.use(traineeTrainingRouter);
 
   // Preliminary Demo 1 API Route Placeholders (To be implemented)
   // app.use('/auth', authRoutes);

--- a/apps/backend/src/controllers/trainee-training.controller.ts
+++ b/apps/backend/src/controllers/trainee-training.controller.ts
@@ -1,0 +1,93 @@
+import type { Request, Response } from 'express';
+import {
+  getTrainingDocumentForCampaignItem,
+  recordTrainingInteraction,
+  TrainingDocumentAccessNotFoundError,
+} from '../services/trainee-training.service.js';
+
+function requireAuthenticatedUserId(req: Request, res: Response) {
+  if (!req.auth) {
+    res.status(401).json({
+      error: 'AUTH_REQUIRED',
+      message: 'Authentication credentials are required',
+    });
+    return null;
+  }
+
+  return req.auth.userId;
+}
+
+function handleTrainingError(error: unknown, res: Response) {
+  if (error instanceof TrainingDocumentAccessNotFoundError) {
+    return res.status(404).json({
+      error: 'TRAINING_DOCUMENT_NOT_FOUND',
+      message: 'Training document was not found',
+    });
+  }
+
+  return res.status(500).json({
+    error: 'INTERNAL_SERVER_ERROR',
+    message: 'An unexpected error occurred',
+  });
+}
+
+function getCampaignItemId(req: Request) {
+  const { campaignItemId } = req.params;
+
+  return Array.isArray(campaignItemId) ? (campaignItemId[0] ?? '') : campaignItemId;
+}
+
+export async function getTrainingDocument(req: Request, res: Response) {
+  const userId = requireAuthenticatedUserId(req, res);
+
+  if (!userId) {
+    return undefined;
+  }
+
+  try {
+    const response = await getTrainingDocumentForCampaignItem(userId, getCampaignItemId(req));
+    return res.status(200).json(response);
+  } catch (error) {
+    return handleTrainingError(error, res);
+  }
+}
+
+export async function recordTrainingViewed(req: Request, res: Response) {
+  const userId = requireAuthenticatedUserId(req, res);
+
+  if (!userId) {
+    return undefined;
+  }
+
+  try {
+    const response = await recordTrainingInteraction({
+      userId,
+      campaignItemId: getCampaignItemId(req),
+      eventType: 'TRAINING_VIEWED',
+    });
+
+    return res.status(201).json(response);
+  } catch (error) {
+    return handleTrainingError(error, res);
+  }
+}
+
+export async function recordTrainingCompleted(req: Request, res: Response) {
+  const userId = requireAuthenticatedUserId(req, res);
+
+  if (!userId) {
+    return undefined;
+  }
+
+  try {
+    const response = await recordTrainingInteraction({
+      userId,
+      campaignItemId: getCampaignItemId(req),
+      eventType: 'TRAINING_COMPLETED',
+    });
+
+    return res.status(201).json(response);
+  } catch (error) {
+    return handleTrainingError(error, res);
+  }
+}

--- a/apps/backend/src/middleware/traineeTrainingRateLimit.ts
+++ b/apps/backend/src/middleware/traineeTrainingRateLimit.ts
@@ -1,0 +1,19 @@
+import rateLimit, { MemoryStore } from 'express-rate-limit';
+
+const traineeTrainingRateLimitStore = new MemoryStore();
+
+export const traineeTrainingRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  store: traineeTrainingRateLimitStore,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'TRAINING_RATE_LIMITED',
+    message: 'Too many training requests. Please try again later.',
+  },
+});
+
+export function clearTraineeTrainingRateLimitStore() {
+  traineeTrainingRateLimitStore.resetAll();
+}

--- a/apps/backend/src/middleware/validateParams.ts
+++ b/apps/backend/src/middleware/validateParams.ts
@@ -1,0 +1,22 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { ZodSchema } from 'zod';
+
+export function validateParams<T>(schema: ZodSchema<T>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.params);
+
+    if (!result.success) {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'Invalid request parameters',
+        details: result.error.issues.map((issue) => ({
+          field: issue.path.join('.'),
+          message: issue.message,
+        })),
+      });
+    }
+
+    req.params = result.data as Request['params'];
+    return next();
+  };
+}

--- a/apps/backend/src/repositories/trainee-training.repository.ts
+++ b/apps/backend/src/repositories/trainee-training.repository.ts
@@ -18,6 +18,11 @@ export function findTrainingCampaignItemById(campaignItemId: string) {
       id: campaignItemId,
     },
     include: {
+      campaign: {
+        select: {
+          status: true,
+        },
+      },
       trainingDocument: true,
     },
   });
@@ -37,6 +42,30 @@ export function findAccessibleCampaignAssignment(input: {
     },
     select: {
       id: true,
+    },
+  });
+}
+
+export function findExistingTrainingCompletedEvent(input: {
+  traineeProfileId: string;
+  campaignAssignmentId: string;
+  campaignItemId: string;
+  trainingDocumentId: string;
+}) {
+  return prisma.interactionEvent.findFirst({
+    where: {
+      traineeProfileId: input.traineeProfileId,
+      campaignAssignmentId: input.campaignAssignmentId,
+      campaignItemId: input.campaignItemId,
+      eventType: 'TRAINING_COMPLETED',
+      targetType: 'TRAINING_DOCUMENT',
+      targetId: input.trainingDocumentId,
+      trainingDocumentId: input.trainingDocumentId,
+    },
+    select: {
+      id: true,
+      eventType: true,
+      occurredAt: true,
     },
   });
 }

--- a/apps/backend/src/repositories/trainee-training.repository.ts
+++ b/apps/backend/src/repositories/trainee-training.repository.ts
@@ -1,0 +1,67 @@
+import { prisma } from '../lib/prisma.js';
+
+export function findActiveTraineeProfileByUserId(userId: string) {
+  return prisma.traineeProfile.findFirst({
+    where: {
+      userId,
+      traineeStatus: 'ACTIVE',
+    },
+    select: {
+      id: true,
+    },
+  });
+}
+
+export function findTrainingCampaignItemById(campaignItemId: string) {
+  return prisma.campaignItem.findUnique({
+    where: {
+      id: campaignItemId,
+    },
+    include: {
+      trainingDocument: true,
+    },
+  });
+}
+
+export function findAccessibleCampaignAssignment(input: {
+  campaignId: string;
+  traineeProfileId: string;
+}) {
+  return prisma.campaignAssignment.findFirst({
+    where: {
+      campaignId: input.campaignId,
+      traineeProfileId: input.traineeProfileId,
+      assignmentStatus: {
+        in: ['AVAILABLE', 'ASSIGNED', 'IN_PROGRESS', 'COMPLETED'],
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+}
+
+export function createTrainingInteractionEvent(input: {
+  traineeProfileId: string;
+  campaignAssignmentId: string;
+  campaignItemId: string;
+  trainingDocumentId: string;
+  eventType: 'TRAINING_VIEWED' | 'TRAINING_COMPLETED';
+}) {
+  return prisma.interactionEvent.create({
+    data: {
+      traineeProfileId: input.traineeProfileId,
+      campaignAssignmentId: input.campaignAssignmentId,
+      campaignItemId: input.campaignItemId,
+      eventType: input.eventType,
+      targetType: 'TRAINING_DOCUMENT',
+      targetId: input.trainingDocumentId,
+      trainingDocumentId: input.trainingDocumentId,
+    },
+    select: {
+      id: true,
+      eventType: true,
+      occurredAt: true,
+    },
+  });
+}

--- a/apps/backend/src/routes/trainee-training.routes.ts
+++ b/apps/backend/src/routes/trainee-training.routes.ts
@@ -1,0 +1,43 @@
+import {
+  getTrainingDocumentRequestParamsSchema,
+  recordTrainingInteractionRequestParamsSchema,
+  recordTrainingInteractionRequestSchema,
+} from '@insightful-phish/shared';
+import { Router } from 'express';
+import {
+  getTrainingDocument,
+  recordTrainingCompleted,
+  recordTrainingViewed,
+} from '../controllers/trainee-training.controller.js';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { traineeTrainingRateLimit } from '../middleware/traineeTrainingRateLimit.js';
+import { validateBody } from '../middleware/validateRequest.js';
+import { validateParams } from '../middleware/validateParams.js';
+
+export const traineeTrainingRouter = Router();
+
+traineeTrainingRouter.get(
+  '/trainee/campaign-items/:campaignItemId/training-document',
+  traineeTrainingRateLimit,
+  requireAuth,
+  validateParams(getTrainingDocumentRequestParamsSchema),
+  getTrainingDocument,
+);
+
+traineeTrainingRouter.post(
+  '/trainee/campaign-items/:campaignItemId/training-document/viewed',
+  traineeTrainingRateLimit,
+  requireAuth,
+  validateParams(recordTrainingInteractionRequestParamsSchema),
+  validateBody(recordTrainingInteractionRequestSchema),
+  recordTrainingViewed,
+);
+
+traineeTrainingRouter.post(
+  '/trainee/campaign-items/:campaignItemId/training-document/completed',
+  traineeTrainingRateLimit,
+  requireAuth,
+  validateParams(recordTrainingInteractionRequestParamsSchema),
+  validateBody(recordTrainingInteractionRequestSchema),
+  recordTrainingCompleted,
+);

--- a/apps/backend/src/services/trainee-training.service.ts
+++ b/apps/backend/src/services/trainee-training.service.ts
@@ -56,6 +56,7 @@ function isAccessibleTrainingDocumentItem(
 } {
   return Boolean(
     campaignItem &&
+    campaignItem.campaign.status === 'ACTIVE' &&
     campaignItem.itemType === 'COMPONENT' &&
     campaignItem.componentType === 'TRAINING_DOCUMENT' &&
     campaignItem.availabilityStatus === 'AVAILABLE' &&
@@ -115,13 +116,19 @@ export async function recordTrainingInteraction(input: {
 }): Promise<RecordTrainingInteractionResponseDto> {
   const access = await resolveTrainingDocumentAccess(input.userId, input.campaignItemId);
 
-  const event = await TraineeTrainingRepository.createTrainingInteractionEvent({
+  const eventInput = {
     traineeProfileId: access.traineeProfileId,
     campaignAssignmentId: access.campaignAssignment.id,
     campaignItemId: access.campaignItem.id,
     trainingDocumentId: access.trainingDocument.id,
     eventType: input.eventType,
-  });
+  };
+
+  const event =
+    input.eventType === 'TRAINING_COMPLETED'
+      ? ((await TraineeTrainingRepository.findExistingTrainingCompletedEvent(eventInput)) ??
+        (await TraineeTrainingRepository.createTrainingInteractionEvent(eventInput)))
+      : await TraineeTrainingRepository.createTrainingInteractionEvent(eventInput);
 
   return {
     success: true,

--- a/apps/backend/src/services/trainee-training.service.ts
+++ b/apps/backend/src/services/trainee-training.service.ts
@@ -1,0 +1,136 @@
+import type {
+  GetTrainingDocumentResponseDto,
+  RecordTrainingInteractionResponseDto,
+  TrainingInteractionEventTypeDto,
+} from '@insightful-phish/shared';
+import * as TraineeTrainingRepository from '../repositories/trainee-training.repository.js';
+
+type TrainingCampaignItem = NonNullable<
+  Awaited<ReturnType<typeof TraineeTrainingRepository.findTrainingCampaignItemById>>
+>;
+type CampaignAssignment = NonNullable<
+  Awaited<ReturnType<typeof TraineeTrainingRepository.findAccessibleCampaignAssignment>>
+>;
+
+export class TrainingDocumentAccessNotFoundError extends Error {
+  constructor(message = 'Training document was not found') {
+    super(message);
+    this.name = 'TrainingDocumentAccessNotFoundError';
+  }
+}
+
+async function resolveTrainingDocumentAccess(userId: string, campaignItemId: string) {
+  const traineeProfile = await TraineeTrainingRepository.findActiveTraineeProfileByUserId(userId);
+
+  if (!traineeProfile) {
+    throw new TrainingDocumentAccessNotFoundError();
+  }
+
+  const campaignItem = await TraineeTrainingRepository.findTrainingCampaignItemById(campaignItemId);
+
+  if (!isAccessibleTrainingDocumentItem(campaignItem)) {
+    throw new TrainingDocumentAccessNotFoundError();
+  }
+
+  const campaignAssignment = await TraineeTrainingRepository.findAccessibleCampaignAssignment({
+    campaignId: campaignItem.campaignId,
+    traineeProfileId: traineeProfile.id,
+  });
+
+  if (!campaignAssignment) {
+    throw new TrainingDocumentAccessNotFoundError();
+  }
+
+  return {
+    traineeProfileId: traineeProfile.id,
+    campaignAssignment,
+    campaignItem,
+    trainingDocument: campaignItem.trainingDocument,
+  };
+}
+
+function isAccessibleTrainingDocumentItem(
+  campaignItem: TrainingCampaignItem | null,
+): campaignItem is TrainingCampaignItem & {
+  trainingDocument: NonNullable<TrainingCampaignItem['trainingDocument']>;
+} {
+  return Boolean(
+    campaignItem &&
+    campaignItem.itemType === 'COMPONENT' &&
+    campaignItem.componentType === 'TRAINING_DOCUMENT' &&
+    campaignItem.availabilityStatus === 'AVAILABLE' &&
+    campaignItem.trainingDocument &&
+    campaignItem.trainingDocument.status === 'AVAILABLE',
+  );
+}
+
+function toTrainingDocumentResponse(input: {
+  campaignItem: TrainingCampaignItem & {
+    trainingDocument: NonNullable<TrainingCampaignItem['trainingDocument']>;
+  };
+  campaignAssignment: CampaignAssignment;
+}): GetTrainingDocumentResponseDto {
+  const { campaignItem, campaignAssignment } = input;
+  const { trainingDocument } = campaignItem;
+
+  return {
+    campaignItemId: campaignItem.id,
+    campaignAssignmentId: campaignAssignment.id,
+    trainingDocument: {
+      id: trainingDocument.id,
+      title: trainingDocument.title,
+      contentType: trainingDocument.contentType,
+      contentRef: trainingDocument.contentRef,
+      contentSummary: trainingDocument.contentSummary,
+      estimatedReadTimeMinutes: trainingDocument.estimatedReadTimeMinutes,
+      difficultyLevel: trainingDocument.difficultyLevel,
+      status: trainingDocument.status,
+    },
+    campaignItem: {
+      title: campaignItem.title,
+      description: campaignItem.description,
+      position: campaignItem.position,
+      isRequired: campaignItem.isRequired,
+      availabilityStatus: campaignItem.availabilityStatus,
+    },
+  };
+}
+
+export async function getTrainingDocumentForCampaignItem(
+  userId: string,
+  campaignItemId: string,
+): Promise<GetTrainingDocumentResponseDto> {
+  const access = await resolveTrainingDocumentAccess(userId, campaignItemId);
+
+  return toTrainingDocumentResponse({
+    campaignItem: access.campaignItem,
+    campaignAssignment: access.campaignAssignment,
+  });
+}
+
+export async function recordTrainingInteraction(input: {
+  userId: string;
+  campaignItemId: string;
+  eventType: TrainingInteractionEventTypeDto;
+}): Promise<RecordTrainingInteractionResponseDto> {
+  const access = await resolveTrainingDocumentAccess(input.userId, input.campaignItemId);
+
+  const event = await TraineeTrainingRepository.createTrainingInteractionEvent({
+    traineeProfileId: access.traineeProfileId,
+    campaignAssignmentId: access.campaignAssignment.id,
+    campaignItemId: access.campaignItem.id,
+    trainingDocumentId: access.trainingDocument.id,
+    eventType: input.eventType,
+  });
+
+  return {
+    success: true,
+    campaignItemId: access.campaignItem.id,
+    trainingDocumentId: access.trainingDocument.id,
+    event: {
+      id: event.id,
+      eventType: input.eventType,
+      occurredAt: event.occurredAt.toISOString(),
+    },
+  };
+}

--- a/apps/backend/tests/unit/trainee-training.routes.test.ts
+++ b/apps/backend/tests/unit/trainee-training.routes.test.ts
@@ -18,6 +18,7 @@ const prismaMock = vi.hoisted(() => ({
     findFirst: vi.fn(),
   },
   interactionEvent: {
+    findFirst: vi.fn(),
     create: vi.fn(),
   },
 }));
@@ -37,8 +38,14 @@ const user = {
   createdAt: new Date('2026-05-16T08:00:00.000Z'),
 };
 
+const campaignItemId = '11111111-1111-4111-8111-111111111111';
+const campaignId = '22222222-2222-4222-8222-222222222222';
+const trainingDocumentId = '33333333-3333-4333-8333-333333333333';
+const campaignAssignmentId = '44444444-4444-4444-8444-444444444444';
+const traineeProfileId = '55555555-5555-4555-8555-555555555555';
+
 const trainingDocument = {
-  id: 'training-doc-1',
+  id: trainingDocumentId,
   createdByUserId: null,
   title: 'Identifying Phishing Emails',
   contentType: 'MARKDOWN',
@@ -52,8 +59,8 @@ const trainingDocument = {
 };
 
 const campaignItem = {
-  id: 'campaign-item-1',
-  campaignId: 'campaign-1',
+  id: campaignItemId,
+  campaignId,
   parentGroupId: null,
   itemType: 'COMPONENT',
   componentType: 'TRAINING_DOCUMENT',
@@ -70,19 +77,29 @@ const campaignItem = {
   simulationId: null,
   createdAt: new Date('2026-05-16T08:00:00.000Z'),
   updatedAt: new Date('2026-05-16T08:00:00.000Z'),
+  campaign: {
+    status: 'ACTIVE',
+  },
   trainingDocument,
 };
 
 const authHeader = () => `Bearer ${generateAuthToken(user.id).token}`;
+const trainingDocumentPath = (id = campaignItemId) =>
+  `/trainee/campaign-items/${id}/training-document`;
+const viewedPath = (id = campaignItemId) =>
+  `/trainee/campaign-items/${id}/training-document/viewed`;
+const completedPath = (id = campaignItemId) =>
+  `/trainee/campaign-items/${id}/training-document/completed`;
 
 function mockAuthenticatedUser() {
   prismaMock.user.findUnique.mockResolvedValue(user);
 }
 
 function mockTrainingAccess() {
-  prismaMock.traineeProfile.findFirst.mockResolvedValue({ id: 'trainee-profile-1' });
+  prismaMock.traineeProfile.findFirst.mockResolvedValue({ id: traineeProfileId });
   prismaMock.campaignItem.findUnique.mockResolvedValue(campaignItem);
-  prismaMock.campaignAssignment.findFirst.mockResolvedValue({ id: 'assignment-1' });
+  prismaMock.campaignAssignment.findFirst.mockResolvedValue({ id: campaignAssignmentId });
+  prismaMock.interactionEvent.findFirst.mockResolvedValue(null);
 }
 
 describe('Trainee training document routes', () => {
@@ -95,23 +112,28 @@ describe('Trainee training document routes', () => {
 
   it('gets a training document resolved through the campaign item', async () => {
     const response = await request(createApp())
-      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .get(trainingDocumentPath())
       .set('Authorization', authHeader());
 
     expect(response.status).toBe(200);
     expect(prismaMock.campaignItem.findUnique).toHaveBeenCalledWith({
       where: {
-        id: 'campaign-item-1',
+        id: campaignItemId,
       },
       include: {
+        campaign: {
+          select: {
+            status: true,
+          },
+        },
         trainingDocument: true,
       },
     });
     expect(response.body).toEqual({
-      campaignItemId: 'campaign-item-1',
-      campaignAssignmentId: 'assignment-1',
+      campaignItemId,
+      campaignAssignmentId,
       trainingDocument: {
-        id: 'training-doc-1',
+        id: trainingDocumentId,
         title: 'Identifying Phishing Emails',
         contentType: 'MARKDOWN',
         contentRef: 'training/training-doc-1',
@@ -131,9 +153,7 @@ describe('Trainee training document routes', () => {
   });
 
   it('returns 401 when authentication is missing', async () => {
-    const response = await request(createApp()).get(
-      '/trainee/campaign-items/campaign-item-1/training-document',
-    );
+    const response = await request(createApp()).get(trainingDocumentPath());
 
     expect(response.status).toBe(401);
     expect(response.body).toHaveProperty('error', 'AUTH_REQUIRED');
@@ -147,18 +167,35 @@ describe('Trainee training document routes', () => {
     });
 
     const response = await request(createApp())
-      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .get(trainingDocumentPath())
       .set('Authorization', authHeader());
 
     expect(response.status).toBe(404);
     expect(response.body).toHaveProperty('error', 'TRAINING_DOCUMENT_NOT_FOUND');
   });
 
+  it('returns safe 404 when the campaign is not active', async () => {
+    prismaMock.campaignItem.findUnique.mockResolvedValue({
+      ...campaignItem,
+      campaign: {
+        status: 'ARCHIVED',
+      },
+    });
+
+    const response = await request(createApp())
+      .get(trainingDocumentPath())
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(404);
+    expect(response.body).toHaveProperty('error', 'TRAINING_DOCUMENT_NOT_FOUND');
+    expect(prismaMock.campaignAssignment.findFirst).not.toHaveBeenCalled();
+  });
+
   it('returns safe 404 when the trainee is not assigned to the campaign', async () => {
     prismaMock.campaignAssignment.findFirst.mockResolvedValue(null);
 
     const response = await request(createApp())
-      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .get(trainingDocumentPath())
       .set('Authorization', authHeader());
 
     expect(response.status).toBe(404);
@@ -175,7 +212,7 @@ describe('Trainee training document routes', () => {
     });
 
     const response = await request(createApp())
-      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .get(trainingDocumentPath())
       .set('Authorization', authHeader());
 
     expect(response.status).toBe(404);
@@ -190,20 +227,21 @@ describe('Trainee training document routes', () => {
     });
 
     const response = await request(createApp())
-      .post('/trainee/campaign-items/campaign-item-1/training-document/viewed')
+      .post(viewedPath())
       .set('Authorization', authHeader())
-      .send({ ignoredClientField: 'safe-to-ignore' });
+      .send();
 
     expect(response.status).toBe(201);
+    expect(prismaMock.interactionEvent.findFirst).not.toHaveBeenCalled();
     expect(prismaMock.interactionEvent.create).toHaveBeenCalledWith({
       data: {
-        traineeProfileId: 'trainee-profile-1',
-        campaignAssignmentId: 'assignment-1',
-        campaignItemId: 'campaign-item-1',
+        traineeProfileId,
+        campaignAssignmentId,
+        campaignItemId,
         eventType: 'TRAINING_VIEWED',
         targetType: 'TRAINING_DOCUMENT',
-        targetId: 'training-doc-1',
-        trainingDocumentId: 'training-doc-1',
+        targetId: trainingDocumentId,
+        trainingDocumentId,
       },
       select: {
         id: true,
@@ -214,14 +252,42 @@ describe('Trainee training document routes', () => {
     expect(prismaMock.interactionEvent.create.mock.calls[0][0].data).not.toHaveProperty('metadata');
     expect(response.body).toEqual({
       success: true,
-      campaignItemId: 'campaign-item-1',
-      trainingDocumentId: 'training-doc-1',
+      campaignItemId,
+      trainingDocumentId,
       event: {
         id: 'event-1',
         eventType: 'TRAINING_VIEWED',
         occurredAt: '2026-05-16T09:00:00.000Z',
       },
     });
+  });
+
+  it('keeps TRAINING_VIEWED repeatable across valid requests', async () => {
+    prismaMock.interactionEvent.create
+      .mockResolvedValueOnce({
+        id: 'event-1',
+        eventType: 'TRAINING_VIEWED',
+        occurredAt: new Date('2026-05-16T09:00:00.000Z'),
+      })
+      .mockResolvedValueOnce({
+        id: 'event-2',
+        eventType: 'TRAINING_VIEWED',
+        occurredAt: new Date('2026-05-16T09:01:00.000Z'),
+      });
+
+    const app = createApp();
+    const firstResponse = await request(app)
+      .post(viewedPath())
+      .set('Authorization', authHeader())
+      .send();
+    const secondResponse = await request(app)
+      .post(viewedPath())
+      .set('Authorization', authHeader())
+      .send();
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(201);
+    expect(prismaMock.interactionEvent.create).toHaveBeenCalledTimes(2);
   });
 
   it('records a TRAINING_COMPLETED interaction event with campaign context and no metadata', async () => {
@@ -232,19 +298,35 @@ describe('Trainee training document routes', () => {
     });
 
     const response = await request(createApp())
-      .post('/trainee/campaign-items/campaign-item-1/training-document/completed')
+      .post(completedPath())
       .set('Authorization', authHeader())
       .send();
 
     expect(response.status).toBe(201);
+    expect(prismaMock.interactionEvent.findFirst).toHaveBeenCalledWith({
+      where: {
+        traineeProfileId,
+        campaignAssignmentId,
+        campaignItemId,
+        eventType: 'TRAINING_COMPLETED',
+        targetType: 'TRAINING_DOCUMENT',
+        targetId: trainingDocumentId,
+        trainingDocumentId,
+      },
+      select: {
+        id: true,
+        eventType: true,
+        occurredAt: true,
+      },
+    });
     expect(prismaMock.interactionEvent.create.mock.calls[0][0].data).toMatchObject({
-      traineeProfileId: 'trainee-profile-1',
-      campaignAssignmentId: 'assignment-1',
-      campaignItemId: 'campaign-item-1',
+      traineeProfileId,
+      campaignAssignmentId,
+      campaignItemId,
       eventType: 'TRAINING_COMPLETED',
       targetType: 'TRAINING_DOCUMENT',
-      targetId: 'training-doc-1',
-      trainingDocumentId: 'training-doc-1',
+      targetId: trainingDocumentId,
+      trainingDocumentId,
     });
     expect(prismaMock.interactionEvent.create.mock.calls[0][0].data).not.toHaveProperty('metadata');
     expect(response.body.event).toEqual({
@@ -254,10 +336,62 @@ describe('Trainee training document routes', () => {
     });
   });
 
-  it('returns 400 for malformed campaign item ids', async () => {
+  it('returns success without creating duplicate TRAINING_COMPLETED events', async () => {
+    prismaMock.interactionEvent.create.mockResolvedValue({
+      id: 'event-2',
+      eventType: 'TRAINING_COMPLETED',
+      occurredAt: new Date('2026-05-16T09:05:00.000Z'),
+    });
+    prismaMock.interactionEvent.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 'event-2',
+      eventType: 'TRAINING_COMPLETED',
+      occurredAt: new Date('2026-05-16T09:05:00.000Z'),
+    });
+
+    const app = createApp();
+    const firstResponse = await request(app)
+      .post(completedPath())
+      .set('Authorization', authHeader())
+      .send();
+    const secondResponse = await request(app)
+      .post(completedPath())
+      .set('Authorization', authHeader())
+      .send();
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(201);
+    expect(prismaMock.interactionEvent.findFirst).toHaveBeenCalledTimes(2);
+    expect(prismaMock.interactionEvent.create).toHaveBeenCalledTimes(1);
+    expect(secondResponse.body.event).toEqual({
+      id: 'event-2',
+      eventType: 'TRAINING_COMPLETED',
+      occurredAt: '2026-05-16T09:05:00.000Z',
+    });
+  });
+
+  it.each([
+    ['GET training document', 'get', trainingDocumentPath('not-a-uuid')],
+    ['POST viewed', 'post', viewedPath('not-a-uuid')],
+    ['POST completed', 'post', completedPath('not-a-uuid')],
+  ] as const)('returns 400 for malformed campaign item ids on %s', async (_name, method, path) => {
     const response = await request(createApp())
-      .get('/trainee/campaign-items/%20%20/training-document')
-      .set('Authorization', authHeader());
+      [method](path)
+      .set('Authorization', authHeader())
+      .send();
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    expect(prismaMock.campaignItem.findUnique).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['viewed', viewedPath()],
+    ['completed', completedPath()],
+  ])('returns 400 when %s request bodies contain unknown fields', async (_name, path) => {
+    const response = await request(createApp())
+      .post(path)
+      .set('Authorization', authHeader())
+      .send({ clientTime: '2026-05-16T10:00:00.000Z' });
 
     expect(response.status).toBe(400);
     expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
@@ -269,9 +403,7 @@ describe('Trainee training document routes', () => {
     let response: request.Response | undefined;
 
     for (let index = 0; index <= 60; index += 1) {
-      response = await request(app)
-        .get('/trainee/campaign-items/campaign-item-1/training-document')
-        .set('Authorization', authHeader());
+      response = await request(app).get(trainingDocumentPath()).set('Authorization', authHeader());
     }
 
     expect(response?.status).toBe(429);

--- a/apps/backend/tests/unit/trainee-training.routes.test.ts
+++ b/apps/backend/tests/unit/trainee-training.routes.test.ts
@@ -1,0 +1,284 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../src/app.js';
+import { clearTraineeTrainingRateLimitStore } from '../../src/middleware/traineeTrainingRateLimit.js';
+import { generateAuthToken } from '../../src/services/auth-token.service.js';
+
+const prismaMock = vi.hoisted(() => ({
+  user: {
+    findUnique: vi.fn(),
+  },
+  traineeProfile: {
+    findFirst: vi.fn(),
+  },
+  campaignItem: {
+    findUnique: vi.fn(),
+  },
+  campaignAssignment: {
+    findFirst: vi.fn(),
+  },
+  interactionEvent: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
+
+const user = {
+  id: 'user-1',
+  firstName: 'Ava',
+  lastName: 'Trainee',
+  email: 'ava@example.com',
+  passwordHash: 'hashed-password',
+  userType: 'GENERAL_TRAINEE',
+  authStatus: 'ACTIVE',
+  createdAt: new Date('2026-05-16T08:00:00.000Z'),
+};
+
+const trainingDocument = {
+  id: 'training-doc-1',
+  createdByUserId: null,
+  title: 'Identifying Phishing Emails',
+  contentType: 'MARKDOWN',
+  contentRef: 'training/training-doc-1',
+  contentSummary: 'Common phishing indicators and safe response steps.',
+  estimatedReadTimeMinutes: 8,
+  difficultyLevel: 'BEGINNER',
+  status: 'AVAILABLE',
+  createdAt: new Date('2026-05-16T08:00:00.000Z'),
+  updatedAt: new Date('2026-05-16T08:00:00.000Z'),
+};
+
+const campaignItem = {
+  id: 'campaign-item-1',
+  campaignId: 'campaign-1',
+  parentGroupId: null,
+  itemType: 'COMPONENT',
+  componentType: 'TRAINING_DOCUMENT',
+  groupType: null,
+  completionRule: null,
+  title: 'Phishing Basics',
+  description: 'Read the basics before the quiz.',
+  position: 1,
+  difficultyLevel: 'BEGINNER',
+  isRequired: true,
+  availabilityStatus: 'AVAILABLE',
+  trainingDocumentId: trainingDocument.id,
+  quizId: null,
+  simulationId: null,
+  createdAt: new Date('2026-05-16T08:00:00.000Z'),
+  updatedAt: new Date('2026-05-16T08:00:00.000Z'),
+  trainingDocument,
+};
+
+const authHeader = () => `Bearer ${generateAuthToken(user.id).token}`;
+
+function mockAuthenticatedUser() {
+  prismaMock.user.findUnique.mockResolvedValue(user);
+}
+
+function mockTrainingAccess() {
+  prismaMock.traineeProfile.findFirst.mockResolvedValue({ id: 'trainee-profile-1' });
+  prismaMock.campaignItem.findUnique.mockResolvedValue(campaignItem);
+  prismaMock.campaignAssignment.findFirst.mockResolvedValue({ id: 'assignment-1' });
+}
+
+describe('Trainee training document routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearTraineeTrainingRateLimitStore();
+    mockAuthenticatedUser();
+    mockTrainingAccess();
+  });
+
+  it('gets a training document resolved through the campaign item', async () => {
+    const response = await request(createApp())
+      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.campaignItem.findUnique).toHaveBeenCalledWith({
+      where: {
+        id: 'campaign-item-1',
+      },
+      include: {
+        trainingDocument: true,
+      },
+    });
+    expect(response.body).toEqual({
+      campaignItemId: 'campaign-item-1',
+      campaignAssignmentId: 'assignment-1',
+      trainingDocument: {
+        id: 'training-doc-1',
+        title: 'Identifying Phishing Emails',
+        contentType: 'MARKDOWN',
+        contentRef: 'training/training-doc-1',
+        contentSummary: 'Common phishing indicators and safe response steps.',
+        estimatedReadTimeMinutes: 8,
+        difficultyLevel: 'BEGINNER',
+        status: 'AVAILABLE',
+      },
+      campaignItem: {
+        title: 'Phishing Basics',
+        description: 'Read the basics before the quiz.',
+        position: 1,
+        isRequired: true,
+        availabilityStatus: 'AVAILABLE',
+      },
+    });
+  });
+
+  it('returns 401 when authentication is missing', async () => {
+    const response = await request(createApp()).get(
+      '/trainee/campaign-items/campaign-item-1/training-document',
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.body).toHaveProperty('error', 'AUTH_REQUIRED');
+    expect(prismaMock.campaignItem.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns safe 404 when the campaign item is unavailable', async () => {
+    prismaMock.campaignItem.findUnique.mockResolvedValue({
+      ...campaignItem,
+      availabilityStatus: 'LOCKED',
+    });
+
+    const response = await request(createApp())
+      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(404);
+    expect(response.body).toHaveProperty('error', 'TRAINING_DOCUMENT_NOT_FOUND');
+  });
+
+  it('returns safe 404 when the trainee is not assigned to the campaign', async () => {
+    prismaMock.campaignAssignment.findFirst.mockResolvedValue(null);
+
+    const response = await request(createApp())
+      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(404);
+    expect(response.body).toHaveProperty('error', 'TRAINING_DOCUMENT_NOT_FOUND');
+  });
+
+  it('returns safe 404 when the campaign item is not a training document component', async () => {
+    prismaMock.campaignItem.findUnique.mockResolvedValue({
+      ...campaignItem,
+      componentType: 'QUIZ',
+      trainingDocument: null,
+      trainingDocumentId: null,
+      quizId: 'quiz-1',
+    });
+
+    const response = await request(createApp())
+      .get('/trainee/campaign-items/campaign-item-1/training-document')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(404);
+    expect(response.body).toHaveProperty('error', 'TRAINING_DOCUMENT_NOT_FOUND');
+  });
+
+  it('records a TRAINING_VIEWED interaction event with campaign context and no metadata', async () => {
+    prismaMock.interactionEvent.create.mockResolvedValue({
+      id: 'event-1',
+      eventType: 'TRAINING_VIEWED',
+      occurredAt: new Date('2026-05-16T09:00:00.000Z'),
+    });
+
+    const response = await request(createApp())
+      .post('/trainee/campaign-items/campaign-item-1/training-document/viewed')
+      .set('Authorization', authHeader())
+      .send({ ignoredClientField: 'safe-to-ignore' });
+
+    expect(response.status).toBe(201);
+    expect(prismaMock.interactionEvent.create).toHaveBeenCalledWith({
+      data: {
+        traineeProfileId: 'trainee-profile-1',
+        campaignAssignmentId: 'assignment-1',
+        campaignItemId: 'campaign-item-1',
+        eventType: 'TRAINING_VIEWED',
+        targetType: 'TRAINING_DOCUMENT',
+        targetId: 'training-doc-1',
+        trainingDocumentId: 'training-doc-1',
+      },
+      select: {
+        id: true,
+        eventType: true,
+        occurredAt: true,
+      },
+    });
+    expect(prismaMock.interactionEvent.create.mock.calls[0][0].data).not.toHaveProperty('metadata');
+    expect(response.body).toEqual({
+      success: true,
+      campaignItemId: 'campaign-item-1',
+      trainingDocumentId: 'training-doc-1',
+      event: {
+        id: 'event-1',
+        eventType: 'TRAINING_VIEWED',
+        occurredAt: '2026-05-16T09:00:00.000Z',
+      },
+    });
+  });
+
+  it('records a TRAINING_COMPLETED interaction event with campaign context and no metadata', async () => {
+    prismaMock.interactionEvent.create.mockResolvedValue({
+      id: 'event-2',
+      eventType: 'TRAINING_COMPLETED',
+      occurredAt: new Date('2026-05-16T09:05:00.000Z'),
+    });
+
+    const response = await request(createApp())
+      .post('/trainee/campaign-items/campaign-item-1/training-document/completed')
+      .set('Authorization', authHeader())
+      .send();
+
+    expect(response.status).toBe(201);
+    expect(prismaMock.interactionEvent.create.mock.calls[0][0].data).toMatchObject({
+      traineeProfileId: 'trainee-profile-1',
+      campaignAssignmentId: 'assignment-1',
+      campaignItemId: 'campaign-item-1',
+      eventType: 'TRAINING_COMPLETED',
+      targetType: 'TRAINING_DOCUMENT',
+      targetId: 'training-doc-1',
+      trainingDocumentId: 'training-doc-1',
+    });
+    expect(prismaMock.interactionEvent.create.mock.calls[0][0].data).not.toHaveProperty('metadata');
+    expect(response.body.event).toEqual({
+      id: 'event-2',
+      eventType: 'TRAINING_COMPLETED',
+      occurredAt: '2026-05-16T09:05:00.000Z',
+    });
+  });
+
+  it('returns 400 for malformed campaign item ids', async () => {
+    const response = await request(createApp())
+      .get('/trainee/campaign-items/%20%20/training-document')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    expect(prismaMock.campaignItem.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when training requests exceed the route rate limit', async () => {
+    const app = createApp();
+    let response: request.Response | undefined;
+
+    for (let index = 0; index <= 60; index += 1) {
+      response = await request(app)
+        .get('/trainee/campaign-items/campaign-item-1/training-document')
+        .set('Authorization', authHeader());
+    }
+
+    expect(response?.status).toBe(429);
+    expect(response?.body).toEqual({
+      error: 'TRAINING_RATE_LIMITED',
+      message: 'Too many training requests. Please try again later.',
+    });
+    expect(response?.headers).toHaveProperty('retry-after');
+  });
+});

--- a/docs/demo1/API.md
+++ b/docs/demo1/API.md
@@ -211,42 +211,82 @@ Component groups support one level of grouping for Demo 1. API responses should 
 
 - **Purpose**: Retrieves the training document placed at a specific trainee-accessible campaign item.
 - **Expected Request Data**: URL Param `campaignItemId`.
+- **Access**: Requires authentication. The authenticated trainee must have an active campaign assignment for the campaign that contains the available campaign item.
 - **Expected Response Data**:
 
 ```json
 {
-  "id": "train-001",
-  "campaignAssignmentId": "assignment-001",
   "campaignItemId": "item-001",
-  "title": "Identifying Phishing Emails",
-  "contentType": "MARKDOWN",
-  "contentRef": "training/train-001",
-  "contentSummary": "Common phishing indicators and safe response steps.",
-  "estimatedReadTimeMinutes": 8,
-  "difficultyLevel": "BEGINNER",
-  "status": "AVAILABLE"
+  "campaignAssignmentId": "assignment-001",
+  "trainingDocument": {
+    "id": "train-001",
+    "title": "Identifying Phishing Emails",
+    "contentType": "MARKDOWN",
+    "contentRef": "training/train-001",
+    "contentSummary": "Common phishing indicators and safe response steps.",
+    "estimatedReadTimeMinutes": 8,
+    "difficultyLevel": "BEGINNER",
+    "status": "AVAILABLE"
+  },
+  "campaignItem": {
+    "title": "Identifying Phishing Emails",
+    "description": "Read the guide before completing the quiz.",
+    "position": 1,
+    "isRequired": true,
+    "availabilityStatus": "AVAILABLE"
+  }
 }
 ```
 
-The backend should resolve access through:
+The backend resolves access through the campaign item placement:
 
 `Trainee -> CampaignAssignment -> Campaign -> CampaignItem -> TrainingDocumentComponent -> TrainingDocument`
+
+In the current Prisma implementation, the conceptual `TrainingDocumentComponent` is represented by a `CampaignItem` with `itemType = COMPONENT`, `componentType = TRAINING_DOCUMENT`, and `trainingDocumentId`.
+
+Training documents are reusable content records. They are not owned by learning paths or training modules, and this endpoint does not require a linked quiz. Missing, unavailable, non-training, or unauthorised campaign items should return a safe `404` so the API does not leak content existence. The endpoint may return `429` if the trainee training route rate limit is exceeded.
 
 ### `POST /trainee/campaign-items/:campaignItemId/training-document/viewed`
 
 - **Purpose**: Records a `TRAINING_VIEWED` interaction event for the campaign item.
-- **Expected Request Data**:
-  - `campaignAssignmentId` (string, optional)
+- **Expected Request Data**: URL Param `campaignItemId`. No request body is required.
 - **Expected Response Data**:
-  - `201 Created`: `{ "success": true, "eventType": "TRAINING_VIEWED" }`
+
+```json
+{
+  "success": true,
+  "campaignItemId": "item-001",
+  "trainingDocumentId": "train-001",
+  "event": {
+    "id": "event-001",
+    "eventType": "TRAINING_VIEWED",
+    "occurredAt": "2026-05-16T09:00:00.000Z"
+  }
+}
+```
+
+The backend reuses the same campaign assignment and item availability checks as the detail endpoint, then records a lightweight `InteractionEvent` with `targetType = TRAINING_DOCUMENT`, `targetId = trainingDocumentId`, `campaignAssignmentId`, and `campaignItemId`. Interaction event metadata should be omitted or kept minimal and must not contain sensitive values. No `TrainingProgress` record is created.
 
 ### `POST /trainee/campaign-items/:campaignItemId/training-document/completed`
 
 - **Purpose**: Records a `TRAINING_COMPLETED` interaction event for the campaign item.
-- **Expected Request Data**:
-  - `campaignAssignmentId` (string, optional)
+- **Expected Request Data**: URL Param `campaignItemId`. No request body is required.
 - **Expected Response Data**:
-  - `201 Created`: `{ "success": true, "eventType": "TRAINING_COMPLETED" }`
+
+```json
+{
+  "success": true,
+  "campaignItemId": "item-001",
+  "trainingDocumentId": "train-001",
+  "event": {
+    "id": "event-002",
+    "eventType": "TRAINING_COMPLETED",
+    "occurredAt": "2026-05-16T09:05:00.000Z"
+  }
+}
+```
+
+The backend records a lightweight `InteractionEvent` with `targetType = TRAINING_DOCUMENT`, `targetId = trainingDocumentId`, `campaignAssignmentId`, and `campaignItemId`. Missing auth returns `401`; malformed `campaignItemId` returns `400`; missing, unavailable, non-training, or unauthorised content returns a safe `404`; route rate limits may return `429`; unexpected failures return a safe `500`.
 
 ## UC-03: Complete Quiz Flow Contracts
 

--- a/packages/shared/src/training.ts
+++ b/packages/shared/src/training.ts
@@ -3,7 +3,6 @@ import type { SuccessResponseDto } from './common.js';
 import type {
   getTrainingDocumentRequestParamsSchema,
   recordTrainingInteractionRequestParamsSchema,
-  recordTrainingInteractionRequestSchema,
 } from './validation/training.schemas.js';
 
 export type DifficultyLevelDto = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED' | 'ADAPTIVE';
@@ -14,33 +13,14 @@ export type TrainingDocumentStatusDto = 'DRAFT' | 'AVAILABLE' | 'UNAVAILABLE' | 
 
 export type TrainingInteractionEventTypeDto = 'TRAINING_VIEWED' | 'TRAINING_COMPLETED';
 
-export interface GetAssignedTrainingRequestParamsDto {}
+type TrainingCampaignItemAvailabilityStatusDto =
+  | 'AVAILABLE'
+  | 'LOCKED'
+  | 'UNAVAILABLE'
+  | 'ARCHIVED';
 
-export interface TrainingDocumentSummaryDto {
+export interface TrainingDocumentContentDto {
   id: string;
-  campaignItemId: string;
-  campaignAssignmentId?: string | null;
-  title: string;
-  description?: string | null;
-  contentSummary?: string | null;
-  estimatedReadTimeMinutes?: number | null;
-  difficultyLevel: DifficultyLevelDto;
-  status: TrainingDocumentStatusDto;
-  availabilityStatus: 'AVAILABLE' | 'LOCKED' | 'UNAVAILABLE' | 'ARCHIVED';
-}
-
-export interface GetAssignedTrainingResponseDto {
-  trainingDocuments: TrainingDocumentSummaryDto[];
-}
-
-export type GetTrainingDocumentRequestParamsDto = z.infer<
-  typeof getTrainingDocumentRequestParamsSchema
->;
-
-export interface TrainingDocumentDetailDto {
-  id: string;
-  campaignItemId: string;
-  campaignAssignmentId?: string | null;
   title: string;
   contentType: TrainingContentTypeDto;
   contentRef: string;
@@ -50,16 +30,37 @@ export interface TrainingDocumentDetailDto {
   status: TrainingDocumentStatusDto;
 }
 
-export interface GetTrainingDocumentResponseDto extends TrainingDocumentDetailDto {}
+export interface TrainingCampaignItemContextDto {
+  title: string;
+  description?: string | null;
+  position: number;
+  isRequired: boolean;
+  availabilityStatus: TrainingCampaignItemAvailabilityStatusDto;
+}
+
+export type GetTrainingDocumentRequestParamsDto = z.infer<
+  typeof getTrainingDocumentRequestParamsSchema
+>;
+
+export interface GetTrainingDocumentResponseDto {
+  campaignItemId: string;
+  campaignAssignmentId?: string | null;
+  trainingDocument: TrainingDocumentContentDto;
+  campaignItem: TrainingCampaignItemContextDto;
+}
 
 export type RecordTrainingInteractionRequestParamsDto = z.infer<
   typeof recordTrainingInteractionRequestParamsSchema
 >;
 
-export type RecordTrainingInteractionRequestDto = z.infer<
-  typeof recordTrainingInteractionRequestSchema
->;
+export interface RecordTrainingInteractionRequestDto {}
 
 export interface RecordTrainingInteractionResponseDto extends SuccessResponseDto {
-  eventType: TrainingInteractionEventTypeDto;
+  campaignItemId: string;
+  trainingDocumentId: string;
+  event: {
+    id: string;
+    eventType: TrainingInteractionEventTypeDto;
+    occurredAt: string;
+  };
 }

--- a/packages/shared/src/validation/training.schemas.test.ts
+++ b/packages/shared/src/validation/training.schemas.test.ts
@@ -2,20 +2,17 @@ import { describe, expect, it } from 'vitest';
 import { recordTrainingInteractionRequestSchema } from './training.schemas.js';
 
 describe('training validation schemas', () => {
-  it('accepts training interaction events with campaign context', () => {
-    const result = recordTrainingInteractionRequestSchema.safeParse({
-      eventType: 'TRAINING_VIEWED',
-      campaignAssignmentId: 'assignment-1',
-    });
+  it('accepts empty training interaction payloads', () => {
+    const result = recordTrainingInteractionRequestSchema.safeParse({});
 
     expect(result.success).toBe(true);
   });
 
-  it('rejects interaction payloads without an event type', () => {
+  it('ignores unknown safe fields in training interaction payloads', () => {
     const result = recordTrainingInteractionRequestSchema.safeParse({
-      campaignAssignmentId: 'assignment-1',
+      clientTime: '2026-05-16T10:00:00.000Z',
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/shared/src/validation/training.schemas.test.ts
+++ b/packages/shared/src/validation/training.schemas.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { recordTrainingInteractionRequestSchema } from './training.schemas.js';
+import {
+  getTrainingDocumentRequestParamsSchema,
+  recordTrainingInteractionRequestSchema,
+} from './training.schemas.js';
 
 describe('training validation schemas', () => {
   it('accepts empty training interaction payloads', () => {
@@ -8,11 +11,33 @@ describe('training validation schemas', () => {
     expect(result.success).toBe(true);
   });
 
-  it('ignores unknown safe fields in training interaction payloads', () => {
+  it('accepts omitted training interaction payloads', () => {
+    const result = recordTrainingInteractionRequestSchema.safeParse(undefined);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown fields in training interaction payloads', () => {
     const result = recordTrainingInteractionRequestSchema.safeParse({
       clientTime: '2026-05-16T10:00:00.000Z',
     });
 
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts UUID campaign item ids', () => {
+    const result = getTrainingDocumentRequestParamsSchema.safeParse({
+      campaignItemId: '11111111-1111-4111-8111-111111111111',
+    });
+
     expect(result.success).toBe(true);
+  });
+
+  it('rejects non-UUID campaign item ids', () => {
+    const result = getTrainingDocumentRequestParamsSchema.safeParse({
+      campaignItemId: 'not-a-uuid',
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/shared/src/validation/training.schemas.ts
+++ b/packages/shared/src/validation/training.schemas.ts
@@ -1,12 +1,16 @@
 import { z } from 'zod';
-import { idParamSchema } from './common.schemas.js';
 
 export const trainingInteractionEventTypeSchema = z.enum(['TRAINING_VIEWED', 'TRAINING_COMPLETED']);
 
+const campaignItemIdParamSchema = z.string().trim().uuid();
+
 export const getTrainingDocumentRequestParamsSchema = z.object({
-  campaignItemId: idParamSchema,
+  campaignItemId: campaignItemIdParamSchema,
 });
 
 export const recordTrainingInteractionRequestParamsSchema = getTrainingDocumentRequestParamsSchema;
 
-export const recordTrainingInteractionRequestSchema = z.object({}).passthrough();
+export const recordTrainingInteractionRequestSchema = z.preprocess(
+  (value) => value ?? {},
+  z.object({}).strict(),
+);

--- a/packages/shared/src/validation/training.schemas.ts
+++ b/packages/shared/src/validation/training.schemas.ts
@@ -9,7 +9,4 @@ export const getTrainingDocumentRequestParamsSchema = z.object({
 
 export const recordTrainingInteractionRequestParamsSchema = getTrainingDocumentRequestParamsSchema;
 
-export const recordTrainingInteractionRequestSchema = z.object({
-  eventType: trainingInteractionEventTypeSchema,
-  campaignAssignmentId: idParamSchema.optional(),
-});
+export const recordTrainingInteractionRequestSchema = z.object({}).passthrough();


### PR DESCRIPTION
## Summary

Implements the revised UC-02 backend training document API using the new modular campaign item domain model.

This replaces the old training-document assignment/progress approach with campaign item-based trainee endpoints:

- `GET /trainee/campaign-items/:campaignItemId/training-document`
- `POST /trainee/campaign-items/:campaignItemId/training-document/viewed`
- `POST /trainee/campaign-items/:campaignItemId/training-document/completed`

The implementation resolves training access through the authenticated trainee’s campaign assignment and the campaign item placement, then records viewed/completed actions as lightweight `InteractionEvent` records.

## Linked Issue

Closes #80 

## Type of change

- [x] Feature
- [ ] Bug Fix
- [x] Documentation
- [x] Chore/Maintenance

## What Changed

### Campaign item-based training API

Added the revised UC-02 trainee training document routes:

- `GET /trainee/campaign-items/:campaignItemId/training-document`
- `POST /trainee/campaign-items/:campaignItemId/training-document/viewed`
- `POST /trainee/campaign-items/:campaignItemId/training-document/completed`

The API now resolves the training document through campaign item context instead of old training assignment/progress models.

### Domain model alignment

The implementation aligns with the revised modular Demo 1 domain model:

- uses `CampaignItem`
- uses `TrainingDocument`
- uses `CampaignAssignment`
- uses trainee profile access
- records `InteractionEvent`
- treats `TrainingDocument` as reusable content
- does not require a fixed training document to quiz relationship

The implementation intentionally does **not** depend on:

- `TrainingProgress`
- `LearningPath`
- `TrainingModule`
- `GeneralLearningAccess`
- `TrainingDocument.quizzes`
- old `/training/assigned`
- old `/training/:trainingId`
- old `/training/:trainingId/progress`

### Access control

Training document access is checked through:

- authenticated trainee profile
- campaign assignment
- campaign item campaign placement
- campaign item availability
- training document availability

Missing, unauthorised, wrong-type, unavailable, or inaccessible campaign items return safe errors.

### Interaction events

The viewed/completed endpoints create interaction events:

- `TRAINING_VIEWED`
- `TRAINING_COMPLETED`

The events include campaign context:

- trainee profile
- campaign assignment
- campaign item
- target type `TRAINING_DOCUMENT`
- target id as the training document id

No sensitive metadata is stored.

### Security and validation

Added/used:

- authentication on trainee training routes
- route param validation for `campaignItemId`
- safe 400 errors for malformed IDs
- safe 401 for missing auth
- safe 404 for unavailable or unauthorised content
- route-level rate limiting
- safe 429 rate limit response

### Shared DTOs and validation

Updated shared training DTOs and validation schemas to use the campaign item-based API shape.

### Documentation

Updated `docs/demo1/API.md` to document the modular campaign item training document endpoints and remove the old TrainingProgress-based API assumptions.

## Testing

Ran locally:

```bash
pnpm --filter @insightful-phish/backend typecheck
pnpm --filter @insightful-phish/backend test:unit
pnpm --filter @insightful-phish/backend test