### PR TITLE
Chore/swagger demo1 api/adriano

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -561,6 +561,28 @@ In that case, start PostgreSQL with:
 docker compose up -d
 ```
 
+### Swagger UI
+
+When the backend is running, Swagger UI is available at:
+
+```txt
+http://localhost:4000/api-docs
+```
+
+Start the backend with:
+
+```bash
+pnpm --filter @insightful-phish/backend dev
+```
+
+Protected endpoints in Swagger require a Bearer token. Use the Authorize button and enter:
+
+```txt
+Bearer <token>
+```
+
+The Swagger docs cover the Demo 1 backend routes currently active on dev. Planned routes that are not mounted on dev, such as future quiz or campaign endpoints, are intentionally not documented yet.
+
 ---
 
 ## 11. Run the frontend

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -74,6 +74,14 @@ function arrayOf(schema: OpenApiSchema): OpenApiSchema {
   };
 }
 
+function uuidArray(example: string[]): OpenApiSchema {
+  return {
+    type: 'array',
+    items: uuidString(example[0] ?? '11111111-1111-1111-1111-111111111111'),
+    example,
+  };
+}
+
 function errorResponseSchema(
   baseSchemaName: string,
   errorCode: string,
@@ -478,9 +486,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'Bearer',
             },
             expiresAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2026-05-12T20:44:54.000Z',
+              ...dateTimeString('2026-05-12T20:44:54.000Z'),
             },
           },
         },
@@ -616,14 +622,10 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               ...trueSuccessProperty(),
             },
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              example: '11111111-1111-4111-8111-111111111111',
+              ...uuidString('11111111-1111-4111-8111-111111111111'),
             },
             trainingDocumentId: {
-              type: 'string',
-              format: 'uuid',
-              example: '33333333-3333-4333-8333-333333333333',
+              ...uuidString('33333333-3333-4333-8333-333333333333'),
             },
             event: {
               $ref: '#/components/schemas/TrainingInteractionEvent',
@@ -657,21 +659,13 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           ],
           properties: {
             id: {
-              type: 'string',
-              format: 'uuid',
-              example: '11111111-1111-1111-1111-111111111111',
+              ...uuidString('11111111-1111-1111-1111-111111111111'),
             },
             campaignAssignmentId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '44444444-4444-4444-4444-444444444444',
+              ...nullableUuidString('44444444-4444-4444-4444-444444444444'),
             },
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '22222222-2222-2222-2222-222222222222',
+              ...nullableUuidString('22222222-2222-2222-2222-222222222222'),
             },
             inboxId: {
               type: 'string',
@@ -696,9 +690,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'Please review this important security notice.',
             },
             receivedAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2026-05-16T09:00:00.000Z',
+              ...dateTimeString(),
             },
             difficultyLevel: {
               $ref: '#/components/schemas/DifficultyLevel',
@@ -729,21 +721,13 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           ],
           properties: {
             id: {
-              type: 'string',
-              format: 'uuid',
-              example: '11111111-1111-1111-1111-111111111111',
+              ...uuidString('11111111-1111-1111-1111-111111111111'),
             },
             campaignAssignmentId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '44444444-4444-4444-4444-444444444444',
+              ...nullableUuidString('44444444-4444-4444-4444-444444444444'),
             },
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '22222222-2222-2222-2222-222222222222',
+              ...nullableUuidString('22222222-2222-2222-2222-222222222222'),
             },
             inboxId: {
               type: 'string',
@@ -781,9 +765,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: false,
             },
             receivedAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2026-05-16T09:00:00.000Z',
+              ...dateTimeString(),
             },
             difficultyLevel: {
               $ref: '#/components/schemas/DifficultyLevel',
@@ -805,9 +787,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['success', 'eventType'],
           properties: {
             success: {
-              type: 'boolean',
-              enum: [true],
-              example: true,
+              ...trueSuccessProperty(),
             },
             eventType: {
               $ref: '#/components/schemas/SimulatedEmailInteractionEventType',
@@ -823,12 +803,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               $ref: '#/components/schemas/EmailClassification',
             },
             selectedRedFlagIds: {
-              type: 'array',
-              items: {
-                type: 'string',
-                format: 'uuid',
-              },
-              example: ['33333333-3333-3333-3333-333333333333'],
+              ...uuidArray(['33333333-3333-3333-3333-333333333333']),
             },
             freeTextReason: {
               type: 'string',
@@ -842,9 +817,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['id', 'redFlagType', 'label', 'severity'],
           properties: {
             id: {
-              type: 'string',
-              format: 'uuid',
-              example: '33333333-3333-3333-3333-333333333333',
+              ...uuidString('33333333-3333-3333-3333-333333333333'),
             },
             redFlagType: {
               $ref: '#/components/schemas/EmailRedFlagType',
@@ -868,9 +841,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['success', 'responseId', 'selectedClassification', 'isCorrect'],
           properties: {
             success: {
-              type: 'boolean',
-              enum: [true],
-              example: true,
+              ...trueSuccessProperty(),
             },
             responseId: {
               type: 'string',
@@ -889,10 +860,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'Great job! You correctly identified the email.',
             },
             redFlags: {
-              type: 'array',
-              items: {
-                $ref: '#/components/schemas/EmailRedFlag',
-              },
+              ...arrayOf(schemaRef('EmailRedFlag')),
             },
           },
         },
@@ -903,16 +871,10 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           type: 'object',
           properties: {
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '11111111-1111-1111-1111-111111111111',
+              ...nullableUuidString('11111111-1111-1111-1111-111111111111'),
             },
             campaignAssignmentId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '44444444-4444-4444-4444-444444444444',
+              ...nullableUuidString('44444444-4444-4444-4444-444444444444'),
             },
           },
         },
@@ -921,9 +883,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['id', 'label', 'text', 'position'],
           properties: {
             id: {
-              type: 'string',
-              format: 'uuid',
-              example: '44444444-4444-4444-4444-444444444444',
+              ...uuidString('44444444-4444-4444-4444-444444444444'),
             },
             label: {
               type: 'string',
@@ -944,9 +904,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['id', 'prompt', 'questionType', 'position', 'points', 'options'],
           properties: {
             id: {
-              type: 'string',
-              format: 'uuid',
-              example: '33333333-3333-3333-3333-333333333333',
+              ...uuidString('33333333-3333-3333-3333-333333333333'),
             },
             prompt: {
               type: 'string',
@@ -964,10 +922,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 5,
             },
             options: {
-              type: 'array',
-              items: {
-                $ref: '#/components/schemas/QuizOptionForTrainee',
-              },
+              ...arrayOf(schemaRef('QuizOptionForTrainee')),
             },
           },
         },
@@ -987,10 +942,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'quiz-1',
             },
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '11111111-1111-1111-1111-111111111111',
+              ...nullableUuidString('11111111-1111-1111-1111-111111111111'),
             },
             campaignAssignmentId: {
               type: 'string',
@@ -1019,10 +971,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               $ref: '#/components/schemas/QuizStatus',
             },
             questions: {
-              type: 'array',
-              items: {
-                $ref: '#/components/schemas/QuizQuestionForTrainee',
-              },
+              ...arrayOf(schemaRef('QuizQuestionForTrainee')),
             },
           },
         },
@@ -1031,9 +980,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['attemptId', 'traineeProfileId', 'quizId', 'status', 'startedAt'],
           properties: {
             attemptId: {
-              type: 'string',
-              format: 'uuid',
-              example: '22222222-2222-2222-2222-222222222222',
+              ...uuidString('22222222-2222-2222-2222-222222222222'),
             },
             traineeProfileId: {
               type: 'string',
@@ -1049,10 +996,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'assign-1',
             },
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '11111111-1111-1111-1111-111111111111',
+              ...nullableUuidString('11111111-1111-1111-1111-111111111111'),
             },
             status: {
               type: 'string',
@@ -1060,9 +1004,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'IN_PROGRESS',
             },
             startedAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2026-05-16T09:00:00.000Z',
+              ...dateTimeString(),
             },
           },
         },
@@ -1079,18 +1021,11 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           additionalProperties: false,
           properties: {
             questionId: {
-              type: 'string',
-              format: 'uuid',
-              example: '33333333-3333-3333-3333-333333333333',
+              ...uuidString('33333333-3333-3333-3333-333333333333'),
             },
             selectedOptionIds: {
-              type: 'array',
+              ...uuidArray(['44444444-4444-4444-4444-444444444444']),
               minItems: 1,
-              items: {
-                type: 'string',
-                format: 'uuid',
-              },
-              example: ['44444444-4444-4444-4444-444444444444'],
             },
             responseSummary: {
               type: 'string',
@@ -1110,11 +1045,8 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           additionalProperties: false,
           properties: {
             answers: {
-              type: 'array',
+              ...arrayOf(schemaRef('AttemptAnswer')),
               minItems: 1,
-              items: {
-                $ref: '#/components/schemas/AttemptAnswer',
-              },
             },
           },
         },
@@ -1123,14 +1055,10 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['success', 'attemptId', 'status'],
           properties: {
             success: {
-              type: 'boolean',
-              enum: [true],
-              example: true,
+              ...trueSuccessProperty(),
             },
             attemptId: {
-              type: 'string',
-              format: 'uuid',
-              example: '22222222-2222-2222-2222-222222222222',
+              ...uuidString('22222222-2222-2222-2222-222222222222'),
             },
             status: {
               type: 'string',
@@ -1144,9 +1072,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['optionId', 'label', 'text', 'isCorrect'],
           properties: {
             optionId: {
-              type: 'string',
-              format: 'uuid',
-              example: '44444444-4444-4444-4444-444444444444',
+              ...uuidString('44444444-4444-4444-4444-444444444444'),
             },
             label: {
               type: 'string',
@@ -1172,9 +1098,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['questionId', 'selectedOptions'],
           properties: {
             questionId: {
-              type: 'string',
-              format: 'uuid',
-              example: '33333333-3333-3333-3333-333333333333',
+              ...uuidString('33333333-3333-3333-3333-333333333333'),
             },
             isCorrect: {
               type: 'boolean',
@@ -1192,10 +1116,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'Correct!',
             },
             selectedOptions: {
-              type: 'array',
-              items: {
-                $ref: '#/components/schemas/QuizResultOption',
-              },
+              ...arrayOf(schemaRef('QuizResultOption')),
             },
           },
         },
@@ -1204,9 +1125,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['attemptId', 'quizId', 'scorePercentage', 'passed', 'answers'],
           properties: {
             attemptId: {
-              type: 'string',
-              format: 'uuid',
-              example: '22222222-2222-2222-2222-222222222222',
+              ...uuidString('22222222-2222-2222-2222-222222222222'),
             },
             quizId: {
               type: 'string',
@@ -1218,10 +1137,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'assign-1',
             },
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '11111111-1111-1111-1111-111111111111',
+              ...nullableUuidString('11111111-1111-1111-1111-111111111111'),
             },
             scorePercentage: {
               type: 'integer',
@@ -1239,10 +1155,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'Well done',
             },
             answers: {
-              type: 'array',
-              items: {
-                $ref: '#/components/schemas/QuizResultQuestion',
-              },
+              ...arrayOf(schemaRef('QuizResultQuestion')),
             },
           },
         },

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -2,6 +2,107 @@ import swaggerJsdoc from 'swagger-jsdoc';
 import { APP_NAME } from '@insightful-phish/shared';
 import { env } from './env.js';
 
+type OpenApiSchema = Record<string, unknown>;
+
+function schemaRef(name: string): OpenApiSchema {
+  return {
+    $ref: `#/components/schemas/${name}`,
+  };
+}
+
+function jsonContent(schema: OpenApiSchema) {
+  return {
+    content: {
+      'application/json': {
+        schema,
+      },
+    },
+  };
+}
+
+function enumString(values: string[], example: string): OpenApiSchema {
+  return {
+    type: 'string',
+    enum: values,
+    example,
+  };
+}
+
+function uuidString(example: string): OpenApiSchema {
+  return {
+    type: 'string',
+    format: 'uuid',
+    example,
+  };
+}
+
+function nullableUuidString(example: string): OpenApiSchema {
+  return {
+    ...uuidString(example),
+    nullable: true,
+  };
+}
+
+function dateTimeString(example = '2026-05-16T09:00:00.000Z'): OpenApiSchema {
+  return {
+    type: 'string',
+    format: 'date-time',
+    example,
+  };
+}
+
+function nullableString(example: string): OpenApiSchema {
+  return {
+    type: 'string',
+    nullable: true,
+    example,
+  };
+}
+
+function trueSuccessProperty(): OpenApiSchema {
+  return {
+    type: 'boolean',
+    enum: [true],
+    example: true,
+  };
+}
+
+function arrayOf(schema: OpenApiSchema): OpenApiSchema {
+  return {
+    type: 'array',
+    items: schema,
+  };
+}
+
+function errorResponseSchema(
+  baseSchemaName: string,
+  errorCode: string,
+  messageExample: string,
+): OpenApiSchema {
+  return {
+    allOf: [
+      schemaRef(baseSchemaName),
+      {
+        type: 'object',
+        properties: {
+          error: enumString([errorCode], errorCode),
+          message: {
+            type: 'string',
+            example: messageExample,
+          },
+        },
+      },
+    ],
+  };
+}
+
+function responseComponent(description: string, schemaName: string) {
+  return {
+    description,
+    ...jsonContent(schemaRef(schemaName)),
+  };
+}
+
 const options: swaggerJsdoc.Options = {
   definition: {
     openapi: '3.0.0',
@@ -72,9 +173,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'connected',
             },
             timestamp: {
-              type: 'string',
-              format: 'date-time',
-              example: '2026-05-11T20:44:54.000Z',
+              ...dateTimeString('2026-05-11T20:44:54.000Z'),
             },
           },
         },
@@ -135,146 +234,48 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           ],
         },
         RateLimitErrorResponse: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ApiErrorResponse',
-            },
-            {
-              type: 'object',
-              properties: {
-                error: {
-                  type: 'string',
-                  example: 'TOO_MANY_REQUESTS',
-                },
-                message: {
-                  type: 'string',
-                  example: 'Too many requests from this IP, please try again after 15 minutes',
-                },
-              },
-            },
-          ],
+          ...errorResponseSchema(
+            'ApiErrorResponse',
+            'TOO_MANY_REQUESTS',
+            'Too many requests from this IP, please try again after 15 minutes',
+          ),
         },
-        AuthEmailExistsErrorResponse: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ApiErrorResponse',
-            },
-            {
-              type: 'object',
-              properties: {
-                error: {
-                  type: 'string',
-                  enum: ['AUTH_EMAIL_EXISTS'],
-                  example: 'AUTH_EMAIL_EXISTS',
-                },
-                message: {
-                  type: 'string',
-                  example: 'A user with the provided email already exists',
-                },
-              },
-            },
-          ],
-        },
-        AuthInvalidErrorResponse: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ApiErrorResponse',
-            },
-            {
-              type: 'object',
-              properties: {
-                error: {
-                  type: 'string',
-                  enum: ['AUTH_INVALID'],
-                  example: 'AUTH_INVALID',
-                },
-                message: {
-                  type: 'string',
-                  example: 'Invalid email or password',
-                },
-              },
-            },
-          ],
-        },
-        AuthRateLimitErrorResponse: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/RateLimitErrorResponse',
-            },
-            {
-              type: 'object',
-              properties: {
-                error: {
-                  type: 'string',
-                  enum: ['AUTH_RATE_LIMITED'],
-                  example: 'AUTH_RATE_LIMITED',
-                },
-                message: {
-                  type: 'string',
-                  example: 'Too many authentication requests. Please try again later.',
-                },
-              },
-            },
-          ],
-        },
-        TrainingDocumentNotFoundErrorResponse: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/ApiErrorResponse',
-            },
-            {
-              type: 'object',
-              properties: {
-                error: {
-                  type: 'string',
-                  enum: ['TRAINING_DOCUMENT_NOT_FOUND'],
-                  example: 'TRAINING_DOCUMENT_NOT_FOUND',
-                },
-                message: {
-                  type: 'string',
-                  example: 'Training document was not found',
-                },
-              },
-            },
-          ],
-        },
-        TrainingRateLimitErrorResponse: {
-          allOf: [
-            {
-              $ref: '#/components/schemas/RateLimitErrorResponse',
-            },
-            {
-              type: 'object',
-              properties: {
-                error: {
-                  type: 'string',
-                  enum: ['TRAINING_RATE_LIMITED'],
-                  example: 'TRAINING_RATE_LIMITED',
-                },
-                message: {
-                  type: 'string',
-                  example: 'Too many training requests. Please try again later.',
-                },
-              },
-            },
-          ],
-        },
+        AuthEmailExistsErrorResponse: errorResponseSchema(
+          'ApiErrorResponse',
+          'AUTH_EMAIL_EXISTS',
+          'A user with the provided email already exists',
+        ),
+        AuthInvalidErrorResponse: errorResponseSchema(
+          'ApiErrorResponse',
+          'AUTH_INVALID',
+          'Invalid email or password',
+        ),
+        AuthRateLimitErrorResponse: errorResponseSchema(
+          'RateLimitErrorResponse',
+          'AUTH_RATE_LIMITED',
+          'Too many authentication requests. Please try again later.',
+        ),
+        TrainingDocumentNotFoundErrorResponse: errorResponseSchema(
+          'ApiErrorResponse',
+          'TRAINING_DOCUMENT_NOT_FOUND',
+          'Training document was not found',
+        ),
+        TrainingRateLimitErrorResponse: errorResponseSchema(
+          'RateLimitErrorResponse',
+          'TRAINING_RATE_LIMITED',
+          'Too many training requests. Please try again later.',
+        ),
         EmptyRequestBody: {
           type: 'object',
           additionalProperties: false,
           description: 'Request body must be omitted or an empty JSON object.',
           example: {},
         },
-        UserType: {
-          type: 'string',
-          enum: ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],
-          example: 'GENERAL_TRAINEE',
-        },
-        AuthStatus: {
-          type: 'string',
-          enum: ['PENDING', 'ACTIVE', 'DISABLED'],
-          example: 'ACTIVE',
-        },
+        UserType: enumString(
+          ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],
+          'GENERAL_TRAINEE',
+        ),
+        AuthStatus: enumString(['PENDING', 'ACTIVE', 'DISABLED'], 'ACTIVE'),
         PublicOrganisation: {
           type: 'object',
           required: ['id', 'name'],
@@ -389,9 +390,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               ],
             },
             createdAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2026-05-11T20:44:54.000Z',
+              ...dateTimeString('2026-05-11T20:44:54.000Z'),
             },
           },
         },
@@ -494,39 +493,32 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           },
         },
-        DifficultyLevel: {
-          type: 'string',
-          enum: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED', 'ADAPTIVE'],
-          example: 'BEGINNER',
-        },
-        TrainingContentType: {
-          type: 'string',
-          enum: ['PDF', 'MARKDOWN', 'HTML', 'URL', 'INTERACTIVE'],
-          example: 'MARKDOWN',
-        },
-        TrainingDocumentStatus: {
-          type: 'string',
-          enum: ['DRAFT', 'AVAILABLE', 'UNAVAILABLE', 'ARCHIVED'],
-          example: 'AVAILABLE',
-        },
-        TrainingCampaignItemAvailabilityStatus: {
-          type: 'string',
-          enum: ['AVAILABLE', 'LOCKED', 'UNAVAILABLE', 'ARCHIVED'],
-          example: 'AVAILABLE',
-        },
-        TrainingInteractionEventType: {
-          type: 'string',
-          enum: ['TRAINING_VIEWED', 'TRAINING_COMPLETED'],
-          example: 'TRAINING_VIEWED',
-        },
+        DifficultyLevel: enumString(
+          ['BEGINNER', 'INTERMEDIATE', 'ADVANCED', 'ADAPTIVE'],
+          'BEGINNER',
+        ),
+        TrainingContentType: enumString(
+          ['PDF', 'MARKDOWN', 'HTML', 'URL', 'INTERACTIVE'],
+          'MARKDOWN',
+        ),
+        TrainingDocumentStatus: enumString(
+          ['DRAFT', 'AVAILABLE', 'UNAVAILABLE', 'ARCHIVED'],
+          'AVAILABLE',
+        ),
+        TrainingCampaignItemAvailabilityStatus: enumString(
+          ['AVAILABLE', 'LOCKED', 'UNAVAILABLE', 'ARCHIVED'],
+          'AVAILABLE',
+        ),
+        TrainingInteractionEventType: enumString(
+          ['TRAINING_VIEWED', 'TRAINING_COMPLETED'],
+          'TRAINING_VIEWED',
+        ),
         TrainingDocument: {
           type: 'object',
           required: ['id', 'title', 'contentType', 'contentRef', 'difficultyLevel', 'status'],
           properties: {
             id: {
-              type: 'string',
-              format: 'uuid',
-              example: '33333333-3333-4333-8333-333333333333',
+              ...uuidString('33333333-3333-4333-8333-333333333333'),
             },
             title: {
               type: 'string',
@@ -540,9 +532,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'training/training-doc-1',
             },
             contentSummary: {
-              type: 'string',
-              nullable: true,
-              example: 'Common phishing indicators and safe response steps.',
+              ...nullableString('Common phishing indicators and safe response steps.'),
             },
             estimatedReadTimeMinutes: {
               type: 'integer',
@@ -589,15 +579,10 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['campaignItemId', 'trainingDocument', 'campaignItem'],
           properties: {
             campaignItemId: {
-              type: 'string',
-              format: 'uuid',
-              example: '11111111-1111-4111-8111-111111111111',
+              ...uuidString('11111111-1111-4111-8111-111111111111'),
             },
             campaignAssignmentId: {
-              type: 'string',
-              format: 'uuid',
-              nullable: true,
-              example: '44444444-4444-4444-8444-444444444444',
+              ...nullableUuidString('44444444-4444-4444-8444-444444444444'),
             },
             trainingDocument: {
               $ref: '#/components/schemas/TrainingDocument',
@@ -619,9 +604,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               $ref: '#/components/schemas/TrainingInteractionEventType',
             },
             occurredAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2026-05-16T09:00:00.000Z',
+              ...dateTimeString(),
             },
           },
         },
@@ -630,9 +613,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['success', 'campaignItemId', 'trainingDocumentId', 'event'],
           properties: {
             success: {
-              type: 'boolean',
-              enum: [true],
-              example: true,
+              ...trueSuccessProperty(),
             },
             campaignItemId: {
               type: 'string',
@@ -649,30 +630,20 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           },
         },
-        EmailClassification: {
-          type: 'string',
-          enum: ['SAFE', 'SUSPICIOUS', 'PHISHING'],
-          example: 'PHISHING',
-        },
-        EmailRedFlagType: {
-          type: 'string',
-          enum: ['SENDER', 'LINK', 'LANGUAGE', 'ATTACHMENT', 'REQUEST', 'DOMAIN', 'OTHER'],
-          example: 'LANGUAGE',
-        },
-        RedFlagSeverity: {
-          type: 'string',
-          enum: ['LOW', 'MEDIUM', 'HIGH'],
-          example: 'MEDIUM',
-        },
-        SimulatedEmailInteractionEventType: {
-          type: 'string',
-          enum: [
+        EmailClassification: enumString(['SAFE', 'SUSPICIOUS', 'PHISHING'], 'PHISHING'),
+        EmailRedFlagType: enumString(
+          ['SENDER', 'LINK', 'LANGUAGE', 'ATTACHMENT', 'REQUEST', 'DOMAIN', 'OTHER'],
+          'LANGUAGE',
+        ),
+        RedFlagSeverity: enumString(['LOW', 'MEDIUM', 'HIGH'], 'MEDIUM'),
+        SimulatedEmailInteractionEventType: enumString(
+          [
             'SIMULATED_EMAIL_OPENED',
             'SIMULATED_EMAIL_LINK_CLICKED',
             'CREDENTIAL_SUBMISSION_ATTEMPTED',
           ],
-          example: 'SIMULATED_EMAIL_LINK_CLICKED',
-        },
+          'SIMULATED_EMAIL_LINK_CLICKED',
+        ),
         SimulatedInboxEmailSummary: {
           type: 'object',
           required: [
@@ -739,10 +710,7 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           required: ['emails'],
           properties: {
             emails: {
-              type: 'array',
-              items: {
-                $ref: '#/components/schemas/SimulatedInboxEmailSummary',
-              },
+              ...arrayOf(schemaRef('SimulatedInboxEmailSummary')),
             },
           },
         },
@@ -928,21 +896,9 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           },
         },
-        QuestionType: {
-          type: 'string',
-          enum: ['SINGLE_CHOICE', 'MULTIPLE_CHOICE'],
-          example: 'SINGLE_CHOICE',
-        },
-        QuizAttemptStatus: {
-          type: 'string',
-          enum: ['IN_PROGRESS', 'SUBMITTED'],
-          example: 'IN_PROGRESS',
-        },
-        QuizStatus: {
-          type: 'string',
-          enum: ['DRAFT', 'PUBLISHED', 'ARCHIVED'],
-          example: 'PUBLISHED',
-        },
+        QuestionType: enumString(['SINGLE_CHOICE', 'MULTIPLE_CHOICE'], 'SINGLE_CHOICE'),
+        QuizAttemptStatus: enumString(['IN_PROGRESS', 'SUBMITTED'], 'IN_PROGRESS'),
+        QuizStatus: enumString(['DRAFT', 'PUBLISHED', 'ARCHIVED'], 'PUBLISHED'),
         QuizCampaignItemContext: {
           type: 'object',
           properties: {
@@ -1327,76 +1283,31 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
         },
       },
       responses: {
-        BadRequest: {
-          description: 'The request payload or parameters are invalid.',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/ValidationErrorResponse',
-              },
-            },
-          },
-        },
-        Unauthorized: {
-          description: 'Authentication credentials are missing or invalid.',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/ApiErrorResponse',
-              },
-            },
-          },
-        },
-        Forbidden: {
-          description: 'The authenticated user is not allowed to perform this action.',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/ApiErrorResponse',
-              },
-            },
-          },
-        },
-        NotFound: {
-          description: 'The requested resource was not found.',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/ApiErrorResponse',
-              },
-            },
-          },
-        },
-        Conflict: {
-          description: 'The request conflicts with an existing resource or state.',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/ApiErrorResponse',
-              },
-            },
-          },
-        },
-        TooManyRequests: {
-          description: 'The client has exceeded the configured rate limit.',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/RateLimitErrorResponse',
-              },
-            },
-          },
-        },
-        InternalServerError: {
-          description: 'An unexpected server error occurred.',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/ApiErrorResponse',
-              },
-            },
-          },
-        },
+        BadRequest: responseComponent(
+          'The request payload or parameters are invalid.',
+          'ValidationErrorResponse',
+        ),
+        Unauthorized: responseComponent(
+          'Authentication credentials are missing or invalid.',
+          'ApiErrorResponse',
+        ),
+        Forbidden: responseComponent(
+          'The authenticated user is not allowed to perform this action.',
+          'ApiErrorResponse',
+        ),
+        NotFound: responseComponent('The requested resource was not found.', 'ApiErrorResponse'),
+        Conflict: responseComponent(
+          'The request conflicts with an existing resource or state.',
+          'ApiErrorResponse',
+        ),
+        TooManyRequests: responseComponent(
+          'The client has exceeded the configured rate limit.',
+          'RateLimitErrorResponse',
+        ),
+        InternalServerError: responseComponent(
+          'An unexpected server error occurred.',
+          'ApiErrorResponse',
+        ),
       },
     },
   },

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -654,8 +654,9 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           description: 'Campaign item identifier.',
           schema: {
             type: 'string',
+            format: 'uuid',
           },
-          example: 'campaign-item-123',
+          example: '11111111-1111-4111-8111-111111111111',
         },
         EmailIdPathParam: {
           name: 'emailId',

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -38,6 +38,10 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
         name: 'Trainee Training',
         description: 'Trainee training document workflows.',
       },
+      {
+        name: 'Trainee Quiz',
+        description: 'Trainee quiz retrieval, attempts, submissions, and results.',
+      },
     ],
     components: {
       securitySchemes: {
@@ -924,6 +928,368 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           },
         },
+        QuestionType: {
+          type: 'string',
+          enum: ['SINGLE_CHOICE', 'MULTIPLE_CHOICE'],
+          example: 'SINGLE_CHOICE',
+        },
+        QuizAttemptStatus: {
+          type: 'string',
+          enum: ['IN_PROGRESS', 'SUBMITTED'],
+          example: 'IN_PROGRESS',
+        },
+        QuizStatus: {
+          type: 'string',
+          enum: ['DRAFT', 'PUBLISHED', 'ARCHIVED'],
+          example: 'PUBLISHED',
+        },
+        QuizCampaignItemContext: {
+          type: 'object',
+          properties: {
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '11111111-1111-1111-1111-111111111111',
+            },
+            campaignAssignmentId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '44444444-4444-4444-4444-444444444444',
+            },
+          },
+        },
+        QuizOptionForTrainee: {
+          type: 'object',
+          required: ['id', 'label', 'text', 'position'],
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              example: '44444444-4444-4444-4444-444444444444',
+            },
+            label: {
+              type: 'string',
+              example: 'A',
+            },
+            text: {
+              type: 'string',
+              example: 'Check the sender address',
+            },
+            position: {
+              type: 'integer',
+              example: 1,
+            },
+          },
+        },
+        QuizQuestionForTrainee: {
+          type: 'object',
+          required: ['id', 'prompt', 'questionType', 'position', 'points', 'options'],
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              example: '33333333-3333-3333-3333-333333333333',
+            },
+            prompt: {
+              type: 'string',
+              example: 'What is the best way to verify an email sender?',
+            },
+            questionType: {
+              $ref: '#/components/schemas/QuestionType',
+            },
+            position: {
+              type: 'integer',
+              example: 1,
+            },
+            points: {
+              type: 'integer',
+              example: 5,
+            },
+            options: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/QuizOptionForTrainee',
+              },
+            },
+          },
+        },
+        GetQuizResponse: {
+          type: 'object',
+          required: [
+            'id',
+            'title',
+            'passThresholdPercentage',
+            'difficultyLevel',
+            'status',
+            'questions',
+          ],
+          properties: {
+            id: {
+              type: 'string',
+              example: 'quiz-1',
+            },
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '11111111-1111-1111-1111-111111111111',
+            },
+            campaignAssignmentId: {
+              type: 'string',
+              nullable: true,
+              example: 'assign-1',
+            },
+            title: {
+              type: 'string',
+              example: 'Phishing Check',
+            },
+            description: {
+              type: 'string',
+              nullable: true,
+              example: 'Check your phishing awareness.',
+            },
+            passThresholdPercentage: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 100,
+              example: 70,
+            },
+            difficultyLevel: {
+              $ref: '#/components/schemas/DifficultyLevel',
+            },
+            status: {
+              $ref: '#/components/schemas/QuizStatus',
+            },
+            questions: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/QuizQuestionForTrainee',
+              },
+            },
+          },
+        },
+        QuizAttempt: {
+          type: 'object',
+          required: ['attemptId', 'traineeProfileId', 'quizId', 'status', 'startedAt'],
+          properties: {
+            attemptId: {
+              type: 'string',
+              format: 'uuid',
+              example: '22222222-2222-2222-2222-222222222222',
+            },
+            traineeProfileId: {
+              type: 'string',
+              example: 'trainee-profile-id',
+            },
+            quizId: {
+              type: 'string',
+              example: 'quiz-1',
+            },
+            campaignAssignmentId: {
+              type: 'string',
+              nullable: true,
+              example: 'assign-1',
+            },
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '11111111-1111-1111-1111-111111111111',
+            },
+            status: {
+              type: 'string',
+              enum: ['IN_PROGRESS'],
+              example: 'IN_PROGRESS',
+            },
+            startedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-05-16T09:00:00.000Z',
+            },
+          },
+        },
+        StartQuizAttemptResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/QuizAttempt',
+            },
+          ],
+        },
+        AttemptAnswer: {
+          type: 'object',
+          required: ['questionId', 'selectedOptionIds'],
+          additionalProperties: false,
+          properties: {
+            questionId: {
+              type: 'string',
+              format: 'uuid',
+              example: '33333333-3333-3333-3333-333333333333',
+            },
+            selectedOptionIds: {
+              type: 'array',
+              minItems: 1,
+              items: {
+                type: 'string',
+                format: 'uuid',
+              },
+              example: ['44444444-4444-4444-4444-444444444444'],
+            },
+            responseSummary: {
+              type: 'string',
+              maxLength: 1000,
+              example: 'Selected the sender verification answer.',
+            },
+            typedResponse: {
+              type: 'string',
+              maxLength: 4000,
+              example: 'I would inspect the sender domain before clicking links.',
+            },
+          },
+        },
+        SubmitQuizAttemptRequest: {
+          type: 'object',
+          required: ['answers'],
+          additionalProperties: false,
+          properties: {
+            answers: {
+              type: 'array',
+              minItems: 1,
+              items: {
+                $ref: '#/components/schemas/AttemptAnswer',
+              },
+            },
+          },
+        },
+        SubmitQuizAttemptResponse: {
+          type: 'object',
+          required: ['success', 'attemptId', 'status'],
+          properties: {
+            success: {
+              type: 'boolean',
+              enum: [true],
+              example: true,
+            },
+            attemptId: {
+              type: 'string',
+              format: 'uuid',
+              example: '22222222-2222-2222-2222-222222222222',
+            },
+            status: {
+              type: 'string',
+              enum: ['SUBMITTED'],
+              example: 'SUBMITTED',
+            },
+          },
+        },
+        QuizResultOption: {
+          type: 'object',
+          required: ['optionId', 'label', 'text', 'isCorrect'],
+          properties: {
+            optionId: {
+              type: 'string',
+              format: 'uuid',
+              example: '44444444-4444-4444-4444-444444444444',
+            },
+            label: {
+              type: 'string',
+              example: 'A',
+            },
+            text: {
+              type: 'string',
+              example: 'Check the sender address',
+            },
+            isCorrect: {
+              type: 'boolean',
+              example: true,
+            },
+            feedbackText: {
+              type: 'string',
+              nullable: true,
+              example: 'Checking the exact sender address helps detect spoofing.',
+            },
+          },
+        },
+        QuizResultQuestion: {
+          type: 'object',
+          required: ['questionId', 'selectedOptions'],
+          properties: {
+            questionId: {
+              type: 'string',
+              format: 'uuid',
+              example: '33333333-3333-3333-3333-333333333333',
+            },
+            isCorrect: {
+              type: 'boolean',
+              nullable: true,
+              example: true,
+            },
+            awardedPoints: {
+              type: 'number',
+              nullable: true,
+              example: 5,
+            },
+            feedbackShown: {
+              type: 'string',
+              nullable: true,
+              example: 'Correct!',
+            },
+            selectedOptions: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/QuizResultOption',
+              },
+            },
+          },
+        },
+        GetQuizResultResponse: {
+          type: 'object',
+          required: ['attemptId', 'quizId', 'scorePercentage', 'passed', 'answers'],
+          properties: {
+            attemptId: {
+              type: 'string',
+              format: 'uuid',
+              example: '22222222-2222-2222-2222-222222222222',
+            },
+            quizId: {
+              type: 'string',
+              example: 'quiz-1',
+            },
+            campaignAssignmentId: {
+              type: 'string',
+              nullable: true,
+              example: 'assign-1',
+            },
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '11111111-1111-1111-1111-111111111111',
+            },
+            scorePercentage: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 100,
+              example: 100,
+            },
+            passed: {
+              type: 'boolean',
+              example: true,
+            },
+            summary: {
+              type: 'string',
+              nullable: true,
+              example: 'Well done',
+            },
+            answers: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/QuizResultQuestion',
+              },
+            },
+          },
+        },
       },
       parameters: {
         CampaignItemIdPathParam: {
@@ -947,6 +1313,17 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             format: 'uuid',
           },
           example: '11111111-1111-1111-1111-111111111111',
+        },
+        AttemptIdPathParam: {
+          name: 'attemptId',
+          in: 'path',
+          required: true,
+          description: 'Quiz attempt identifier.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+          example: '22222222-2222-2222-2222-222222222222',
         },
       },
       responses: {

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -120,8 +120,8 @@ const options: swaggerJsdoc.Options = {
       description: `
 API documentation for ${APP_NAME}.
 
-### Sprint 2 Note
-Full endpoint coverage is optional for Sprint 2. This documentation serves as a proof-of-concept and will be expanded as features are finalized.
+### Demo 1 API Coverage
+This reference covers the currently mounted Demo 1 backend routes. Planned or unmounted routes are intentionally omitted.
       `,
     },
     servers: [
@@ -1195,7 +1195,128 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           example: '22222222-2222-2222-2222-222222222222',
         },
       },
+      requestBodies: {
+        AuthRegister: {
+          required: true,
+          ...jsonContent(schemaRef('AuthRegisterRequest')),
+        },
+        AuthLogin: {
+          required: true,
+          ...jsonContent(schemaRef('AuthLoginRequest')),
+        },
+        EmptyJson: {
+          required: false,
+          ...jsonContent(schemaRef('EmptyRequestBody')),
+        },
+        RecordSimulatedEmailInteraction: {
+          required: true,
+          ...jsonContent(schemaRef('RecordSimulatedEmailInteractionRequest')),
+        },
+        ClassifySimulatedEmail: {
+          required: true,
+          ...jsonContent(schemaRef('ClassifySimulatedEmailRequest')),
+        },
+        SubmitQuizAttempt: {
+          required: true,
+          ...jsonContent(schemaRef('SubmitQuizAttemptRequest')),
+        },
+      },
       responses: {
+        HealthOk: responseComponent('API and database are reachable.', 'HealthStatus'),
+        HealthDatabaseUnavailable: responseComponent(
+          'API is reachable, but the database check failed.',
+          'HealthStatus',
+        ),
+        AuthRegisterCreated: responseComponent(
+          'Account registered successfully.',
+          'AuthRegisterResponse',
+        ),
+        AuthLoginOk: responseComponent('Login successful.', 'AuthLoginResponse'),
+        AuthMeOk: responseComponent('Current authenticated user.', 'AuthMeResponse'),
+        AuthEmailExists: responseComponent(
+          'A user with the provided email already exists.',
+          'AuthEmailExistsErrorResponse',
+        ),
+        AuthInvalid: responseComponent(
+          'Email, password, or account status is invalid.',
+          'AuthInvalidErrorResponse',
+        ),
+        AuthRateLimited: responseComponent(
+          'Too many authentication requests.',
+          'AuthRateLimitErrorResponse',
+        ),
+        SimulatedInboxOk: responseComponent(
+          'Simulated inbox email summaries for the campaign item.',
+          'SimulatedInbox',
+        ),
+        SimulatedEmailDetailOk: responseComponent(
+          'Simulated email details safe for pre-classification display.',
+          'SimulatedEmailDetail',
+        ),
+        SimulatedEmailInteractionOk: responseComponent(
+          'Simulated email interaction recorded.',
+          'RecordSimulatedEmailInteractionResponse',
+        ),
+        SimulatedEmailClassificationOk: responseComponent(
+          'Simulated email classification recorded with feedback.',
+          'ClassifySimulatedEmailResponse',
+        ),
+        SimulationNotFound: responseComponent(
+          'Simulated inbox or email is missing, unavailable, or not accessible through this campaign item.',
+          'ApiErrorResponse',
+        ),
+        SimulatedEmailAlreadyClassified: responseComponent(
+          'The simulated email has already been classified by this trainee.',
+          'ApiErrorResponse',
+        ),
+        TrainingDocumentOk: responseComponent(
+          'Training document resolved for the campaign item.',
+          'GetTrainingDocumentResponse',
+        ),
+        TrainingViewedCreated: responseComponent(
+          'Training view interaction recorded.',
+          'RecordTrainingInteractionResponse',
+        ),
+        TrainingCompletedCreated: responseComponent(
+          'Training completion interaction recorded.',
+          'RecordTrainingInteractionResponse',
+        ),
+        TrainingDocumentNotFound: responseComponent(
+          'Training document is missing, unavailable, or not accessible to the trainee.',
+          'TrainingDocumentNotFoundErrorResponse',
+        ),
+        TrainingRateLimited: responseComponent(
+          'Too many trainee training requests.',
+          'TrainingRateLimitErrorResponse',
+        ),
+        QuizOk: responseComponent(
+          'Quiz content safe for trainee pre-submission display.',
+          'GetQuizResponse',
+        ),
+        QuizAttemptCreated: responseComponent(
+          'Quiz attempt is ready for answers.',
+          'StartQuizAttemptResponse',
+        ),
+        QuizAttemptSubmitted: responseComponent(
+          'Quiz attempt submitted successfully.',
+          'SubmitQuizAttemptResponse',
+        ),
+        QuizResultOk: responseComponent(
+          'Quiz result and answer feedback for a submitted attempt.',
+          'GetQuizResultResponse',
+        ),
+        QuizNotFound: responseComponent(
+          'Quiz, quiz attempt, or associated campaign item was not found.',
+          'ApiErrorResponse',
+        ),
+        QuizAttemptAlreadySubmitted: responseComponent(
+          'Quiz attempt has already been submitted.',
+          'ApiErrorResponse',
+        ),
+        QuizResultUnavailable: responseComponent(
+          'Results are not available until the attempt is submitted, or the user cannot access the attempt.',
+          'ApiErrorResponse',
+        ),
         BadRequest: responseComponent(
           'The request payload or parameters are invalid.',
           'ValidationErrorResponse',

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -49,6 +49,31 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
         },
       },
       schemas: {
+        HealthStatus: {
+          type: 'object',
+          required: ['app', 'api', 'database', 'timestamp'],
+          properties: {
+            app: {
+              type: 'string',
+              example: APP_NAME,
+            },
+            api: {
+              type: 'string',
+              enum: ['working'],
+              example: 'working',
+            },
+            database: {
+              type: 'string',
+              enum: ['connected', 'not connected'],
+              example: 'connected',
+            },
+            timestamp: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-05-11T20:44:54.000Z',
+            },
+          },
+        },
         ApiErrorResponse: {
           type: 'object',
           required: ['error', 'message'],

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -645,6 +645,285 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           },
         },
+        EmailClassification: {
+          type: 'string',
+          enum: ['SAFE', 'SUSPICIOUS', 'PHISHING'],
+          example: 'PHISHING',
+        },
+        EmailRedFlagType: {
+          type: 'string',
+          enum: ['SENDER', 'LINK', 'LANGUAGE', 'ATTACHMENT', 'REQUEST', 'DOMAIN', 'OTHER'],
+          example: 'LANGUAGE',
+        },
+        RedFlagSeverity: {
+          type: 'string',
+          enum: ['LOW', 'MEDIUM', 'HIGH'],
+          example: 'MEDIUM',
+        },
+        SimulatedEmailInteractionEventType: {
+          type: 'string',
+          enum: [
+            'SIMULATED_EMAIL_OPENED',
+            'SIMULATED_EMAIL_LINK_CLICKED',
+            'CREDENTIAL_SUBMISSION_ATTEMPTED',
+          ],
+          example: 'SIMULATED_EMAIL_LINK_CLICKED',
+        },
+        SimulatedInboxEmailSummary: {
+          type: 'object',
+          required: [
+            'id',
+            'inboxId',
+            'senderLabel',
+            'senderAddress',
+            'subject',
+            'receivedAt',
+            'difficultyLevel',
+          ],
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              example: '11111111-1111-1111-1111-111111111111',
+            },
+            campaignAssignmentId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '44444444-4444-4444-4444-444444444444',
+            },
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '22222222-2222-2222-2222-222222222222',
+            },
+            inboxId: {
+              type: 'string',
+              example: 'inbox-1',
+            },
+            senderLabel: {
+              type: 'string',
+              example: 'Bank',
+            },
+            senderAddress: {
+              type: 'string',
+              format: 'email',
+              example: 'bank@example.com',
+            },
+            subject: {
+              type: 'string',
+              example: 'Security Alert',
+            },
+            preview: {
+              type: 'string',
+              nullable: true,
+              example: 'Please review this important security notice.',
+            },
+            receivedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-05-16T09:00:00.000Z',
+            },
+            difficultyLevel: {
+              $ref: '#/components/schemas/DifficultyLevel',
+            },
+          },
+        },
+        SimulatedInbox: {
+          type: 'object',
+          required: ['emails'],
+          properties: {
+            emails: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/SimulatedInboxEmailSummary',
+              },
+            },
+          },
+        },
+        SimulatedEmailDetail: {
+          type: 'object',
+          required: [
+            'id',
+            'inboxId',
+            'senderLabel',
+            'senderAddress',
+            'subject',
+            'bodyHtml',
+            'hasAttachment',
+            'receivedAt',
+            'difficultyLevel',
+          ],
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              example: '11111111-1111-1111-1111-111111111111',
+            },
+            campaignAssignmentId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '44444444-4444-4444-4444-444444444444',
+            },
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '22222222-2222-2222-2222-222222222222',
+            },
+            inboxId: {
+              type: 'string',
+              example: 'inbox-1',
+            },
+            senderLabel: {
+              type: 'string',
+              example: 'Bank',
+            },
+            senderAddress: {
+              type: 'string',
+              format: 'email',
+              example: 'bank@example.com',
+            },
+            subject: {
+              type: 'string',
+              example: 'Security Alert',
+            },
+            preview: {
+              type: 'string',
+              nullable: true,
+              example: 'Please review this important security notice.',
+            },
+            bodyHtml: {
+              type: 'string',
+              example: '<p>Hello</p>',
+            },
+            simulatedLinkTarget: {
+              type: 'string',
+              nullable: true,
+              example: '/simulations/credential-warning',
+            },
+            hasAttachment: {
+              type: 'boolean',
+              example: false,
+            },
+            receivedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-05-16T09:00:00.000Z',
+            },
+            difficultyLevel: {
+              $ref: '#/components/schemas/DifficultyLevel',
+            },
+          },
+        },
+        RecordSimulatedEmailInteractionRequest: {
+          type: 'object',
+          required: ['eventType'],
+          additionalProperties: false,
+          properties: {
+            eventType: {
+              $ref: '#/components/schemas/SimulatedEmailInteractionEventType',
+            },
+          },
+        },
+        RecordSimulatedEmailInteractionResponse: {
+          type: 'object',
+          required: ['success', 'eventType'],
+          properties: {
+            success: {
+              type: 'boolean',
+              enum: [true],
+              example: true,
+            },
+            eventType: {
+              $ref: '#/components/schemas/SimulatedEmailInteractionEventType',
+            },
+          },
+        },
+        ClassifySimulatedEmailRequest: {
+          type: 'object',
+          required: ['selectedClassification'],
+          additionalProperties: false,
+          properties: {
+            selectedClassification: {
+              $ref: '#/components/schemas/EmailClassification',
+            },
+            selectedRedFlagIds: {
+              type: 'array',
+              items: {
+                type: 'string',
+                format: 'uuid',
+              },
+              example: ['33333333-3333-3333-3333-333333333333'],
+            },
+            freeTextReason: {
+              type: 'string',
+              maxLength: 1000,
+              example: 'The message uses urgent language and asks me to click a suspicious link.',
+            },
+          },
+        },
+        EmailRedFlag: {
+          type: 'object',
+          required: ['id', 'redFlagType', 'label', 'severity'],
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              example: '33333333-3333-3333-3333-333333333333',
+            },
+            redFlagType: {
+              $ref: '#/components/schemas/EmailRedFlagType',
+            },
+            label: {
+              type: 'string',
+              example: 'Urgent language',
+            },
+            description: {
+              type: 'string',
+              nullable: true,
+              example: 'The email pressures the trainee to act quickly.',
+            },
+            severity: {
+              $ref: '#/components/schemas/RedFlagSeverity',
+            },
+          },
+        },
+        ClassifySimulatedEmailResponse: {
+          type: 'object',
+          required: ['success', 'responseId', 'selectedClassification', 'isCorrect'],
+          properties: {
+            success: {
+              type: 'boolean',
+              enum: [true],
+              example: true,
+            },
+            responseId: {
+              type: 'string',
+              example: 'resp-123',
+            },
+            selectedClassification: {
+              $ref: '#/components/schemas/EmailClassification',
+            },
+            isCorrect: {
+              type: 'boolean',
+              example: true,
+            },
+            feedback: {
+              type: 'string',
+              nullable: true,
+              example: 'Great job! You correctly identified the email.',
+            },
+            redFlags: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/EmailRedFlag',
+              },
+            },
+          },
+        },
       },
       parameters: {
         CampaignItemIdPathParam: {
@@ -665,8 +944,9 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           description: 'Simulated email identifier.',
           schema: {
             type: 'string',
+            format: 'uuid',
           },
-          example: 'email-123',
+          example: '11111111-1111-1111-1111-111111111111',
         },
       },
       responses: {

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -213,6 +213,54 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           ],
         },
+        TrainingDocumentNotFoundErrorResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ApiErrorResponse',
+            },
+            {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  enum: ['TRAINING_DOCUMENT_NOT_FOUND'],
+                  example: 'TRAINING_DOCUMENT_NOT_FOUND',
+                },
+                message: {
+                  type: 'string',
+                  example: 'Training document was not found',
+                },
+              },
+            },
+          ],
+        },
+        TrainingRateLimitErrorResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/RateLimitErrorResponse',
+            },
+            {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  enum: ['TRAINING_RATE_LIMITED'],
+                  example: 'TRAINING_RATE_LIMITED',
+                },
+                message: {
+                  type: 'string',
+                  example: 'Too many training requests. Please try again later.',
+                },
+              },
+            },
+          ],
+        },
+        EmptyRequestBody: {
+          type: 'object',
+          additionalProperties: false,
+          description: 'Request body must be omitted or an empty JSON object.',
+          example: {},
+        },
         UserType: {
           type: 'string',
           enum: ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],
@@ -439,6 +487,161 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
           properties: {
             user: {
               $ref: '#/components/schemas/PublicUser',
+            },
+          },
+        },
+        DifficultyLevel: {
+          type: 'string',
+          enum: ['BEGINNER', 'INTERMEDIATE', 'ADVANCED', 'ADAPTIVE'],
+          example: 'BEGINNER',
+        },
+        TrainingContentType: {
+          type: 'string',
+          enum: ['PDF', 'MARKDOWN', 'HTML', 'URL', 'INTERACTIVE'],
+          example: 'MARKDOWN',
+        },
+        TrainingDocumentStatus: {
+          type: 'string',
+          enum: ['DRAFT', 'AVAILABLE', 'UNAVAILABLE', 'ARCHIVED'],
+          example: 'AVAILABLE',
+        },
+        TrainingCampaignItemAvailabilityStatus: {
+          type: 'string',
+          enum: ['AVAILABLE', 'LOCKED', 'UNAVAILABLE', 'ARCHIVED'],
+          example: 'AVAILABLE',
+        },
+        TrainingInteractionEventType: {
+          type: 'string',
+          enum: ['TRAINING_VIEWED', 'TRAINING_COMPLETED'],
+          example: 'TRAINING_VIEWED',
+        },
+        TrainingDocument: {
+          type: 'object',
+          required: ['id', 'title', 'contentType', 'contentRef', 'difficultyLevel', 'status'],
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              example: '33333333-3333-4333-8333-333333333333',
+            },
+            title: {
+              type: 'string',
+              example: 'Identifying Phishing Emails',
+            },
+            contentType: {
+              $ref: '#/components/schemas/TrainingContentType',
+            },
+            contentRef: {
+              type: 'string',
+              example: 'training/training-doc-1',
+            },
+            contentSummary: {
+              type: 'string',
+              nullable: true,
+              example: 'Common phishing indicators and safe response steps.',
+            },
+            estimatedReadTimeMinutes: {
+              type: 'integer',
+              nullable: true,
+              minimum: 0,
+              example: 8,
+            },
+            difficultyLevel: {
+              $ref: '#/components/schemas/DifficultyLevel',
+            },
+            status: {
+              $ref: '#/components/schemas/TrainingDocumentStatus',
+            },
+          },
+        },
+        TrainingCampaignItemContext: {
+          type: 'object',
+          required: ['title', 'position', 'isRequired', 'availabilityStatus'],
+          properties: {
+            title: {
+              type: 'string',
+              example: 'Phishing Basics',
+            },
+            description: {
+              type: 'string',
+              nullable: true,
+              example: 'Read the basics before the quiz.',
+            },
+            position: {
+              type: 'integer',
+              example: 1,
+            },
+            isRequired: {
+              type: 'boolean',
+              example: true,
+            },
+            availabilityStatus: {
+              $ref: '#/components/schemas/TrainingCampaignItemAvailabilityStatus',
+            },
+          },
+        },
+        GetTrainingDocumentResponse: {
+          type: 'object',
+          required: ['campaignItemId', 'trainingDocument', 'campaignItem'],
+          properties: {
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              example: '11111111-1111-4111-8111-111111111111',
+            },
+            campaignAssignmentId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              example: '44444444-4444-4444-8444-444444444444',
+            },
+            trainingDocument: {
+              $ref: '#/components/schemas/TrainingDocument',
+            },
+            campaignItem: {
+              $ref: '#/components/schemas/TrainingCampaignItemContext',
+            },
+          },
+        },
+        TrainingInteractionEvent: {
+          type: 'object',
+          required: ['id', 'eventType', 'occurredAt'],
+          properties: {
+            id: {
+              type: 'string',
+              example: 'event-1',
+            },
+            eventType: {
+              $ref: '#/components/schemas/TrainingInteractionEventType',
+            },
+            occurredAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-05-16T09:00:00.000Z',
+            },
+          },
+        },
+        RecordTrainingInteractionResponse: {
+          type: 'object',
+          required: ['success', 'campaignItemId', 'trainingDocumentId', 'event'],
+          properties: {
+            success: {
+              type: 'boolean',
+              enum: [true],
+              example: true,
+            },
+            campaignItemId: {
+              type: 'string',
+              format: 'uuid',
+              example: '11111111-1111-4111-8111-111111111111',
+            },
+            trainingDocumentId: {
+              type: 'string',
+              format: 'uuid',
+              example: '33333333-3333-4333-8333-333333333333',
+            },
+            event: {
+              $ref: '#/components/schemas/TrainingInteractionEvent',
             },
           },
         },

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -21,6 +21,262 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
         description: 'Development server',
       },
     ],
+    tags: [
+      {
+        name: 'Health',
+        description: 'Service health and readiness checks.',
+      },
+      {
+        name: 'Auth',
+        description: 'Authentication and current user endpoints.',
+      },
+      {
+        name: 'Trainee Simulation',
+        description: 'Trainee simulated phishing email workflows.',
+      },
+      {
+        name: 'Trainee Training',
+        description: 'Trainee training document workflows.',
+      },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Bearer token returned by the authentication endpoints.',
+        },
+      },
+      schemas: {
+        ApiErrorResponse: {
+          type: 'object',
+          required: ['error', 'message'],
+          properties: {
+            error: {
+              type: 'string',
+              description: 'Stable application error code.',
+              example: 'AUTH_REQUIRED',
+            },
+            message: {
+              type: 'string',
+              description: 'Human-readable error message.',
+              example: 'Authentication credentials are required',
+            },
+          },
+        },
+        ValidationErrorDetail: {
+          type: 'object',
+          required: ['field', 'message'],
+          properties: {
+            field: {
+              type: 'string',
+              description: 'Request field path that failed validation.',
+              example: 'email',
+            },
+            message: {
+              type: 'string',
+              description: 'Validation failure message.',
+              example: 'Invalid email',
+            },
+          },
+        },
+        ValidationErrorResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ApiErrorResponse',
+            },
+            {
+              type: 'object',
+              required: ['details'],
+              properties: {
+                error: {
+                  type: 'string',
+                  enum: ['VALIDATION_ERROR'],
+                  example: 'VALIDATION_ERROR',
+                },
+                details: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/ValidationErrorDetail',
+                  },
+                },
+              },
+            },
+          ],
+        },
+        RateLimitErrorResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ApiErrorResponse',
+            },
+            {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  example: 'TOO_MANY_REQUESTS',
+                },
+                message: {
+                  type: 'string',
+                  example: 'Too many requests from this IP, please try again after 15 minutes',
+                },
+              },
+            },
+          ],
+        },
+        PublicUser: {
+          type: 'object',
+          required: ['id', 'firstName', 'lastName', 'email', 'userType', 'authStatus', 'createdAt'],
+          properties: {
+            id: {
+              type: 'string',
+              example: 'user-123',
+            },
+            firstName: {
+              type: 'string',
+              example: 'Johan',
+            },
+            lastName: {
+              type: 'string',
+              example: 'Botha',
+            },
+            email: {
+              type: 'string',
+              format: 'email',
+              example: 'johan@example.com',
+            },
+            userType: {
+              type: 'string',
+              enum: ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],
+              example: 'GENERAL_TRAINEE',
+            },
+            authStatus: {
+              type: 'string',
+              enum: ['PENDING', 'ACTIVE', 'DISABLED'],
+              example: 'ACTIVE',
+            },
+            traineeProfile: {
+              type: 'object',
+              nullable: true,
+              additionalProperties: true,
+            },
+            adminProfile: {
+              type: 'object',
+              nullable: true,
+              additionalProperties: true,
+            },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-05-11T20:44:54.000Z',
+            },
+          },
+        },
+        AuthUser: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/PublicUser',
+            },
+          ],
+          description: 'Authenticated user attached to protected requests.',
+        },
+      },
+      parameters: {
+        CampaignItemIdPathParam: {
+          name: 'campaignItemId',
+          in: 'path',
+          required: true,
+          description: 'Campaign item identifier.',
+          schema: {
+            type: 'string',
+          },
+          example: 'campaign-item-123',
+        },
+        EmailIdPathParam: {
+          name: 'emailId',
+          in: 'path',
+          required: true,
+          description: 'Simulated email identifier.',
+          schema: {
+            type: 'string',
+          },
+          example: 'email-123',
+        },
+      },
+      responses: {
+        BadRequest: {
+          description: 'The request payload or parameters are invalid.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationErrorResponse',
+              },
+            },
+          },
+        },
+        Unauthorized: {
+          description: 'Authentication credentials are missing or invalid.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ApiErrorResponse',
+              },
+            },
+          },
+        },
+        Forbidden: {
+          description: 'The authenticated user is not allowed to perform this action.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ApiErrorResponse',
+              },
+            },
+          },
+        },
+        NotFound: {
+          description: 'The requested resource was not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ApiErrorResponse',
+              },
+            },
+          },
+        },
+        Conflict: {
+          description: 'The request conflicts with an existing resource or state.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ApiErrorResponse',
+              },
+            },
+          },
+        },
+        TooManyRequests: {
+          description: 'The client has exceeded the configured rate limit.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/RateLimitErrorResponse',
+              },
+            },
+          },
+        },
+        InternalServerError: {
+          description: 'An unexpected server error occurred.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ApiErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
   },
   apis: ['./src/app.ts', './src/routes/*.ts'], // Path to the API docs
 };

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -192,6 +192,27 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           ],
         },
+        AuthRateLimitErrorResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/RateLimitErrorResponse',
+            },
+            {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  enum: ['AUTH_RATE_LIMITED'],
+                  example: 'AUTH_RATE_LIMITED',
+                },
+                message: {
+                  type: 'string',
+                  example: 'Too many authentication requests. Please try again later.',
+                },
+              },
+            },
+          ],
+        },
         UserType: {
           type: 'string',
           enum: ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -150,6 +150,128 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           ],
         },
+        AuthEmailExistsErrorResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ApiErrorResponse',
+            },
+            {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  enum: ['AUTH_EMAIL_EXISTS'],
+                  example: 'AUTH_EMAIL_EXISTS',
+                },
+                message: {
+                  type: 'string',
+                  example: 'A user with the provided email already exists',
+                },
+              },
+            },
+          ],
+        },
+        AuthInvalidErrorResponse: {
+          allOf: [
+            {
+              $ref: '#/components/schemas/ApiErrorResponse',
+            },
+            {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  enum: ['AUTH_INVALID'],
+                  example: 'AUTH_INVALID',
+                },
+                message: {
+                  type: 'string',
+                  example: 'Invalid email or password',
+                },
+              },
+            },
+          ],
+        },
+        UserType: {
+          type: 'string',
+          enum: ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],
+          example: 'GENERAL_TRAINEE',
+        },
+        AuthStatus: {
+          type: 'string',
+          enum: ['PENDING', 'ACTIVE', 'DISABLED'],
+          example: 'ACTIVE',
+        },
+        PublicOrganisation: {
+          type: 'object',
+          required: ['id', 'name'],
+          properties: {
+            id: {
+              type: 'string',
+              example: 'org-123',
+            },
+            name: {
+              type: 'string',
+              example: 'Example Organisation',
+            },
+          },
+        },
+        PublicTraineeProfile: {
+          type: 'object',
+          required: ['id', 'traineeStatus', 'traineeType'],
+          properties: {
+            id: {
+              type: 'string',
+              example: 'trainee-profile-123',
+            },
+            traineeStatus: {
+              type: 'string',
+              enum: ['ACTIVE', 'INACTIVE'],
+              example: 'ACTIVE',
+            },
+            traineeType: {
+              type: 'string',
+              enum: ['GENERAL', 'ORGANISATION'],
+              example: 'GENERAL',
+            },
+            organisation: {
+              nullable: true,
+              allOf: [
+                {
+                  $ref: '#/components/schemas/PublicOrganisation',
+                },
+              ],
+            },
+          },
+        },
+        PublicAdminProfile: {
+          type: 'object',
+          required: ['id', 'adminStatus', 'adminType'],
+          properties: {
+            id: {
+              type: 'string',
+              example: 'admin-profile-123',
+            },
+            adminStatus: {
+              type: 'string',
+              enum: ['ACTIVE', 'INACTIVE'],
+              example: 'ACTIVE',
+            },
+            adminType: {
+              type: 'string',
+              enum: ['ORGANISATION', 'IP'],
+              example: 'ORGANISATION',
+            },
+            organisation: {
+              nullable: true,
+              allOf: [
+                {
+                  $ref: '#/components/schemas/PublicOrganisation',
+                },
+              ],
+            },
+          },
+        },
         PublicUser: {
           type: 'object',
           required: ['id', 'firstName', 'lastName', 'email', 'userType', 'authStatus', 'createdAt'],
@@ -172,24 +294,26 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
               example: 'johan@example.com',
             },
             userType: {
-              type: 'string',
-              enum: ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],
-              example: 'GENERAL_TRAINEE',
+              $ref: '#/components/schemas/UserType',
             },
             authStatus: {
-              type: 'string',
-              enum: ['PENDING', 'ACTIVE', 'DISABLED'],
-              example: 'ACTIVE',
+              $ref: '#/components/schemas/AuthStatus',
             },
             traineeProfile: {
-              type: 'object',
               nullable: true,
-              additionalProperties: true,
+              allOf: [
+                {
+                  $ref: '#/components/schemas/PublicTraineeProfile',
+                },
+              ],
             },
             adminProfile: {
-              type: 'object',
               nullable: true,
-              additionalProperties: true,
+              allOf: [
+                {
+                  $ref: '#/components/schemas/PublicAdminProfile',
+                },
+              ],
             },
             createdAt: {
               type: 'string',
@@ -205,6 +329,97 @@ Full endpoint coverage is optional for Sprint 2. This documentation serves as a 
             },
           ],
           description: 'Authenticated user attached to protected requests.',
+        },
+        AuthRegisterRequest: {
+          type: 'object',
+          required: ['email', 'password', 'firstName', 'lastName'],
+          properties: {
+            email: {
+              type: 'string',
+              format: 'email',
+              description: 'Email is trimmed and lowercased before registration.',
+              example: 'johan@example.com',
+            },
+            password: {
+              type: 'string',
+              format: 'password',
+              minLength: 8,
+              example: 'correct-horse-battery-staple',
+            },
+            firstName: {
+              type: 'string',
+              minLength: 1,
+              description: 'First name is trimmed before registration.',
+              example: 'Johan',
+            },
+            lastName: {
+              type: 'string',
+              minLength: 1,
+              description: 'Last name is trimmed before registration.',
+              example: 'Botha',
+            },
+          },
+        },
+        AuthLoginRequest: {
+          type: 'object',
+          required: ['email', 'password'],
+          properties: {
+            email: {
+              type: 'string',
+              format: 'email',
+              description: 'Email is trimmed and lowercased before login.',
+              example: 'johan@example.com',
+            },
+            password: {
+              type: 'string',
+              format: 'password',
+              minLength: 1,
+              example: 'correct-horse-battery-staple',
+            },
+          },
+        },
+        AuthRegisterResponse: {
+          type: 'object',
+          required: ['user'],
+          properties: {
+            user: {
+              $ref: '#/components/schemas/PublicUser',
+            },
+          },
+        },
+        AuthLoginResponse: {
+          type: 'object',
+          required: ['user', 'token', 'tokenType', 'expiresAt'],
+          properties: {
+            user: {
+              $ref: '#/components/schemas/PublicUser',
+            },
+            token: {
+              type: 'string',
+              description: 'Bearer token for authenticated requests.',
+              example:
+                'eyJ1c2VySWQiOiJ1c2VyLTEyMyIsImV4cGlyZXNBdCI6IjIwMjYtMDUtMTJUMjA6NDQ6NTQuMDAwWiJ9.signature',
+            },
+            tokenType: {
+              type: 'string',
+              enum: ['Bearer'],
+              example: 'Bearer',
+            },
+            expiresAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-05-12T20:44:54.000Z',
+            },
+          },
+        },
+        AuthMeResponse: {
+          type: 'object',
+          required: ['user'],
+          properties: {
+            user: {
+              $ref: '#/components/schemas/PublicUser',
+            },
+          },
         },
       },
       parameters: {

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -11,46 +11,21 @@ export const authRouter = Router();
  * @openapi
  * /auth/register:
  *   post:
- *     tags:
- *       - Auth
+ *     tags: [Auth]
  *     summary: Register a trainee account
- *     description: Creates a general trainee user account and returns the safe public user representation.
+ *     description: Creates a general trainee user account and returns the public user DTO.
  *     security: []
  *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/AuthRegisterRequest'
- *           examples:
- *             traineeRegistration:
- *               summary: Register a trainee
- *               value:
- *                 email: johan@example.com
- *                 password: correct-horse-battery-staple
- *                 firstName: Johan
- *                 lastName: Botha
+ *       $ref: '#/components/requestBodies/AuthRegister'
  *     responses:
  *       201:
- *         description: Account registered successfully.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRegisterResponse'
+ *         $ref: '#/components/responses/AuthRegisterCreated'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       409:
- *         description: A user with the provided email already exists.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthEmailExistsErrorResponse'
+ *         $ref: '#/components/responses/AuthEmailExists'
  *       429:
- *         description: Too many authentication requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *         $ref: '#/components/responses/AuthRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
@@ -60,44 +35,21 @@ authRouter.post('/auth/register', authRateLimit, validateBody(authRegisterReques
  * @openapi
  * /auth/login:
  *   post:
- *     tags:
- *       - Auth
+ *     tags: [Auth]
  *     summary: Log in with email and password
- *     description: Authenticates an active user and returns a bearer token with the safe public user representation.
+ *     description: Authenticates an active user and returns a bearer token.
  *     security: []
  *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/AuthLoginRequest'
- *           examples:
- *             traineeLogin:
- *               summary: Log in a user
- *               value:
- *                 email: johan@example.com
- *                 password: correct-horse-battery-staple
+ *       $ref: '#/components/requestBodies/AuthLogin'
  *     responses:
  *       200:
- *         description: Login successful.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthLoginResponse'
+ *         $ref: '#/components/responses/AuthLoginOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
- *         description: Email, password, or account status is invalid.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthInvalidErrorResponse'
+ *         $ref: '#/components/responses/AuthInvalid'
  *       429:
- *         description: Too many authentication requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *         $ref: '#/components/responses/AuthRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
@@ -107,33 +59,18 @@ authRouter.post('/auth/login', authRateLimit, validateBody(authLoginRequestSchem
  * @openapi
  * /auth/me:
  *   get:
- *     tags:
- *       - Auth
+ *     tags: [Auth]
  *     summary: Get the current authenticated user
- *     description: Returns the safe public user representation for the bearer token on the request.
+ *     description: Returns the public user DTO for the bearer token on the request.
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Current authenticated user.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthMeResponse'
+ *         $ref: '#/components/responses/AuthMeOk'
  *       401:
- *         description: Authentication credentials are missing or invalid.
- *         content:
- *           application/json:
- *             schema:
- *               oneOf:
- *                 - $ref: '#/components/schemas/ApiErrorResponse'
- *                 - $ref: '#/components/schemas/AuthInvalidErrorResponse'
+ *         $ref: '#/components/responses/Unauthorized'
  *       429:
- *         description: Too many authentication requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *         $ref: '#/components/responses/AuthRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -7,6 +7,134 @@ import { validateBody } from '../middleware/validateRequest.js';
 
 export const authRouter = Router();
 
+/**
+ * @openapi
+ * /auth/register:
+ *   post:
+ *     tags:
+ *       - Auth
+ *     summary: Register a trainee account
+ *     description: Creates a general trainee user account and returns the safe public user representation.
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AuthRegisterRequest'
+ *           examples:
+ *             traineeRegistration:
+ *               summary: Register a trainee
+ *               value:
+ *                 email: johan@example.com
+ *                 password: correct-horse-battery-staple
+ *                 firstName: Johan
+ *                 lastName: Botha
+ *     responses:
+ *       201:
+ *         description: Account registered successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRegisterResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       409:
+ *         description: A user with the provided email already exists.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthEmailExistsErrorResponse'
+ *       429:
+ *         description: Too many authentication requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 authRouter.post('/auth/register', authRateLimit, validateBody(authRegisterRequestSchema), register);
+
+/**
+ * @openapi
+ * /auth/login:
+ *   post:
+ *     tags:
+ *       - Auth
+ *     summary: Log in with email and password
+ *     description: Authenticates an active user and returns a bearer token with the safe public user representation.
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AuthLoginRequest'
+ *           examples:
+ *             traineeLogin:
+ *               summary: Log in a user
+ *               value:
+ *                 email: johan@example.com
+ *                 password: correct-horse-battery-staple
+ *     responses:
+ *       200:
+ *         description: Login successful.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthLoginResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         description: Email, password, or account status is invalid.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthInvalidErrorResponse'
+ *       429:
+ *         description: Too many authentication requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 authRouter.post('/auth/login', authRateLimit, validateBody(authLoginRequestSchema), login);
+
+/**
+ * @openapi
+ * /auth/me:
+ *   get:
+ *     tags:
+ *       - Auth
+ *     summary: Get the current authenticated user
+ *     description: Returns the safe public user representation for the bearer token on the request.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Current authenticated user.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthMeResponse'
+ *       401:
+ *         description: Authentication credentials are missing or invalid.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               oneOf:
+ *                 - $ref: '#/components/schemas/ApiErrorResponse'
+ *                 - $ref: '#/components/schemas/AuthInvalidErrorResponse'
+ *       429:
+ *         description: Too many authentication requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 authRouter.get('/auth/me', authRateLimit, requireAuth, getMe);

--- a/apps/backend/src/routes/health.routes.ts
+++ b/apps/backend/src/routes/health.routes.ts
@@ -7,62 +7,39 @@ export const healthRoutes = Router();
  * @openapi
  * /health:
  *   get:
+ *     tags:
+ *       - Health
  *     summary: Check system health
- *     description: Verifies API status and database connectivity.
+ *     description: Verifies that the API is reachable and reports the current database connectivity status.
+ *     security: []
  *     responses:
  *       200:
  *         description: API and database are reachable.
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               required:
- *                 - app
- *                 - api
- *                 - database
- *                 - timestamp
- *               properties:
- *                 app:
- *                   type: string
- *                   example: Insightful Phish
- *                 api:
- *                   type: string
- *                   enum: [working]
- *                   example: working
- *                 database:
- *                   type: string
- *                   enum: [connected]
- *                   example: connected
- *                 timestamp:
- *                   type: string
- *                   format: date-time
- *                   example: 2026-05-11T20:44:54.000Z
+ *               $ref: '#/components/schemas/HealthStatus'
+ *             examples:
+ *               connected:
+ *                 summary: Healthy response
+ *                 value:
+ *                   app: Insightful Phish
+ *                   api: working
+ *                   database: connected
+ *                   timestamp: 2026-05-11T20:44:54.000Z
  *       500:
  *         description: API is reachable, but the database check failed.
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               required:
- *                 - app
- *                 - api
- *                 - database
- *                 - timestamp
- *               properties:
- *                 app:
- *                   type: string
- *                   example: Insightful Phish
- *                 api:
- *                   type: string
- *                   enum: [working]
- *                   example: working
- *                 database:
- *                   type: string
- *                   enum: [not connected]
- *                   example: not connected
- *                 timestamp:
- *                   type: string
- *                   format: date-time
- *                   example: 2026-05-11T20:44:54.000Z
+ *               $ref: '#/components/schemas/HealthStatus'
+ *             examples:
+ *               databaseUnavailable:
+ *                 summary: Database connectivity failure
+ *                 value:
+ *                   app: Insightful Phish
+ *                   api: working
+ *                   database: not connected
+ *                   timestamp: 2026-05-11T20:44:54.000Z
  */
 healthRoutes.get('/health', getHealth);

--- a/apps/backend/src/routes/health.routes.ts
+++ b/apps/backend/src/routes/health.routes.ts
@@ -7,39 +7,14 @@ export const healthRoutes = Router();
  * @openapi
  * /health:
  *   get:
- *     tags:
- *       - Health
+ *     tags: [Health]
  *     summary: Check system health
- *     description: Verifies that the API is reachable and reports the current database connectivity status.
+ *     description: Verifies that the API is reachable and reports database connectivity.
  *     security: []
  *     responses:
  *       200:
- *         description: API and database are reachable.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/HealthStatus'
- *             examples:
- *               connected:
- *                 summary: Healthy response
- *                 value:
- *                   app: Insightful Phish
- *                   api: working
- *                   database: connected
- *                   timestamp: 2026-05-11T20:44:54.000Z
+ *         $ref: '#/components/responses/HealthOk'
  *       500:
- *         description: API is reachable, but the database check failed.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/HealthStatus'
- *             examples:
- *               databaseUnavailable:
- *                 summary: Database connectivity failure
- *                 value:
- *                   app: Insightful Phish
- *                   api: working
- *                   database: not connected
- *                   timestamp: 2026-05-11T20:44:54.000Z
+ *         $ref: '#/components/responses/HealthDatabaseUnavailable'
  */
 healthRoutes.get('/health', getHealth);

--- a/apps/backend/src/routes/quiz.routes.ts
+++ b/apps/backend/src/routes/quiz.routes.ts
@@ -16,6 +16,46 @@ export const traineeQuizRouter = Router();
 export const quizAttemptRouter = Router();
 
 // Routes for /trainee/campaign-items/:campaignItemId/quiz
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/quiz:
+ *   get:
+ *     tags:
+ *       - Trainee Quiz
+ *     summary: Get a quiz for a campaign item
+ *     description: Resolves a trainee-accessible quiz through campaign assignment and campaign item availability. The trainee-facing response does not expose correct answers or answer feedback before submission.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *     responses:
+ *       200:
+ *         description: Quiz content safe for trainee pre-submission display.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetQuizResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Quiz or associated campaign item was not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         description: Too many authentication-protected quiz requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 traineeQuizRouter.get(
   '/:campaignItemId/quiz',
   authRateLimit,
@@ -24,6 +64,52 @@ traineeQuizRouter.get(
   getQuiz,
 );
 
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/quiz/attempts:
+ *   post:
+ *     tags:
+ *       - Trainee Quiz
+ *     summary: Start or reuse a quiz attempt
+ *     description: Starts a quiz attempt for the campaign item, or returns the latest in-progress attempt when one already exists.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/EmptyRequestBody'
+ *     responses:
+ *       201:
+ *         description: Quiz attempt is ready for answers.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/StartQuizAttemptResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Quiz or associated campaign item was not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         description: Too many authentication-protected quiz requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 traineeQuizRouter.post(
   '/:campaignItemId/quiz/attempts',
   authRateLimit,
@@ -34,6 +120,66 @@ traineeQuizRouter.post(
 );
 
 // Routes for /quiz-attempts/:attemptId
+/**
+ * @openapi
+ * /quiz-attempts/{attemptId}/submit:
+ *   post:
+ *     tags:
+ *       - Trainee Quiz
+ *     summary: Submit a quiz attempt
+ *     description: Submits final answers for an in-progress attempt and scores the quiz. Validation rejects malformed IDs, duplicate question answers, unknown question or option IDs, duplicate selected options, missing answers, and invalid selection counts.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/AttemptIdPathParam'
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SubmitQuizAttemptRequest'
+ *           examples:
+ *             singleChoiceSubmission:
+ *               summary: Submit a selected option
+ *               value:
+ *                 answers:
+ *                   - questionId: 33333333-3333-3333-3333-333333333333
+ *                     selectedOptionIds:
+ *                       - 44444444-4444-4444-4444-444444444444
+ *     responses:
+ *       200:
+ *         description: Quiz attempt submitted successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SubmitQuizAttemptResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Quiz attempt was not found for this trainee.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       409:
+ *         description: Quiz attempt has already been submitted.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         description: Too many authentication-protected quiz requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 quizAttemptRouter.post(
   '/:attemptId/submit',
   authRateLimit,
@@ -43,6 +189,50 @@ quizAttemptRouter.post(
   submitAttempt,
 );
 
+/**
+ * @openapi
+ * /quiz-attempts/{attemptId}/results:
+ *   get:
+ *     tags:
+ *       - Trainee Quiz
+ *     summary: Get quiz attempt results
+ *     description: Returns quiz result scoring and answer-level feedback after the attempt has been submitted.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/AttemptIdPathParam'
+ *     responses:
+ *       200:
+ *         description: Quiz result and answer feedback for a submitted attempt.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetQuizResultResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         description: Results are not available until the attempt is submitted, or the user cannot access the attempt.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       404:
+ *         description: Quiz attempt was not found for this trainee.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         description: Too many authentication-protected quiz requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 quizAttemptRouter.get(
   '/:attemptId/results',
   authRateLimit,

--- a/apps/backend/src/routes/quiz.routes.ts
+++ b/apps/backend/src/routes/quiz.routes.ts
@@ -20,21 +20,16 @@ export const quizAttemptRouter = Router();
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/quiz:
  *   get:
- *     tags:
- *       - Trainee Quiz
+ *     tags: [Trainee Quiz]
  *     summary: Get a quiz for a campaign item
- *     description: Resolves a trainee-accessible quiz through campaign assignment and campaign item availability. The trainee-facing response does not expose correct answers or answer feedback before submission.
+ *     description: Returns trainee-safe quiz content without correct answers or feedback.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *     responses:
  *       200:
- *         description: Quiz content safe for trainee pre-submission display.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/GetQuizResponse'
+ *         $ref: '#/components/responses/QuizOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -42,17 +37,9 @@ export const quizAttemptRouter = Router();
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  *       404:
- *         description: Quiz or associated campaign item was not found.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/QuizNotFound'
  *       429:
- *         description: Too many authentication-protected quiz requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *         $ref: '#/components/responses/AuthRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
@@ -68,27 +55,18 @@ traineeQuizRouter.get(
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/quiz/attempts:
  *   post:
- *     tags:
- *       - Trainee Quiz
+ *     tags: [Trainee Quiz]
  *     summary: Start or reuse a quiz attempt
- *     description: Starts a quiz attempt for the campaign item, or returns the latest in-progress attempt when one already exists.
+ *     description: Starts an attempt or returns the latest in-progress attempt for the campaign item.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *     requestBody:
- *       required: false
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/EmptyRequestBody'
+ *       $ref: '#/components/requestBodies/EmptyJson'
  *     responses:
  *       201:
- *         description: Quiz attempt is ready for answers.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/StartQuizAttemptResponse'
+ *         $ref: '#/components/responses/QuizAttemptCreated'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -96,17 +74,9 @@ traineeQuizRouter.get(
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  *       404:
- *         description: Quiz or associated campaign item was not found.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/QuizNotFound'
  *       429:
- *         description: Too many authentication-protected quiz requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *         $ref: '#/components/responses/AuthRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
@@ -124,35 +94,18 @@ traineeQuizRouter.post(
  * @openapi
  * /quiz-attempts/{attemptId}/submit:
  *   post:
- *     tags:
- *       - Trainee Quiz
+ *     tags: [Trainee Quiz]
  *     summary: Submit a quiz attempt
- *     description: Submits final answers for an in-progress attempt and scores the quiz. Validation rejects malformed IDs, duplicate question answers, unknown question or option IDs, duplicate selected options, missing answers, and invalid selection counts.
+ *     description: Submits final answers and validates question IDs, option IDs, and selection counts.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/AttemptIdPathParam'
  *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/SubmitQuizAttemptRequest'
- *           examples:
- *             singleChoiceSubmission:
- *               summary: Submit a selected option
- *               value:
- *                 answers:
- *                   - questionId: 33333333-3333-3333-3333-333333333333
- *                     selectedOptionIds:
- *                       - 44444444-4444-4444-4444-444444444444
+ *       $ref: '#/components/requestBodies/SubmitQuizAttempt'
  *     responses:
  *       200:
- *         description: Quiz attempt submitted successfully.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/SubmitQuizAttemptResponse'
+ *         $ref: '#/components/responses/QuizAttemptSubmitted'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -160,23 +113,11 @@ traineeQuizRouter.post(
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  *       404:
- *         description: Quiz attempt was not found for this trainee.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/QuizNotFound'
  *       409:
- *         description: Quiz attempt has already been submitted.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/QuizAttemptAlreadySubmitted'
  *       429:
- *         description: Too many authentication-protected quiz requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *         $ref: '#/components/responses/AuthRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
@@ -193,43 +134,26 @@ quizAttemptRouter.post(
  * @openapi
  * /quiz-attempts/{attemptId}/results:
  *   get:
- *     tags:
- *       - Trainee Quiz
+ *     tags: [Trainee Quiz]
  *     summary: Get quiz attempt results
- *     description: Returns quiz result scoring and answer-level feedback after the attempt has been submitted.
+ *     description: Returns scoring and answer-level feedback after the attempt has been submitted.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/AttemptIdPathParam'
  *     responses:
  *       200:
- *         description: Quiz result and answer feedback for a submitted attempt.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/GetQuizResultResponse'
+ *         $ref: '#/components/responses/QuizResultOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
  *         $ref: '#/components/responses/Unauthorized'
  *       403:
- *         description: Results are not available until the attempt is submitted, or the user cannot access the attempt.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/QuizResultUnavailable'
  *       404:
- *         description: Quiz attempt was not found for this trainee.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/QuizNotFound'
  *       429:
- *         description: Too many authentication-protected quiz requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/AuthRateLimitErrorResponse'
+ *         $ref: '#/components/responses/AuthRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */

--- a/apps/backend/src/routes/trainee-training.routes.ts
+++ b/apps/backend/src/routes/trainee-training.routes.ts
@@ -20,37 +20,24 @@ export const traineeTrainingRouter = Router();
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/training-document:
  *   get:
- *     tags:
- *       - Trainee Training
+ *     tags: [Trainee Training]
  *     summary: Get a training document for a campaign item
- *     description: Resolves a trainee-accessible training document through the authenticated user's campaign assignment and campaign item availability.
+ *     description: Resolves a trainee-accessible training document through campaign item access.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *     responses:
  *       200:
- *         description: Training document resolved for the campaign item.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/GetTrainingDocumentResponse'
+ *         $ref: '#/components/responses/TrainingDocumentOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
  *         $ref: '#/components/responses/Unauthorized'
  *       404:
- *         description: Training document is missing, unavailable, or not accessible to the trainee.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/TrainingDocumentNotFoundErrorResponse'
+ *         $ref: '#/components/responses/TrainingDocumentNotFound'
  *       429:
- *         description: Too many trainee training requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/TrainingRateLimitErrorResponse'
+ *         $ref: '#/components/responses/TrainingRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
@@ -66,43 +53,26 @@ traineeTrainingRouter.get(
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/training-document/viewed:
  *   post:
- *     tags:
- *       - Trainee Training
+ *     tags: [Trainee Training]
  *     summary: Record a training document view
- *     description: Records a TRAINING_VIEWED interaction after resolving access through the authenticated user's campaign assignment and campaign item availability.
+ *     description: Records a TRAINING_VIEWED interaction for the campaign item.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *     requestBody:
- *       required: false
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/EmptyRequestBody'
+ *       $ref: '#/components/requestBodies/EmptyJson'
  *     responses:
  *       201:
- *         description: Training view interaction recorded.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/RecordTrainingInteractionResponse'
+ *         $ref: '#/components/responses/TrainingViewedCreated'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
  *         $ref: '#/components/responses/Unauthorized'
  *       404:
- *         description: Training document is missing, unavailable, or not accessible to the trainee.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/TrainingDocumentNotFoundErrorResponse'
+ *         $ref: '#/components/responses/TrainingDocumentNotFound'
  *       429:
- *         description: Too many trainee training requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/TrainingRateLimitErrorResponse'
+ *         $ref: '#/components/responses/TrainingRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
@@ -119,43 +89,26 @@ traineeTrainingRouter.post(
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/training-document/completed:
  *   post:
- *     tags:
- *       - Trainee Training
+ *     tags: [Trainee Training]
  *     summary: Record training document completion
- *     description: Records a TRAINING_COMPLETED interaction after resolving access through the authenticated user's campaign assignment and campaign item availability.
+ *     description: Records a TRAINING_COMPLETED interaction for the campaign item.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *     requestBody:
- *       required: false
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/EmptyRequestBody'
+ *       $ref: '#/components/requestBodies/EmptyJson'
  *     responses:
  *       201:
- *         description: Training completion interaction recorded.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/RecordTrainingInteractionResponse'
+ *         $ref: '#/components/responses/TrainingCompletedCreated'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
  *         $ref: '#/components/responses/Unauthorized'
  *       404:
- *         description: Training document is missing, unavailable, or not accessible to the trainee.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/TrainingDocumentNotFoundErrorResponse'
+ *         $ref: '#/components/responses/TrainingDocumentNotFound'
  *       429:
- *         description: Too many trainee training requests.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/TrainingRateLimitErrorResponse'
+ *         $ref: '#/components/responses/TrainingRateLimited'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */

--- a/apps/backend/src/routes/trainee-training.routes.ts
+++ b/apps/backend/src/routes/trainee-training.routes.ts
@@ -16,6 +16,44 @@ import { validateParams } from '../middleware/validateParams.js';
 
 export const traineeTrainingRouter = Router();
 
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/training-document:
+ *   get:
+ *     tags:
+ *       - Trainee Training
+ *     summary: Get a training document for a campaign item
+ *     description: Resolves a trainee-accessible training document through the authenticated user's campaign assignment and campaign item availability.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *     responses:
+ *       200:
+ *         description: Training document resolved for the campaign item.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetTrainingDocumentResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: Training document is missing, unavailable, or not accessible to the trainee.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TrainingDocumentNotFoundErrorResponse'
+ *       429:
+ *         description: Too many trainee training requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TrainingRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 traineeTrainingRouter.get(
   '/trainee/campaign-items/:campaignItemId/training-document',
   traineeTrainingRateLimit,
@@ -24,6 +62,50 @@ traineeTrainingRouter.get(
   getTrainingDocument,
 );
 
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/training-document/viewed:
+ *   post:
+ *     tags:
+ *       - Trainee Training
+ *     summary: Record a training document view
+ *     description: Records a TRAINING_VIEWED interaction after resolving access through the authenticated user's campaign assignment and campaign item availability.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/EmptyRequestBody'
+ *     responses:
+ *       201:
+ *         description: Training view interaction recorded.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RecordTrainingInteractionResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: Training document is missing, unavailable, or not accessible to the trainee.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TrainingDocumentNotFoundErrorResponse'
+ *       429:
+ *         description: Too many trainee training requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TrainingRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 traineeTrainingRouter.post(
   '/trainee/campaign-items/:campaignItemId/training-document/viewed',
   traineeTrainingRateLimit,
@@ -33,6 +115,50 @@ traineeTrainingRouter.post(
   recordTrainingViewed,
 );
 
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/training-document/completed:
+ *   post:
+ *     tags:
+ *       - Trainee Training
+ *     summary: Record training document completion
+ *     description: Records a TRAINING_COMPLETED interaction after resolving access through the authenticated user's campaign assignment and campaign item availability.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/EmptyRequestBody'
+ *     responses:
+ *       201:
+ *         description: Training completion interaction recorded.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RecordTrainingInteractionResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       404:
+ *         description: Training document is missing, unavailable, or not accessible to the trainee.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TrainingDocumentNotFoundErrorResponse'
+ *       429:
+ *         description: Too many trainee training requests.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TrainingRateLimitErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 traineeTrainingRouter.post(
   '/trainee/campaign-items/:campaignItemId/training-document/completed',
   traineeTrainingRateLimit,

--- a/apps/backend/src/routes/trainee.routes.ts
+++ b/apps/backend/src/routes/trainee.routes.ts
@@ -24,21 +24,16 @@ router.use(apiRateLimit);
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/simulated-inbox:
  *   get:
- *     tags:
- *       - Trainee Simulation
+ *     tags: [Trainee Simulation]
  *     summary: Get a simulated inbox for a campaign item
- *     description: Resolves a trainee-accessible simulated inbox through the authenticated user's campaign assignment and campaign item availability.
+ *     description: Resolves a trainee-accessible simulated inbox through campaign item access.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *     responses:
  *       200:
- *         description: Simulated inbox email summaries for the campaign item.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/SimulatedInbox'
+ *         $ref: '#/components/responses/SimulatedInboxOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -46,11 +41,7 @@ router.use(apiRateLimit);
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  *       404:
- *         description: Simulated inbox is missing, unavailable, or not accessible through this campaign item.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/SimulationNotFound'
  *       429:
  *         $ref: '#/components/responses/TooManyRequests'
  *       500:
@@ -68,10 +59,9 @@ router.get(
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}:
  *   get:
- *     tags:
- *       - Trainee Simulation
+ *     tags: [Trainee Simulation]
  *     summary: Get simulated email details
- *     description: Resolves a trainee-accessible simulated email through the authenticated user's campaign assignment and campaign item availability. The response intentionally does not expose expectedClassification or redFlags before classification.
+ *     description: Returns pre-classification email details without expectedClassification or redFlags.
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -79,11 +69,7 @@ router.get(
  *       - $ref: '#/components/parameters/EmailIdPathParam'
  *     responses:
  *       200:
- *         description: Simulated email details safe for pre-classification display.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/SimulatedEmailDetail'
+ *         $ref: '#/components/responses/SimulatedEmailDetailOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -91,11 +77,7 @@ router.get(
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  *       404:
- *         description: Simulated email is missing or not accessible through this campaign item.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/SimulationNotFound'
  *       429:
  *         $ref: '#/components/responses/TooManyRequests'
  *       500:
@@ -113,33 +95,19 @@ router.get(
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/interactions:
  *   post:
- *     tags:
- *       - Trainee Simulation
+ *     tags: [Trainee Simulation]
  *     summary: Record a simulated email interaction
- *     description: Records an allowed simulated email interaction event after resolving access through the authenticated user's campaign assignment and campaign item availability. No client-supplied context or sensitive metadata is accepted.
+ *     description: Records an allowed interaction event without accepting sensitive metadata.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *       - $ref: '#/components/parameters/EmailIdPathParam'
  *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/RecordSimulatedEmailInteractionRequest'
- *           examples:
- *             linkClicked:
- *               summary: Link clicked interaction
- *               value:
- *                 eventType: SIMULATED_EMAIL_LINK_CLICKED
+ *       $ref: '#/components/requestBodies/RecordSimulatedEmailInteraction'
  *     responses:
  *       200:
- *         description: Simulated email interaction recorded.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/RecordSimulatedEmailInteractionResponse'
+ *         $ref: '#/components/responses/SimulatedEmailInteractionOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -147,11 +115,7 @@ router.get(
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  *       404:
- *         description: Simulated email is missing or not accessible through this campaign item.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/SimulationNotFound'
  *       429:
  *         $ref: '#/components/responses/TooManyRequests'
  *       500:
@@ -170,35 +134,19 @@ router.post(
  * @openapi
  * /trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/classification:
  *   post:
- *     tags:
- *       - Trainee Simulation
+ *     tags: [Trainee Simulation]
  *     summary: Classify a simulated email
- *     description: Records the trainee's selected email classification after resolving access through the authenticated user's campaign assignment and campaign item availability. The expectedClassification and redFlags are not provided before classification; feedback and redFlags are returned after classification.
+ *     description: Records classification and returns feedback plus red flags only after submission.
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
  *       - $ref: '#/components/parameters/EmailIdPathParam'
  *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/ClassifySimulatedEmailRequest'
- *           examples:
- *             phishingClassification:
- *               summary: Classify an email as phishing
- *               value:
- *                 selectedClassification: PHISHING
- *                 selectedRedFlagIds:
- *                   - 33333333-3333-3333-3333-333333333333
+ *       $ref: '#/components/requestBodies/ClassifySimulatedEmail'
  *     responses:
  *       200:
- *         description: Simulated email classification recorded with feedback.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ClassifySimulatedEmailResponse'
+ *         $ref: '#/components/responses/SimulatedEmailClassificationOk'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       401:
@@ -206,17 +154,9 @@ router.post(
  *       403:
  *         $ref: '#/components/responses/Forbidden'
  *       404:
- *         description: Simulated email is missing or not accessible through this campaign item.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/SimulationNotFound'
  *       409:
- *         description: The simulated email has already been classified by this trainee.
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
+ *         $ref: '#/components/responses/SimulatedEmailAlreadyClassified'
  *       429:
  *         $ref: '#/components/responses/TooManyRequests'
  *       500:

--- a/apps/backend/src/routes/trainee.routes.ts
+++ b/apps/backend/src/routes/trainee.routes.ts
@@ -20,6 +20,42 @@ const simulationController = new SimulationController();
 router.use(apiRateLimit);
 
 // Simulated Inbox
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/simulated-inbox:
+ *   get:
+ *     tags:
+ *       - Trainee Simulation
+ *     summary: Get a simulated inbox for a campaign item
+ *     description: Resolves a trainee-accessible simulated inbox through the authenticated user's campaign assignment and campaign item availability.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *     responses:
+ *       200:
+ *         description: Simulated inbox email summaries for the campaign item.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimulatedInbox'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Simulated inbox is missing, unavailable, or not accessible through this campaign item.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         $ref: '#/components/responses/TooManyRequests'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 router.get(
   '/campaign-items/:campaignItemId/simulated-inbox',
   requireAuth,
@@ -28,6 +64,43 @@ router.get(
 );
 
 // Simulated Email Details
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}:
+ *   get:
+ *     tags:
+ *       - Trainee Simulation
+ *     summary: Get simulated email details
+ *     description: Resolves a trainee-accessible simulated email through the authenticated user's campaign assignment and campaign item availability. The response intentionally does not expose expectedClassification or redFlags before classification.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *       - $ref: '#/components/parameters/EmailIdPathParam'
+ *     responses:
+ *       200:
+ *         description: Simulated email details safe for pre-classification display.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimulatedEmailDetail'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Simulated email is missing or not accessible through this campaign item.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         $ref: '#/components/responses/TooManyRequests'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 router.get(
   '/campaign-items/:campaignItemId/simulated-emails/:emailId',
   requireAuth,

--- a/apps/backend/src/routes/trainee.routes.ts
+++ b/apps/backend/src/routes/trainee.routes.ts
@@ -109,6 +109,54 @@ router.get(
 );
 
 // Simulated Email Interactions
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/interactions:
+ *   post:
+ *     tags:
+ *       - Trainee Simulation
+ *     summary: Record a simulated email interaction
+ *     description: Records an allowed simulated email interaction event after resolving access through the authenticated user's campaign assignment and campaign item availability. No client-supplied context or sensitive metadata is accepted.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *       - $ref: '#/components/parameters/EmailIdPathParam'
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/RecordSimulatedEmailInteractionRequest'
+ *           examples:
+ *             linkClicked:
+ *               summary: Link clicked interaction
+ *               value:
+ *                 eventType: SIMULATED_EMAIL_LINK_CLICKED
+ *     responses:
+ *       200:
+ *         description: Simulated email interaction recorded.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RecordSimulatedEmailInteractionResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Simulated email is missing or not accessible through this campaign item.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         $ref: '#/components/responses/TooManyRequests'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 router.post(
   '/campaign-items/:campaignItemId/simulated-emails/:emailId/interactions',
   requireAuth,
@@ -118,6 +166,62 @@ router.post(
 );
 
 // Simulated Email Classification
+/**
+ * @openapi
+ * /trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/classification:
+ *   post:
+ *     tags:
+ *       - Trainee Simulation
+ *     summary: Classify a simulated email
+ *     description: Records the trainee's selected email classification after resolving access through the authenticated user's campaign assignment and campaign item availability. The expectedClassification and redFlags are not provided before classification; feedback and redFlags are returned after classification.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/CampaignItemIdPathParam'
+ *       - $ref: '#/components/parameters/EmailIdPathParam'
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ClassifySimulatedEmailRequest'
+ *           examples:
+ *             phishingClassification:
+ *               summary: Classify an email as phishing
+ *               value:
+ *                 selectedClassification: PHISHING
+ *                 selectedRedFlagIds:
+ *                   - 33333333-3333-3333-3333-333333333333
+ *     responses:
+ *       200:
+ *         description: Simulated email classification recorded with feedback.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ClassifySimulatedEmailResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         description: Simulated email is missing or not accessible through this campaign item.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       409:
+ *         description: The simulated email has already been classified by this trainee.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         $ref: '#/components/responses/TooManyRequests'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 router.post(
   '/campaign-items/:campaignItemId/simulated-emails/:emailId/classification',
   requireAuth,

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -90,10 +90,16 @@ describe('swaggerSpec', () => {
     );
   });
 
-  it('includes the mounted trainee simulation read paths', () => {
+  it('includes the mounted trainee simulation paths', () => {
     expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/simulated-inbox');
     expect(spec.paths).toHaveProperty(
       '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}',
+    );
+    expect(spec.paths).toHaveProperty(
+      '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/interactions',
+    );
+    expect(spec.paths).toHaveProperty(
+      '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/classification',
     );
   });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -102,4 +102,32 @@ describe('swaggerSpec', () => {
       '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/classification',
     );
   });
+
+  it('includes reusable trainee quiz schemas without leaking pre-submission answers', () => {
+    expect(spec.components?.schemas).toHaveProperty('QuizCampaignItemContext');
+    expect(spec.components?.schemas).toHaveProperty('QuizOptionForTrainee');
+    expect(spec.components?.schemas).toHaveProperty('QuizQuestionForTrainee');
+    expect(spec.components?.schemas).toHaveProperty('GetQuizResponse');
+    expect(spec.components?.schemas).toHaveProperty('StartQuizAttemptResponse');
+    expect(spec.components?.schemas).toHaveProperty('SubmitQuizAttemptRequest');
+    expect(spec.components?.schemas).toHaveProperty('SubmitQuizAttemptResponse');
+    expect(spec.components?.schemas).toHaveProperty('GetQuizResultResponse');
+    expect(spec.components?.schemas).toHaveProperty('QuizResultQuestion');
+    expect(spec.components?.schemas).toHaveProperty('QuizResultOption');
+    expect(spec.components?.schemas).toHaveProperty('QuizAttempt');
+    expect(spec.components?.schemas).toHaveProperty('AttemptAnswer');
+    expect(spec.components?.schemas).toHaveProperty('QuestionType');
+    expect(spec.components?.schemas).toHaveProperty('QuizAttemptStatus');
+    expect(spec.components?.schemas).toHaveProperty('QuizStatus');
+    expect(spec.components?.securitySchemes).toHaveProperty('bearerAuth');
+    expect(JSON.stringify(spec.components?.schemas?.GetQuizResponse)).not.toContain('isCorrect');
+    expect(JSON.stringify(spec.components?.schemas?.GetQuizResponse)).not.toContain('feedbackText');
+  });
+
+  it('includes the mounted trainee quiz paths', () => {
+    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/quiz');
+    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/quiz/attempts');
+    expect(spec.paths).toHaveProperty('/quiz-attempts/{attemptId}/submit');
+    expect(spec.paths).toHaveProperty('/quiz-attempts/{attemptId}/results');
+  });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -28,8 +28,15 @@ describe('swaggerSpec', () => {
     expect(spec.components?.schemas).toHaveProperty('AuthRegisterResponse');
     expect(spec.components?.schemas).toHaveProperty('AuthLoginResponse');
     expect(spec.components?.schemas).toHaveProperty('AuthMeResponse');
+    expect(spec.components?.schemas).toHaveProperty('AuthRateLimitErrorResponse');
     expect(spec.components?.schemas).toHaveProperty('UserType');
     expect(spec.components?.schemas).toHaveProperty('AuthStatus');
     expect(JSON.stringify(spec.components?.schemas?.PublicUser)).not.toContain('passwordHash');
+  });
+
+  it('includes the mounted auth paths', () => {
+    expect(spec.paths).toHaveProperty('/auth/register');
+    expect(spec.paths).toHaveProperty('/auth/login');
+    expect(spec.paths).toHaveProperty('/auth/me');
   });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { swaggerSpec } from '../../src/config/swagger.js';
+
+interface SwaggerSpecShape {
+  openapi?: string;
+  paths?: Record<string, unknown>;
+  components?: {
+    schemas?: Record<string, unknown>;
+    securitySchemes?: Record<string, unknown>;
+  };
+}
+
+describe('swaggerSpec', () => {
+  const spec = swaggerSpec as SwaggerSpecShape;
+
+  it('generates the base OpenAPI spec with health docs and shared components', () => {
+    expect(spec).toBeDefined();
+    expect(spec.openapi).toBe('3.0.0');
+    expect(spec.paths).toHaveProperty('/health');
+    expect(spec.components?.schemas).toHaveProperty('HealthStatus');
+    expect(spec.components?.schemas).toHaveProperty('ApiErrorResponse');
+    expect(spec.components?.securitySchemes).toHaveProperty('bearerAuth');
+  });
+});

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -1,28 +1,160 @@
 import { describe, expect, it } from 'vitest';
 import { swaggerSpec } from '../../src/config/swagger.js';
 
+type HttpMethod = 'get' | 'post';
+
+interface SwaggerOperationShape {
+  responses?: Record<string, unknown>;
+}
+
 interface SwaggerSpecShape {
   openapi?: string;
-  paths?: Record<string, unknown>;
+  paths?: Record<string, Record<string, SwaggerOperationShape>>;
   components?: {
     schemas?: Record<string, unknown>;
+    responses?: Record<string, unknown>;
     securitySchemes?: Record<string, unknown>;
   };
 }
 
+const expectedSchemas = [
+  'HealthStatus',
+  'ApiErrorResponse',
+  'ValidationErrorResponse',
+  'RateLimitErrorResponse',
+  'PublicUser',
+  'AuthRegisterRequest',
+  'AuthLoginRequest',
+  'AuthRegisterResponse',
+  'AuthLoginResponse',
+  'AuthMeResponse',
+  'AuthRateLimitErrorResponse',
+  'UserType',
+  'AuthStatus',
+  'TrainingDocument',
+  'TrainingCampaignItemContext',
+  'GetTrainingDocumentResponse',
+  'RecordTrainingInteractionResponse',
+  'TrainingInteractionEvent',
+  'EmptyRequestBody',
+  'TrainingContentType',
+  'DifficultyLevel',
+  'TrainingDocumentStatus',
+  'TrainingInteractionEventType',
+  'SimulatedInbox',
+  'SimulatedInboxEmailSummary',
+  'SimulatedEmailDetail',
+  'RecordSimulatedEmailInteractionRequest',
+  'RecordSimulatedEmailInteractionResponse',
+  'ClassifySimulatedEmailRequest',
+  'ClassifySimulatedEmailResponse',
+  'EmailRedFlag',
+  'EmailClassification',
+  'EmailRedFlagType',
+  'RedFlagSeverity',
+  'SimulatedEmailInteractionEventType',
+  'QuizCampaignItemContext',
+  'QuizOptionForTrainee',
+  'QuizQuestionForTrainee',
+  'GetQuizResponse',
+  'StartQuizAttemptResponse',
+  'SubmitQuizAttemptRequest',
+  'SubmitQuizAttemptResponse',
+  'GetQuizResultResponse',
+  'QuizResultQuestion',
+  'QuizResultOption',
+  'QuizAttempt',
+  'AttemptAnswer',
+  'QuestionType',
+  'QuizAttemptStatus',
+  'QuizStatus',
+] as const;
+
+const expectedResponses = [
+  'BadRequest',
+  'Unauthorized',
+  'Forbidden',
+  'NotFound',
+  'Conflict',
+  'TooManyRequests',
+  'InternalServerError',
+] as const;
+
+const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
+  ['get', '/health', ['200', '500']],
+  ['post', '/auth/register', ['201', '400', '409', '429', '500']],
+  ['post', '/auth/login', ['200', '400', '401', '429', '500']],
+  ['get', '/auth/me', ['200', '401', '429', '500']],
+  [
+    'get',
+    '/trainee/campaign-items/{campaignItemId}/training-document',
+    ['200', '400', '401', '404', '429', '500'],
+  ],
+  [
+    'post',
+    '/trainee/campaign-items/{campaignItemId}/training-document/viewed',
+    ['201', '400', '401', '404', '429', '500'],
+  ],
+  [
+    'post',
+    '/trainee/campaign-items/{campaignItemId}/training-document/completed',
+    ['201', '400', '401', '404', '429', '500'],
+  ],
+  [
+    'get',
+    '/trainee/campaign-items/{campaignItemId}/simulated-inbox',
+    ['200', '400', '401', '403', '404', '429', '500'],
+  ],
+  [
+    'get',
+    '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}',
+    ['200', '400', '401', '403', '404', '429', '500'],
+  ],
+  [
+    'post',
+    '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/interactions',
+    ['200', '400', '401', '403', '404', '429', '500'],
+  ],
+  [
+    'post',
+    '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/classification',
+    ['200', '400', '401', '403', '404', '409', '429', '500'],
+  ],
+  [
+    'get',
+    '/trainee/campaign-items/{campaignItemId}/quiz',
+    ['200', '400', '401', '403', '404', '429', '500'],
+  ],
+  [
+    'post',
+    '/trainee/campaign-items/{campaignItemId}/quiz/attempts',
+    ['201', '400', '401', '403', '404', '429', '500'],
+  ],
+  [
+    'post',
+    '/quiz-attempts/{attemptId}/submit',
+    ['200', '400', '401', '403', '404', '409', '429', '500'],
+  ],
+  ['get', '/quiz-attempts/{attemptId}/results', ['200', '400', '401', '403', '404', '429', '500']],
+];
+
 describe('swaggerSpec', () => {
   const spec = swaggerSpec as SwaggerSpecShape;
 
-  function expectComponentSchemas(schemaNames: string[]) {
-    for (const schemaName of schemaNames) {
-      expect(spec.components?.schemas).toHaveProperty(schemaName);
-    }
+  function getPath(path: string, method: HttpMethod) {
+    return spec.paths?.[path]?.[method];
   }
 
-  function expectPaths(paths: string[]) {
-    for (const path of paths) {
-      expect(spec.paths).toHaveProperty(path);
-    }
+  function expectPathExists(path: string, method: HttpMethod) {
+    expect(getPath(path, method), `${method.toUpperCase()} ${path}`).toBeDefined();
+  }
+
+  function expectSchemaExists(name: string) {
+    expect(spec.components?.schemas).toHaveProperty(name);
+  }
+
+  function expectPathResponse(path: string, method: HttpMethod, status: string) {
+    expect(getPath(path, method)?.responses).toHaveProperty(status);
   }
 
   function expectSchemaNotToContain(schemaName: string, forbiddenTerms: string[]) {
@@ -33,111 +165,37 @@ describe('swaggerSpec', () => {
     }
   }
 
-  it('generates the base OpenAPI spec with health docs and shared components', () => {
+  it('generates the base OpenAPI spec with bearer auth', () => {
     expect(spec).toBeDefined();
     expect(spec.openapi).toBe('3.0.0');
-    expectPaths(['/health']);
-    expectComponentSchemas(['HealthStatus', 'ApiErrorResponse']);
     expect(spec.components?.securitySchemes).toHaveProperty('bearerAuth');
   });
 
-  it('includes reusable auth schemas without exposing password hashes', () => {
-    expectComponentSchemas([
-      'AuthRegisterRequest',
-      'AuthLoginRequest',
-      'AuthRegisterResponse',
-      'AuthLoginResponse',
-      'AuthMeResponse',
-      'AuthRateLimitErrorResponse',
-      'UserType',
-      'AuthStatus',
-    ]);
+  it.each(expectedSchemas)('includes reusable schema %s', (schemaName) => {
+    expectSchemaExists(schemaName);
+  });
+
+  it.each(expectedResponses)('includes reusable response %s', (responseName) => {
+    expect(spec.components?.responses).toHaveProperty(responseName);
+  });
+
+  it.each(expectedRouteDocs)('documents %s %s', (method, path, statuses) => {
+    expectPathExists(path, method);
+
+    for (const status of statuses) {
+      expectPathResponse(path, method, status);
+    }
+  });
+
+  it('keeps public user schemas free of password hashes', () => {
     expectSchemaNotToContain('PublicUser', ['passwordHash']);
   });
 
-  it('includes the mounted auth paths', () => {
-    expectPaths(['/auth/register', '/auth/login', '/auth/me']);
-  });
-
-  it('includes reusable trainee training schemas', () => {
-    expectComponentSchemas([
-      'TrainingDocument',
-      'TrainingCampaignItemContext',
-      'GetTrainingDocumentResponse',
-      'RecordTrainingInteractionResponse',
-      'TrainingInteractionEvent',
-      'EmptyRequestBody',
-      'TrainingContentType',
-      'DifficultyLevel',
-      'TrainingDocumentStatus',
-      'TrainingInteractionEventType',
-    ]);
-    expectSchemaNotToContain('GetTrainingDocumentResponse', ['TrainingProgress', 'quiz']);
-  });
-
-  it('includes the mounted trainee training paths', () => {
-    expectPaths([
-      '/trainee/campaign-items/{campaignItemId}/training-document',
-      '/trainee/campaign-items/{campaignItemId}/training-document/viewed',
-      '/trainee/campaign-items/{campaignItemId}/training-document/completed',
-    ]);
-  });
-
-  it('includes reusable trainee simulation schemas without leaking classification answers', () => {
-    expectComponentSchemas([
-      'SimulatedInbox',
-      'SimulatedInboxEmailSummary',
-      'SimulatedEmailDetail',
-      'RecordSimulatedEmailInteractionRequest',
-      'RecordSimulatedEmailInteractionResponse',
-      'ClassifySimulatedEmailRequest',
-      'ClassifySimulatedEmailResponse',
-      'EmailRedFlag',
-      'EmailClassification',
-      'EmailRedFlagType',
-      'RedFlagSeverity',
-      'SimulatedEmailInteractionEventType',
-    ]);
+  it('keeps simulated email detail free of pre-classification answers', () => {
     expectSchemaNotToContain('SimulatedEmailDetail', ['expectedClassification', 'redFlags']);
   });
 
-  it('includes the mounted trainee simulation paths', () => {
-    expectPaths([
-      '/trainee/campaign-items/{campaignItemId}/simulated-inbox',
-      '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}',
-      '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/interactions',
-      '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/classification',
-    ]);
-  });
-
-  it('includes reusable trainee quiz schemas without leaking pre-submission answers', () => {
-    expectComponentSchemas([
-      'QuizCampaignItemContext',
-      'QuizOptionForTrainee',
-      'QuizQuestionForTrainee',
-      'GetQuizResponse',
-      'StartQuizAttemptResponse',
-      'SubmitQuizAttemptRequest',
-      'SubmitQuizAttemptResponse',
-      'GetQuizResultResponse',
-      'QuizResultQuestion',
-      'QuizResultOption',
-      'QuizAttempt',
-      'AttemptAnswer',
-      'QuestionType',
-      'QuizAttemptStatus',
-      'QuizStatus',
-    ]);
-    expect(spec.components?.securitySchemes).toHaveProperty('bearerAuth');
+  it('keeps quiz fetch response free of pre-submission answers', () => {
     expectSchemaNotToContain('GetQuizResponse', ['isCorrect', 'feedbackText']);
-  });
-
-  it('includes the mounted trainee quiz paths', () => {
-    expectPaths([
-      '/trainee/campaign-items/{campaignItemId}/quiz',
-      '/trainee/campaign-items/{campaignItemId}/quiz/attempts',
-      '/quiz-attempts/{attemptId}/submit',
-      '/quiz-attempts/{attemptId}/results',
-    ]);
   });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -21,4 +21,15 @@ describe('swaggerSpec', () => {
     expect(spec.components?.schemas).toHaveProperty('ApiErrorResponse');
     expect(spec.components?.securitySchemes).toHaveProperty('bearerAuth');
   });
+
+  it('includes reusable auth schemas without exposing password hashes', () => {
+    expect(spec.components?.schemas).toHaveProperty('AuthRegisterRequest');
+    expect(spec.components?.schemas).toHaveProperty('AuthLoginRequest');
+    expect(spec.components?.schemas).toHaveProperty('AuthRegisterResponse');
+    expect(spec.components?.schemas).toHaveProperty('AuthLoginResponse');
+    expect(spec.components?.schemas).toHaveProperty('AuthMeResponse');
+    expect(spec.components?.schemas).toHaveProperty('UserType');
+    expect(spec.components?.schemas).toHaveProperty('AuthStatus');
+    expect(JSON.stringify(spec.components?.schemas?.PublicUser)).not.toContain('passwordHash');
+  });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -68,4 +68,25 @@ describe('swaggerSpec', () => {
       '/trainee/campaign-items/{campaignItemId}/training-document/completed',
     );
   });
+
+  it('includes reusable trainee simulation schemas without leaking classification answers', () => {
+    expect(spec.components?.schemas).toHaveProperty('SimulatedInbox');
+    expect(spec.components?.schemas).toHaveProperty('SimulatedInboxEmailSummary');
+    expect(spec.components?.schemas).toHaveProperty('SimulatedEmailDetail');
+    expect(spec.components?.schemas).toHaveProperty('RecordSimulatedEmailInteractionRequest');
+    expect(spec.components?.schemas).toHaveProperty('RecordSimulatedEmailInteractionResponse');
+    expect(spec.components?.schemas).toHaveProperty('ClassifySimulatedEmailRequest');
+    expect(spec.components?.schemas).toHaveProperty('ClassifySimulatedEmailResponse');
+    expect(spec.components?.schemas).toHaveProperty('EmailRedFlag');
+    expect(spec.components?.schemas).toHaveProperty('EmailClassification');
+    expect(spec.components?.schemas).toHaveProperty('EmailRedFlagType');
+    expect(spec.components?.schemas).toHaveProperty('RedFlagSeverity');
+    expect(spec.components?.schemas).toHaveProperty('SimulatedEmailInteractionEventType');
+    expect(JSON.stringify(spec.components?.schemas?.SimulatedEmailDetail)).not.toContain(
+      'expectedClassification',
+    );
+    expect(JSON.stringify(spec.components?.schemas?.SimulatedEmailDetail)).not.toContain(
+      'redFlags',
+    );
+  });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -13,121 +13,131 @@ interface SwaggerSpecShape {
 describe('swaggerSpec', () => {
   const spec = swaggerSpec as SwaggerSpecShape;
 
+  function expectComponentSchemas(schemaNames: string[]) {
+    for (const schemaName of schemaNames) {
+      expect(spec.components?.schemas).toHaveProperty(schemaName);
+    }
+  }
+
+  function expectPaths(paths: string[]) {
+    for (const path of paths) {
+      expect(spec.paths).toHaveProperty(path);
+    }
+  }
+
+  function expectSchemaNotToContain(schemaName: string, forbiddenTerms: string[]) {
+    const serializedSchema = JSON.stringify(spec.components?.schemas?.[schemaName]);
+
+    for (const term of forbiddenTerms) {
+      expect(serializedSchema).not.toContain(term);
+    }
+  }
+
   it('generates the base OpenAPI spec with health docs and shared components', () => {
     expect(spec).toBeDefined();
     expect(spec.openapi).toBe('3.0.0');
-    expect(spec.paths).toHaveProperty('/health');
-    expect(spec.components?.schemas).toHaveProperty('HealthStatus');
-    expect(spec.components?.schemas).toHaveProperty('ApiErrorResponse');
+    expectPaths(['/health']);
+    expectComponentSchemas(['HealthStatus', 'ApiErrorResponse']);
     expect(spec.components?.securitySchemes).toHaveProperty('bearerAuth');
   });
 
   it('includes reusable auth schemas without exposing password hashes', () => {
-    expect(spec.components?.schemas).toHaveProperty('AuthRegisterRequest');
-    expect(spec.components?.schemas).toHaveProperty('AuthLoginRequest');
-    expect(spec.components?.schemas).toHaveProperty('AuthRegisterResponse');
-    expect(spec.components?.schemas).toHaveProperty('AuthLoginResponse');
-    expect(spec.components?.schemas).toHaveProperty('AuthMeResponse');
-    expect(spec.components?.schemas).toHaveProperty('AuthRateLimitErrorResponse');
-    expect(spec.components?.schemas).toHaveProperty('UserType');
-    expect(spec.components?.schemas).toHaveProperty('AuthStatus');
-    expect(JSON.stringify(spec.components?.schemas?.PublicUser)).not.toContain('passwordHash');
+    expectComponentSchemas([
+      'AuthRegisterRequest',
+      'AuthLoginRequest',
+      'AuthRegisterResponse',
+      'AuthLoginResponse',
+      'AuthMeResponse',
+      'AuthRateLimitErrorResponse',
+      'UserType',
+      'AuthStatus',
+    ]);
+    expectSchemaNotToContain('PublicUser', ['passwordHash']);
   });
 
   it('includes the mounted auth paths', () => {
-    expect(spec.paths).toHaveProperty('/auth/register');
-    expect(spec.paths).toHaveProperty('/auth/login');
-    expect(spec.paths).toHaveProperty('/auth/me');
+    expectPaths(['/auth/register', '/auth/login', '/auth/me']);
   });
 
   it('includes reusable trainee training schemas', () => {
-    expect(spec.components?.schemas).toHaveProperty('TrainingDocument');
-    expect(spec.components?.schemas).toHaveProperty('TrainingCampaignItemContext');
-    expect(spec.components?.schemas).toHaveProperty('GetTrainingDocumentResponse');
-    expect(spec.components?.schemas).toHaveProperty('RecordTrainingInteractionResponse');
-    expect(spec.components?.schemas).toHaveProperty('TrainingInteractionEvent');
-    expect(spec.components?.schemas).toHaveProperty('EmptyRequestBody');
-    expect(spec.components?.schemas).toHaveProperty('TrainingContentType');
-    expect(spec.components?.schemas).toHaveProperty('DifficultyLevel');
-    expect(spec.components?.schemas).toHaveProperty('TrainingDocumentStatus');
-    expect(spec.components?.schemas).toHaveProperty('TrainingInteractionEventType');
-    expect(JSON.stringify(spec.components?.schemas?.GetTrainingDocumentResponse)).not.toContain(
-      'TrainingProgress',
-    );
-    expect(JSON.stringify(spec.components?.schemas?.GetTrainingDocumentResponse)).not.toContain(
-      'quiz',
-    );
+    expectComponentSchemas([
+      'TrainingDocument',
+      'TrainingCampaignItemContext',
+      'GetTrainingDocumentResponse',
+      'RecordTrainingInteractionResponse',
+      'TrainingInteractionEvent',
+      'EmptyRequestBody',
+      'TrainingContentType',
+      'DifficultyLevel',
+      'TrainingDocumentStatus',
+      'TrainingInteractionEventType',
+    ]);
+    expectSchemaNotToContain('GetTrainingDocumentResponse', ['TrainingProgress', 'quiz']);
   });
 
   it('includes the mounted trainee training paths', () => {
-    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/training-document');
-    expect(spec.paths).toHaveProperty(
+    expectPaths([
+      '/trainee/campaign-items/{campaignItemId}/training-document',
       '/trainee/campaign-items/{campaignItemId}/training-document/viewed',
-    );
-    expect(spec.paths).toHaveProperty(
       '/trainee/campaign-items/{campaignItemId}/training-document/completed',
-    );
+    ]);
   });
 
   it('includes reusable trainee simulation schemas without leaking classification answers', () => {
-    expect(spec.components?.schemas).toHaveProperty('SimulatedInbox');
-    expect(spec.components?.schemas).toHaveProperty('SimulatedInboxEmailSummary');
-    expect(spec.components?.schemas).toHaveProperty('SimulatedEmailDetail');
-    expect(spec.components?.schemas).toHaveProperty('RecordSimulatedEmailInteractionRequest');
-    expect(spec.components?.schemas).toHaveProperty('RecordSimulatedEmailInteractionResponse');
-    expect(spec.components?.schemas).toHaveProperty('ClassifySimulatedEmailRequest');
-    expect(spec.components?.schemas).toHaveProperty('ClassifySimulatedEmailResponse');
-    expect(spec.components?.schemas).toHaveProperty('EmailRedFlag');
-    expect(spec.components?.schemas).toHaveProperty('EmailClassification');
-    expect(spec.components?.schemas).toHaveProperty('EmailRedFlagType');
-    expect(spec.components?.schemas).toHaveProperty('RedFlagSeverity');
-    expect(spec.components?.schemas).toHaveProperty('SimulatedEmailInteractionEventType');
-    expect(JSON.stringify(spec.components?.schemas?.SimulatedEmailDetail)).not.toContain(
-      'expectedClassification',
-    );
-    expect(JSON.stringify(spec.components?.schemas?.SimulatedEmailDetail)).not.toContain(
-      'redFlags',
-    );
+    expectComponentSchemas([
+      'SimulatedInbox',
+      'SimulatedInboxEmailSummary',
+      'SimulatedEmailDetail',
+      'RecordSimulatedEmailInteractionRequest',
+      'RecordSimulatedEmailInteractionResponse',
+      'ClassifySimulatedEmailRequest',
+      'ClassifySimulatedEmailResponse',
+      'EmailRedFlag',
+      'EmailClassification',
+      'EmailRedFlagType',
+      'RedFlagSeverity',
+      'SimulatedEmailInteractionEventType',
+    ]);
+    expectSchemaNotToContain('SimulatedEmailDetail', ['expectedClassification', 'redFlags']);
   });
 
   it('includes the mounted trainee simulation paths', () => {
-    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/simulated-inbox');
-    expect(spec.paths).toHaveProperty(
+    expectPaths([
+      '/trainee/campaign-items/{campaignItemId}/simulated-inbox',
       '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}',
-    );
-    expect(spec.paths).toHaveProperty(
       '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/interactions',
-    );
-    expect(spec.paths).toHaveProperty(
       '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}/classification',
-    );
+    ]);
   });
 
   it('includes reusable trainee quiz schemas without leaking pre-submission answers', () => {
-    expect(spec.components?.schemas).toHaveProperty('QuizCampaignItemContext');
-    expect(spec.components?.schemas).toHaveProperty('QuizOptionForTrainee');
-    expect(spec.components?.schemas).toHaveProperty('QuizQuestionForTrainee');
-    expect(spec.components?.schemas).toHaveProperty('GetQuizResponse');
-    expect(spec.components?.schemas).toHaveProperty('StartQuizAttemptResponse');
-    expect(spec.components?.schemas).toHaveProperty('SubmitQuizAttemptRequest');
-    expect(spec.components?.schemas).toHaveProperty('SubmitQuizAttemptResponse');
-    expect(spec.components?.schemas).toHaveProperty('GetQuizResultResponse');
-    expect(spec.components?.schemas).toHaveProperty('QuizResultQuestion');
-    expect(spec.components?.schemas).toHaveProperty('QuizResultOption');
-    expect(spec.components?.schemas).toHaveProperty('QuizAttempt');
-    expect(spec.components?.schemas).toHaveProperty('AttemptAnswer');
-    expect(spec.components?.schemas).toHaveProperty('QuestionType');
-    expect(spec.components?.schemas).toHaveProperty('QuizAttemptStatus');
-    expect(spec.components?.schemas).toHaveProperty('QuizStatus');
+    expectComponentSchemas([
+      'QuizCampaignItemContext',
+      'QuizOptionForTrainee',
+      'QuizQuestionForTrainee',
+      'GetQuizResponse',
+      'StartQuizAttemptResponse',
+      'SubmitQuizAttemptRequest',
+      'SubmitQuizAttemptResponse',
+      'GetQuizResultResponse',
+      'QuizResultQuestion',
+      'QuizResultOption',
+      'QuizAttempt',
+      'AttemptAnswer',
+      'QuestionType',
+      'QuizAttemptStatus',
+      'QuizStatus',
+    ]);
     expect(spec.components?.securitySchemes).toHaveProperty('bearerAuth');
-    expect(JSON.stringify(spec.components?.schemas?.GetQuizResponse)).not.toContain('isCorrect');
-    expect(JSON.stringify(spec.components?.schemas?.GetQuizResponse)).not.toContain('feedbackText');
+    expectSchemaNotToContain('GetQuizResponse', ['isCorrect', 'feedbackText']);
   });
 
   it('includes the mounted trainee quiz paths', () => {
-    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/quiz');
-    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/quiz/attempts');
-    expect(spec.paths).toHaveProperty('/quiz-attempts/{attemptId}/submit');
-    expect(spec.paths).toHaveProperty('/quiz-attempts/{attemptId}/results');
+    expectPaths([
+      '/trainee/campaign-items/{campaignItemId}/quiz',
+      '/trainee/campaign-items/{campaignItemId}/quiz/attempts',
+      '/quiz-attempts/{attemptId}/submit',
+      '/quiz-attempts/{attemptId}/results',
+    ]);
   });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -39,4 +39,23 @@ describe('swaggerSpec', () => {
     expect(spec.paths).toHaveProperty('/auth/login');
     expect(spec.paths).toHaveProperty('/auth/me');
   });
+
+  it('includes reusable trainee training schemas', () => {
+    expect(spec.components?.schemas).toHaveProperty('TrainingDocument');
+    expect(spec.components?.schemas).toHaveProperty('TrainingCampaignItemContext');
+    expect(spec.components?.schemas).toHaveProperty('GetTrainingDocumentResponse');
+    expect(spec.components?.schemas).toHaveProperty('RecordTrainingInteractionResponse');
+    expect(spec.components?.schemas).toHaveProperty('TrainingInteractionEvent');
+    expect(spec.components?.schemas).toHaveProperty('EmptyRequestBody');
+    expect(spec.components?.schemas).toHaveProperty('TrainingContentType');
+    expect(spec.components?.schemas).toHaveProperty('DifficultyLevel');
+    expect(spec.components?.schemas).toHaveProperty('TrainingDocumentStatus');
+    expect(spec.components?.schemas).toHaveProperty('TrainingInteractionEventType');
+    expect(JSON.stringify(spec.components?.schemas?.GetTrainingDocumentResponse)).not.toContain(
+      'TrainingProgress',
+    );
+    expect(JSON.stringify(spec.components?.schemas?.GetTrainingDocumentResponse)).not.toContain(
+      'quiz',
+    );
+  });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -13,6 +13,8 @@ interface SwaggerSpecShape {
   components?: {
     schemas?: Record<string, unknown>;
     responses?: Record<string, unknown>;
+    requestBodies?: Record<string, unknown>;
+    parameters?: Record<string, unknown>;
     securitySchemes?: Record<string, unknown>;
   };
 }
@@ -80,6 +82,21 @@ const expectedResponses = [
   'InternalServerError',
 ] as const;
 
+const expectedParameters = [
+  'CampaignItemIdPathParam',
+  'EmailIdPathParam',
+  'AttemptIdPathParam',
+] as const;
+
+const expectedRequestBodies = [
+  'AuthRegister',
+  'AuthLogin',
+  'EmptyJson',
+  'RecordSimulatedEmailInteraction',
+  'ClassifySimulatedEmail',
+  'SubmitQuizAttempt',
+] as const;
+
 const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
   ['get', '/health', ['200', '500']],
   ['post', '/auth/register', ['201', '400', '409', '429', '500']],
@@ -138,6 +155,18 @@ const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
   ['get', '/quiz-attempts/{attemptId}/results', ['200', '400', '401', '403', '404', '429', '500']],
 ];
 
+const inactiveRouteDocs = [
+  '/training/assigned',
+  '/training/{trainingId}',
+  '/training/{trainingId}/progress',
+  '/simulations/inbox',
+  '/simulations/emails/{emailId}',
+  '/quizzes/{quizId}',
+  '/trainee/simulated-emails/{emailId}',
+  '/trainee/campaign-items/{campaignItemId}/quiz-attempts',
+  '/quiz-attempts/{attemptId}/result',
+] as const;
+
 describe('swaggerSpec', () => {
   const spec = swaggerSpec as SwaggerSpecShape;
 
@@ -179,12 +208,25 @@ describe('swaggerSpec', () => {
     expect(spec.components?.responses).toHaveProperty(responseName);
   });
 
+  it.each(expectedParameters)('includes reusable UUID parameter %s', (parameterName) => {
+    expect(spec.components?.parameters).toHaveProperty(parameterName);
+    expect(JSON.stringify(spec.components?.parameters?.[parameterName])).toContain('"uuid"');
+  });
+
+  it.each(expectedRequestBodies)('includes reusable request body %s', (requestBodyName) => {
+    expect(spec.components?.requestBodies).toHaveProperty(requestBodyName);
+  });
+
   it.each(expectedRouteDocs)('documents %s %s', (method, path, statuses) => {
     expectPathExists(path, method);
 
     for (const status of statuses) {
       expectPathResponse(path, method, status);
     }
+  });
+
+  it.each(inactiveRouteDocs)('does not document inactive route %s', (path) => {
+    expect(spec.paths).not.toHaveProperty(path);
   });
 
   it('keeps public user schemas free of password hashes', () => {
@@ -197,5 +239,16 @@ describe('swaggerSpec', () => {
 
   it('keeps quiz fetch response free of pre-submission answers', () => {
     expectSchemaNotToContain('GetQuizResponse', ['isCorrect', 'feedbackText']);
+  });
+
+  it('includes quiz result feedback fields only in post-submission result schemas', () => {
+    const resultSchema = JSON.stringify([
+      spec.components?.schemas?.GetQuizResultResponse,
+      spec.components?.schemas?.QuizResultQuestion,
+      spec.components?.schemas?.QuizResultOption,
+    ]);
+
+    expect(resultSchema).toContain('isCorrect');
+    expect(resultSchema).toContain('feedbackText');
   });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -58,4 +58,14 @@ describe('swaggerSpec', () => {
       'quiz',
     );
   });
+
+  it('includes the mounted trainee training paths', () => {
+    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/training-document');
+    expect(spec.paths).toHaveProperty(
+      '/trainee/campaign-items/{campaignItemId}/training-document/viewed',
+    );
+    expect(spec.paths).toHaveProperty(
+      '/trainee/campaign-items/{campaignItemId}/training-document/completed',
+    );
+  });
 });

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -89,4 +89,11 @@ describe('swaggerSpec', () => {
       'redFlags',
     );
   });
+
+  it('includes the mounted trainee simulation read paths', () => {
+    expect(spec.paths).toHaveProperty('/trainee/campaign-items/{campaignItemId}/simulated-inbox');
+    expect(spec.paths).toHaveProperty(
+      '/trainee/campaign-items/{campaignItemId}/simulated-emails/{emailId}',
+    );
+  });
 });

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.exclusions=**/apps/backend/prisma/migrations/**/*.sql,apps/backend/prisma/migrations/**/*.sql,**/dist/**,**/build/**,**/coverage/**
-sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.test.js,**/tests/**,**/__tests__/**
+sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.test.js,**/tests/**,**/__tests__/**,apps/backend/src/config/swagger.ts,apps/backend/tests/unit/swagger.spec.test.ts
 
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=*:S1590

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.exclusions=**/apps/backend/prisma/migrations/**/*.sql,apps/backend/prisma/migrations/**/*.sql,**/dist/**,**/build/**,**/coverage/**
-sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.test.js,**/tests/**,**/__tests__/**,apps/backend/src/config/swagger.ts,apps/backend/tests/unit/swagger.spec.test.ts
+sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.test.js,**/tests/**,**/__tests__/**
 
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=*:S1590


### PR DESCRIPTION
## Summary

Closes #123

Adds Swagger/OpenAPI documentation for the backend endpoints currently active on `dev`.

Swagger UI was already mounted at `/api-docs`, but the OpenAPI coverage was incomplete. This PR expands the Swagger configuration and route annotations so the current Demo 1 backend APIs are documented for frontend integration, manual testing, and demo preparation.

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [x] Chore/Maintenance

## What Changed

### Swagger setup and reusable schemas

Updated the existing Swagger setup in:

- `apps/backend/src/config/swagger.ts`

Added reusable OpenAPI components for:

- common API error responses
- validation errors
- rate limit errors
- bearer authentication
- auth request/response bodies
- public user response shape
- training document responses
- training interaction responses
- simulated inbox responses
- simulated email detail responses
- simulated email interaction/classification responses
- quiz fetch responses
- quiz attempt responses
- quiz submit/result responses
- common UUID path parameters

### Health endpoint Swagger docs

Updated Swagger docs for:

- `GET /health`

The health route is documented as a public route and includes the expected health response shape.

### Auth Swagger docs

Added Swagger docs for:

- `POST /auth/register`
- `POST /auth/login`
- `GET /auth/me`

The docs include:

- request bodies
- response schemas
- auth requirements where applicable
- validation errors
- duplicate/auth failure responses
- rate limit responses
- safe server error responses

### UC-01 simulated inbox/email Swagger docs

Added Swagger docs for:

- `GET /trainee/campaign-items/:campaignItemId/simulated-inbox`
- `GET /trainee/campaign-items/:campaignItemId/simulated-emails/:emailId`
- `POST /trainee/campaign-items/:campaignItemId/simulated-emails/:emailId/interactions`
- `POST /trainee/campaign-items/:campaignItemId/simulated-emails/:emailId/classification`

The docs include:

- bearer auth
- UUID path params
- request bodies
- success responses
- validation errors
- safe 401/403/404 responses
- 429 rate limit responses
- 500 safe error responses

The simulated email detail schema avoids exposing trainee-hidden fields before classification, such as `expectedClassification` and `redFlags`.

### UC-02 training document Swagger docs

Added Swagger docs for:

- `GET /trainee/campaign-items/:campaignItemId/training-document`
- `POST /trainee/campaign-items/:campaignItemId/training-document/viewed`
- `POST /trainee/campaign-items/:campaignItemId/training-document/completed`

The docs reflect the campaign item-based training API and include:

- bearer auth
- UUID `campaignItemId` path param
- training document response schema
- viewed/completed event response schema
- strict empty action body behavior
- safe missing/unauthorised content responses
- rate limit responses

The docs do not reintroduce old training assumptions such as `/training/assigned`, `/training/:trainingId`, or `TrainingProgress`.

### UC-03 quiz Swagger docs

After merging latest `dev`, active quiz routes were added to the branch and documented as well:

- `GET /trainee/campaign-items/:campaignItemId/quiz`
- `POST /trainee/campaign-items/:campaignItemId/quiz/attempts`
- `POST /quiz-attempts/:attemptId/submit`
- `GET /quiz-attempts/:attemptId/results`

The quiz docs include:

- bearer auth
- UUID path params
- attempt creation response
- submit request/response schema
- result response schema
- duplicate submission/conflict response
- validation errors
- rate limit responses

The trainee quiz fetch schema does not expose `isCorrect` or `feedbackText`. Feedback and correctness are only documented in result responses after submission.

### Swagger spec test coverage

Added/updated:

- `apps/backend/tests/unit/swagger.spec.test.ts`

The Swagger spec tests verify:

- Swagger spec exists
- OpenAPI version exists
- bearer auth scheme exists
- common components exist
- health/auth/training/simulation/quiz paths are present
- sensitive fields are not exposed in trainee-facing schemas
- active paths are documented

### Swagger usage note

Updated:

- `SETUP.md`

Added a short note explaining:

- Swagger UI is available at `/api-docs`
- backend must be running to view Swagger UI
- protected routes require Bearer token auth
- Swagger covers currently active Demo 1 backend routes

## Files Changed

### Swagger config/components

- `apps/backend/src/config/swagger.ts`

### Route annotations

- `apps/backend/src/routes/health.routes.ts`
- `apps/backend/src/routes/auth.routes.ts`
- `apps/backend/src/routes/trainee.routes.ts`
- `apps/backend/src/routes/trainee-training.routes.ts`
- `apps/backend/src/routes/quiz.routes.ts`

### Tests

- `apps/backend/tests/unit/swagger.spec.test.ts`

### Documentation

- `SETUP.md`

## What Was Not Changed

This PR does not:

- change endpoint behavior
- add new backend endpoints
- alter Prisma schema or migrations
- add frontend work
- document unmounted/planned routes as active
- reintroduce old model assumptions
- expose sensitive fields such as `passwordHash`
- expose quiz correctness or feedback in pre-submit quiz fetch responses
- expose simulated email expected classification/red flags before classification

## Testing

Ran locally:

```bash
pnpm --filter @insightful-phish/backend typecheck
pnpm --filter @insightful-phish/backend test:unit
pnpm --filter @insightful-phish/backend test
pnpm --filter @insightful-phish/shared typecheck
pnpm --filter @insightful-phish/shared test
pnpm --filter @insightful-phish/backend exec vitest run tests/unit/swagger.spec.test.ts