### PR TITLE
fix: update shared DTOs to be stricter

### DIFF
--- a/packages/shared/src/validation/auth.schemas.test.ts
+++ b/packages/shared/src/validation/auth.schemas.test.ts
@@ -96,6 +96,17 @@ describe('auth validation schemas', () => {
     expect(result.success).toBe(false);
   });
 
+  it('does not count whitespace as a register password special character', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'Stronger Pass1',
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('rejects whitespace-only register names after trimming', () => {
     const result = authRegisterRequestSchema.safeParse({
       email: 'trainee@example.com',

--- a/packages/shared/src/validation/auth.schemas.test.ts
+++ b/packages/shared/src/validation/auth.schemas.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { authLoginRequestSchema, authRegisterRequestSchema } from './auth.schemas.js';
 
 describe('auth validation schemas', () => {
+  const issueMessagesFor = (result: ReturnType<typeof authRegisterRequestSchema.safeParse>) => {
+    if (result.success) {
+      return [];
+    }
+
+    return result.error.issues.map((issue) => issue.message);
+  };
+
   it('normalizes valid register input', () => {
     const result = authRegisterRequestSchema.parse({
       email: '  TRAINEE@EXAMPLE.COM  ',
@@ -27,6 +35,13 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toEqual(
+      expect.arrayContaining([
+        'Please enter a valid email address.',
+        'Please enter a first name.',
+        'Please enter a last name.',
+      ]),
+    );
   });
 
   it('rejects register payloads with unexpected fields', () => {
@@ -50,6 +65,7 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toContain('Password must be at least 12 characters long');
   });
 
   it('rejects register passwords without a lowercase letter', () => {
@@ -61,6 +77,9 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toContain(
+      'Password must contain at least one lowercase letter',
+    );
   });
 
   it('rejects register passwords without an uppercase letter', () => {
@@ -72,6 +91,9 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toContain(
+      'Password must contain at least one uppercase letter',
+    );
   });
 
   it('rejects register passwords without a number', () => {
@@ -83,6 +105,7 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toContain('Password must contain at least one number');
   });
 
   it('rejects register passwords without a special character', () => {
@@ -94,6 +117,9 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toContain(
+      'Password must contain at least one special character',
+    );
   });
 
   it('does not count whitespace as a register password special character', () => {
@@ -105,6 +131,28 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toContain(
+      'Password must contain at least one special character',
+    );
+  });
+
+  it('rejects register fields over maximum length', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: `${'a'.repeat(250)}@example.com`,
+      password: `${'A'.repeat(126)}a1!`,
+      firstName: 'J'.repeat(101),
+      lastName: 'D'.repeat(101),
+    });
+
+    expect(result.success).toBe(false);
+    expect(issueMessagesFor(result)).toEqual(
+      expect.arrayContaining([
+        'Email address must be at most 254 characters.',
+        'Password must be at most 128 characters long',
+        'First name must be at most 100 characters.',
+        'Last name must be at most 100 characters.',
+      ]),
+    );
   });
 
   it('rejects whitespace-only register names after trimming', () => {
@@ -137,6 +185,27 @@ describe('auth validation schemas', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('rejects empty and too-long login passwords without requiring register strength', () => {
+    expect(
+      authLoginRequestSchema.safeParse({
+        email: 'trainee@example.com',
+        password: '',
+      }).success,
+    ).toBe(false);
+
+    const tooLongResult = authLoginRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'a'.repeat(129),
+    });
+
+    expect(tooLongResult.success).toBe(false);
+    if (!tooLongResult.success) {
+      expect(tooLongResult.error.issues.map((issue) => issue.message)).toContain(
+        'Password must be at most 128 characters long.',
+      );
+    }
   });
 
   it('rejects login payloads with unexpected fields', () => {

--- a/packages/shared/src/validation/auth.schemas.test.ts
+++ b/packages/shared/src/validation/auth.schemas.test.ts
@@ -10,13 +10,42 @@ describe('auth validation schemas', () => {
     return result.error.issues.map((issue) => issue.message);
   };
 
+  const validRegisterInput = (
+    overrides: Partial<{
+      email: string;
+      password: string;
+      firstName: string;
+      lastName: string;
+      role: string;
+    }> = {},
+  ) => ({
+    email: 'trainee@example.com',
+    password: 'StrongerPass1!',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    ...overrides,
+  });
+
+  const validLoginInput = (
+    overrides: Partial<{
+      email: string;
+      password: string;
+      rememberMe: boolean;
+    }> = {},
+  ) => ({
+    email: 'trainee@example.com',
+    password: 'password',
+    ...overrides,
+  });
+
   it('normalizes valid register input', () => {
-    const result = authRegisterRequestSchema.parse({
-      email: '  TRAINEE@EXAMPLE.COM  ',
-      password: 'StrongerPass1!',
-      firstName: ' Jane ',
-      lastName: ' Doe ',
-    });
+    const result = authRegisterRequestSchema.parse(
+      validRegisterInput({
+        email: '  TRAINEE@EXAMPLE.COM  ',
+        firstName: ' Jane ',
+        lastName: ' Doe ',
+      }),
+    );
 
     expect(result).toEqual({
       email: 'trainee@example.com',
@@ -45,104 +74,50 @@ describe('auth validation schemas', () => {
   });
 
   it('rejects register payloads with unexpected fields', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'StrongerPass1!',
-      firstName: 'Jane',
-      lastName: 'Doe',
-      role: 'IP_ADMIN',
-    });
+    const result = authRegisterRequestSchema.safeParse(validRegisterInput({ role: 'IP_ADMIN' }));
 
     expect(result.success).toBe(false);
   });
 
-  it('rejects register passwords shorter than 12 characters', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'Short1!',
-      firstName: 'Jane',
-      lastName: 'Doe',
-    });
-
-    expect(result.success).toBe(false);
-    expect(issueMessagesFor(result)).toContain('Password must be at least 12 characters long');
-  });
-
-  it('rejects register passwords without a lowercase letter', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'STRONGERPASS1!',
-      firstName: 'Jane',
-      lastName: 'Doe',
-    });
-
-    expect(result.success).toBe(false);
-    expect(issueMessagesFor(result)).toContain(
+  it.each([
+    ['shorter than 12 characters', 'Short1!', 'Password must be at least 12 characters long'],
+    [
+      'without a lowercase letter',
+      'STRONGERPASS1!',
       'Password must contain at least one lowercase letter',
-    );
-  });
-
-  it('rejects register passwords without an uppercase letter', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'strongerpass1!',
-      firstName: 'Jane',
-      lastName: 'Doe',
-    });
-
-    expect(result.success).toBe(false);
-    expect(issueMessagesFor(result)).toContain(
+    ],
+    [
+      'without an uppercase letter',
+      'strongerpass1!',
       'Password must contain at least one uppercase letter',
-    );
-  });
-
-  it('rejects register passwords without a number', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'StrongerPass!',
-      firstName: 'Jane',
-      lastName: 'Doe',
-    });
-
-    expect(result.success).toBe(false);
-    expect(issueMessagesFor(result)).toContain('Password must contain at least one number');
-  });
-
-  it('rejects register passwords without a special character', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'StrongerPass1',
-      firstName: 'Jane',
-      lastName: 'Doe',
-    });
-
-    expect(result.success).toBe(false);
-    expect(issueMessagesFor(result)).toContain(
+    ],
+    ['without a number', 'StrongerPass!', 'Password must contain at least one number'],
+    [
+      'without a special character',
+      'StrongerPass1',
       'Password must contain at least one special character',
-    );
-  });
-
-  it('does not count whitespace as a register password special character', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'Stronger Pass1',
-      firstName: 'Jane',
-      lastName: 'Doe',
-    });
+    ],
+    [
+      'with whitespace as the only special character',
+      'Stronger Pass1',
+      'Password must contain at least one special character',
+    ],
+  ])('rejects register passwords %s', (_caseName, password, expectedMessage) => {
+    const result = authRegisterRequestSchema.safeParse(validRegisterInput({ password }));
 
     expect(result.success).toBe(false);
-    expect(issueMessagesFor(result)).toContain(
-      'Password must contain at least one special character',
-    );
+    expect(issueMessagesFor(result)).toContain(expectedMessage);
   });
 
   it('rejects register fields over maximum length', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: `${'a'.repeat(250)}@example.com`,
-      password: `${'A'.repeat(126)}a1!`,
-      firstName: 'J'.repeat(101),
-      lastName: 'D'.repeat(101),
-    });
+    const result = authRegisterRequestSchema.safeParse(
+      validRegisterInput({
+        email: `${'a'.repeat(250)}@example.com`,
+        password: `${'A'.repeat(126)}a1!`,
+        firstName: 'J'.repeat(101),
+        lastName: 'D'.repeat(101),
+      }),
+    );
 
     expect(result.success).toBe(false);
     expect(issueMessagesFor(result)).toEqual(
@@ -156,21 +131,22 @@ describe('auth validation schemas', () => {
   });
 
   it('rejects whitespace-only register names after trimming', () => {
-    const result = authRegisterRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'StrongerPass1!',
-      firstName: '   ',
-      lastName: '\t',
-    });
+    const result = authRegisterRequestSchema.safeParse(
+      validRegisterInput({
+        firstName: '   ',
+        lastName: '\t',
+      }),
+    );
 
     expect(result.success).toBe(false);
   });
 
   it('normalizes valid login input', () => {
-    const result = authLoginRequestSchema.parse({
-      email: '  TRAINEE@EXAMPLE.COM  ',
-      password: 'password',
-    });
+    const result = authLoginRequestSchema.parse(
+      validLoginInput({
+        email: '  TRAINEE@EXAMPLE.COM  ',
+      }),
+    );
 
     expect(result).toEqual({
       email: 'trainee@example.com',
@@ -179,26 +155,17 @@ describe('auth validation schemas', () => {
   });
 
   it('keeps login password validation weaker than registration', () => {
-    const result = authLoginRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'legacy',
-    });
+    const result = authLoginRequestSchema.safeParse(validLoginInput({ password: 'legacy' }));
 
     expect(result.success).toBe(true);
   });
 
   it('rejects empty and too-long login passwords without requiring register strength', () => {
-    expect(
-      authLoginRequestSchema.safeParse({
-        email: 'trainee@example.com',
-        password: '',
-      }).success,
-    ).toBe(false);
+    expect(authLoginRequestSchema.safeParse(validLoginInput({ password: '' })).success).toBe(false);
 
-    const tooLongResult = authLoginRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'a'.repeat(129),
-    });
+    const tooLongResult = authLoginRequestSchema.safeParse(
+      validLoginInput({ password: 'a'.repeat(129) }),
+    );
 
     expect(tooLongResult.success).toBe(false);
     if (!tooLongResult.success) {
@@ -209,11 +176,7 @@ describe('auth validation schemas', () => {
   });
 
   it('rejects login payloads with unexpected fields', () => {
-    const result = authLoginRequestSchema.safeParse({
-      email: 'trainee@example.com',
-      password: 'password',
-      rememberMe: true,
-    });
+    const result = authLoginRequestSchema.safeParse(validLoginInput({ rememberMe: true }));
 
     expect(result.success).toBe(false);
   });

--- a/packages/shared/src/validation/auth.schemas.test.ts
+++ b/packages/shared/src/validation/auth.schemas.test.ts
@@ -5,14 +5,14 @@ describe('auth validation schemas', () => {
   it('normalizes valid register input', () => {
     const result = authRegisterRequestSchema.parse({
       email: '  TRAINEE@EXAMPLE.COM  ',
-      password: 'password123',
+      password: 'StrongerPass1!',
       firstName: ' Jane ',
       lastName: ' Doe ',
     });
 
     expect(result).toEqual({
       email: 'trainee@example.com',
-      password: 'password123',
+      password: 'StrongerPass1!',
       firstName: 'Jane',
       lastName: 'Doe',
     });
@@ -29,15 +29,112 @@ describe('auth validation schemas', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects register payloads with unexpected fields', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'StrongerPass1!',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      role: 'IP_ADMIN',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects register passwords shorter than 12 characters', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'Short1!',
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects register passwords without a lowercase letter', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'STRONGERPASS1!',
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects register passwords without an uppercase letter', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'strongerpass1!',
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects register passwords without a number', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'StrongerPass!',
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects register passwords without a special character', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'StrongerPass1',
+      firstName: 'Jane',
+      lastName: 'Doe',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects whitespace-only register names after trimming', () => {
+    const result = authRegisterRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'StrongerPass1!',
+      firstName: '   ',
+      lastName: '\t',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('normalizes valid login input', () => {
     const result = authLoginRequestSchema.parse({
       email: '  TRAINEE@EXAMPLE.COM  ',
-      password: 'password123',
+      password: 'password',
     });
 
     expect(result).toEqual({
       email: 'trainee@example.com',
-      password: 'password123',
+      password: 'password',
     });
+  });
+
+  it('keeps login password validation weaker than registration', () => {
+    const result = authLoginRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'legacy',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects login payloads with unexpected fields', () => {
+    const result = authLoginRequestSchema.safeParse({
+      email: 'trainee@example.com',
+      password: 'password',
+      rememberMe: true,
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/shared/src/validation/auth.schemas.ts
+++ b/packages/shared/src/validation/auth.schemas.ts
@@ -1,13 +1,23 @@
 import { z } from 'zod';
 
-export const authRegisterRequestSchema = z.object({
-  email: z.string().trim().email().toLowerCase(),
-  password: z.string().min(8),
-  firstName: z.string().trim().min(1),
-  lastName: z.string().trim().min(1),
-});
+export const authRegisterRequestSchema = z
+  .object({
+    email: z.string().trim().email().toLowerCase(),
+    password: z
+      .string()
+      .min(12, 'Password must be at least 12 characters long')
+      .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+      .regex(/\d/, 'Password must contain at least one number')
+      .regex(/[^A-Za-z0-9]/, 'Password must contain at least one special character'),
+    firstName: z.string().trim().min(1),
+    lastName: z.string().trim().min(1),
+  })
+  .strict();
 
-export const authLoginRequestSchema = z.object({
-  email: z.string().trim().email().toLowerCase(),
-  password: z.string().min(1),
-});
+export const authLoginRequestSchema = z
+  .object({
+    email: z.string().trim().email().toLowerCase(),
+    password: z.string().min(1),
+  })
+  .strict();

--- a/packages/shared/src/validation/auth.schemas.ts
+++ b/packages/shared/src/validation/auth.schemas.ts
@@ -1,23 +1,57 @@
 import { z } from 'zod';
+import { requiredTrimmedStringSchema } from './common.schemas.js';
+
+const emailSchema = z
+  .string({
+    required_error: 'Please enter an email address.',
+    invalid_type_error: 'Please enter a valid email address.',
+  })
+  .trim()
+  .min(1, 'Please enter an email address.')
+  .max(254, 'Email address must be at most 254 characters.')
+  .email('Please enter a valid email address.')
+  .toLowerCase();
+
+const firstNameSchema = requiredTrimmedStringSchema({
+  requiredMessage: 'Please enter a first name.',
+  maxLength: 100,
+  maxMessage: 'First name must be at most 100 characters.',
+});
+
+const lastNameSchema = requiredTrimmedStringSchema({
+  requiredMessage: 'Please enter a last name.',
+  maxLength: 100,
+  maxMessage: 'Last name must be at most 100 characters.',
+});
 
 export const authRegisterRequestSchema = z
   .object({
-    email: z.string().trim().email().toLowerCase(),
+    email: emailSchema,
     password: z
-      .string()
+      .string({
+        required_error: 'Please enter a password.',
+        invalid_type_error: 'Please enter a password.',
+      })
       .min(12, 'Password must be at least 12 characters long')
+      .max(128, 'Password must be at most 128 characters long')
       .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
       .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
       .regex(/\d/, 'Password must contain at least one number')
       .regex(/[^\sA-Za-z0-9]/, 'Password must contain at least one special character'),
-    firstName: z.string().trim().min(1),
-    lastName: z.string().trim().min(1),
+    firstName: firstNameSchema,
+    lastName: lastNameSchema,
   })
   .strict();
 
 export const authLoginRequestSchema = z
   .object({
-    email: z.string().trim().email().toLowerCase(),
-    password: z.string().min(1),
+    email: emailSchema,
+    password: z
+      .string({
+        required_error: 'Please enter your password.',
+        invalid_type_error: 'Please enter your password.',
+      })
+      .min(1, 'Please enter your password.')
+      .max(128, 'Password must be at most 128 characters long.'),
   })
   .strict();

--- a/packages/shared/src/validation/auth.schemas.ts
+++ b/packages/shared/src/validation/auth.schemas.ts
@@ -9,7 +9,7 @@ export const authRegisterRequestSchema = z
       .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
       .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
       .regex(/\d/, 'Password must contain at least one number')
-      .regex(/[^A-Za-z0-9]/, 'Password must contain at least one special character'),
+      .regex(/[^\sA-Za-z0-9]/, 'Password must contain at least one special character'),
     firstName: z.string().trim().min(1),
     lastName: z.string().trim().min(1),
   })

--- a/packages/shared/src/validation/campaigns.schemas.test.ts
+++ b/packages/shared/src/validation/campaigns.schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { getTraineeCampaignActivityApiPath } from '../campaigns.js';
 import {
   getTraineeCampaignRequestParamsSchema,
+  listTraineeCampaignsRequestSchema,
   traineeCampaignComponentItemSummarySchema,
   traineeCampaignItemRequestParamsSchema,
   traineeCampaignItemSummarySchema,
@@ -23,6 +24,23 @@ describe('campaign validation schemas', () => {
   it('rejects malformed trainee campaign route params', () => {
     const result = getTraineeCampaignRequestParamsSchema.safeParse({
       campaignId: 'not-a-uuid',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unexpected trainee campaign route params', () => {
+    const result = getTraineeCampaignRequestParamsSchema.safeParse({
+      campaignId,
+      organisationId: '44444444-4444-4444-8444-444444444444',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects list trainee campaign payload fields', () => {
+    const result = listTraineeCampaignsRequestSchema.safeParse({
+      includeArchived: true,
     });
 
     expect(result.success).toBe(false);

--- a/packages/shared/src/validation/campaigns.schemas.test.ts
+++ b/packages/shared/src/validation/campaigns.schemas.test.ts
@@ -4,6 +4,7 @@ import {
   getTraineeCampaignRequestParamsSchema,
   listTraineeCampaignsRequestSchema,
   traineeCampaignComponentItemSummarySchema,
+  getTraineeCampaignsResponseSchema,
   traineeCampaignItemRequestParamsSchema,
   traineeCampaignItemSummarySchema,
 } from './campaigns.schemas.js';
@@ -44,6 +45,33 @@ describe('campaign validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('rejects campaign summaries over maximum display lengths', () => {
+    const result = getTraineeCampaignsResponseSchema.safeParse({
+      campaigns: [
+        {
+          campaignId,
+          name: 'A'.repeat(201),
+          description: 'B'.repeat(2001),
+          campaignType: 'PREMADE_GENERAL',
+          difficultyLevel: 'BEGINNER',
+          status: 'ACTIVE',
+          accessType: 'ASSIGNED',
+          progressStatus: 'IN_PROGRESS',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.message)).toEqual(
+        expect.arrayContaining([
+          'Campaign name must be at most 200 characters.',
+          'Description must be at most 2000 characters.',
+        ]),
+      );
+    }
   });
 
   it('accepts trainee campaign item route params', () => {
@@ -87,6 +115,28 @@ describe('campaign validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('rejects component item titles over maximum length', () => {
+    const result = traineeCampaignComponentItemSummarySchema.safeParse({
+      campaignItemId,
+      campaignId,
+      itemType: 'COMPONENT',
+      componentType: 'QUIZ',
+      title: 'Q'.repeat(201),
+      position: 0,
+      isRequired: true,
+      availabilityStatus: 'AVAILABLE',
+      isOpenable: true,
+      activityApiPath: getTraineeCampaignActivityApiPath('QUIZ', campaignItemId),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.message)).toContain(
+        'Title must be at most 200 characters.',
+      );
+    }
   });
 
   it('accepts group items with child campaign items', () => {

--- a/packages/shared/src/validation/campaigns.schemas.ts
+++ b/packages/shared/src/validation/campaigns.schemas.ts
@@ -1,5 +1,28 @@
 import { z } from 'zod';
-import { idParamSchema } from './common.schemas.js';
+import {
+  idParamSchema,
+  optionalTrimmedStringSchema,
+  requiredTrimmedStringSchema,
+} from './common.schemas.js';
+
+const titleSchema = requiredTrimmedStringSchema({
+  requiredMessage: 'Please enter a title.',
+  maxLength: 200,
+  maxMessage: 'Title must be at most 200 characters.',
+});
+
+const campaignNameSchema = requiredTrimmedStringSchema({
+  requiredMessage: 'Please enter a campaign name.',
+  maxLength: 200,
+  maxMessage: 'Campaign name must be at most 200 characters.',
+});
+
+const descriptionSchema = optionalTrimmedStringSchema(
+  2000,
+  'Description must be at most 2000 characters.',
+);
+
+const summarySchema = optionalTrimmedStringSchema(2000, 'Summary must be at most 2000 characters.');
 
 const campaignTypeSchema = z.enum(['PREMADE_GENERAL', 'ORGANISATION_CUSTOM']);
 
@@ -50,8 +73,12 @@ export const traineeCampaignProgressStatusSchema = z.enum([
 const activityApiPathSchema = z
   .string()
   .trim()
-  .min(1)
-  .regex(/^\/trainee\/campaign-items\/[^/]+\/(simulated-inbox|training-document|quiz)$/);
+  .min(1, 'Please enter an activity API path.')
+  .max(500, 'Activity API path must be at most 500 characters.')
+  .regex(
+    /^\/trainee\/campaign-items\/[^/]+\/(simulated-inbox|training-document|quiz)$/,
+    'Activity API path must reference a supported trainee campaign item activity.',
+  );
 
 export const getTraineeCampaignRequestParamsSchema = z
   .object({
@@ -86,8 +113,8 @@ export const traineeCampaignAssignmentSummarySchema = z
 export const traineeCampaignSummarySchema = z
   .object({
     campaignId: idParamSchema,
-    name: z.string().trim().min(1),
-    description: z.string().trim().nullish(),
+    name: campaignNameSchema,
+    description: descriptionSchema.nullish(),
     campaignType: campaignTypeSchema,
     difficultyLevel: difficultyLevelSchema,
     status: campaignStatusSchema,
@@ -102,8 +129,8 @@ export const traineeCampaignSummarySchema = z
 const campaignTrainingDocumentSummarySchema = z
   .object({
     id: idParamSchema,
-    title: z.string().trim().min(1),
-    contentSummary: z.string().trim().nullish(),
+    title: titleSchema,
+    contentSummary: summarySchema.nullish(),
     estimatedReadTimeMinutes: z.number().int().positive().nullish(),
     difficultyLevel: difficultyLevelSchema,
     status: z.enum(['DRAFT', 'AVAILABLE', 'UNAVAILABLE', 'ARCHIVED']),
@@ -113,8 +140,8 @@ const campaignTrainingDocumentSummarySchema = z
 const campaignQuizSummarySchema = z
   .object({
     id: idParamSchema,
-    title: z.string().trim().min(1),
-    description: z.string().trim().nullish(),
+    title: titleSchema,
+    description: descriptionSchema.nullish(),
     passThresholdPercentage: z.number().min(0).max(100),
     difficultyLevel: difficultyLevelSchema,
     status: z.enum(['DRAFT', 'PUBLISHED', 'ARCHIVED']),
@@ -125,8 +152,8 @@ const campaignQuizSummarySchema = z
 const campaignSimulationSummarySchema = z
   .object({
     id: idParamSchema,
-    title: z.string().trim().min(1),
-    description: z.string().trim().nullish(),
+    title: titleSchema,
+    description: descriptionSchema.nullish(),
     difficultyLevel: difficultyLevelSchema,
   })
   .strict();
@@ -136,8 +163,8 @@ const traineeCampaignItemSummaryBaseSchema = z
     campaignItemId: idParamSchema,
     campaignId: idParamSchema,
     parentGroupId: idParamSchema.nullish(),
-    title: z.string().trim().min(1),
-    description: z.string().trim().nullish(),
+    title: titleSchema,
+    description: descriptionSchema.nullish(),
     position: z.number().int().nonnegative(),
     isRequired: z.boolean(),
     availabilityStatus: campaignItemAvailabilityStatusSchema,

--- a/packages/shared/src/validation/common.schemas.test.ts
+++ b/packages/shared/src/validation/common.schemas.test.ts
@@ -12,5 +12,8 @@ describe('common validation schemas', () => {
     const result = idParamSchema.safeParse('not-a-uuid');
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Invalid identifier format.');
+    }
   });
 });

--- a/packages/shared/src/validation/common.schemas.test.ts
+++ b/packages/shared/src/validation/common.schemas.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { idParamSchema } from './common.schemas.js';
+
+describe('common validation schemas', () => {
+  it('accepts and trims UUID values', () => {
+    const result = idParamSchema.parse(' 11111111-1111-4111-8111-111111111111 ');
+
+    expect(result).toBe('11111111-1111-4111-8111-111111111111');
+  });
+
+  it('rejects non-UUID values', () => {
+    const result = idParamSchema.safeParse('not-a-uuid');
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/validation/common.schemas.ts
+++ b/packages/shared/src/validation/common.schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const idParamSchema = z.string().uuid();
+export const idParamSchema = z.string().trim().uuid();
 
 export const validationErrorDetailSchema = z.object({
   field: z.string(),

--- a/packages/shared/src/validation/common.schemas.ts
+++ b/packages/shared/src/validation/common.schemas.ts
@@ -1,16 +1,47 @@
 import { z } from 'zod';
 
-export const idParamSchema = z.string().trim().uuid();
+type TrimmedStringOptions = {
+  requiredMessage: string;
+  maxMessage: string;
+  maxLength: number;
+};
+
+export const idParamSchema = z
+  .string({
+    required_error: 'Invalid identifier format.',
+    invalid_type_error: 'Invalid identifier format.',
+  })
+  .trim()
+  .uuid('Invalid identifier format.');
+
+export function requiredTrimmedStringSchema({
+  requiredMessage,
+  maxMessage,
+  maxLength,
+}: TrimmedStringOptions) {
+  return z
+    .string({
+      required_error: requiredMessage,
+      invalid_type_error: requiredMessage,
+    })
+    .trim()
+    .min(1, requiredMessage)
+    .max(maxLength, maxMessage);
+}
+
+export function optionalTrimmedStringSchema(maxLength: number, maxMessage: string) {
+  return z.string().trim().max(maxLength, maxMessage);
+}
 
 export const validationErrorDetailSchema = z.object({
-  field: z.string(),
-  message: z.string(),
+  field: z.string().max(200, 'Field name must be at most 200 characters.'),
+  message: z.string().max(2000, 'Validation message must be at most 2000 characters.'),
 });
 
 export const apiErrorResponseSchema = z.object({
-  error: z.string(),
-  message: z.string().optional(),
-  fields: z.array(z.string()).optional(),
+  error: z.string().max(200, 'Error code must be at most 200 characters.'),
+  message: z.string().max(2000, 'Error message must be at most 2000 characters.').optional(),
+  fields: z.array(z.string().max(200, 'Field name must be at most 200 characters.')).optional(),
   details: z.array(validationErrorDetailSchema).optional(),
 });
 

--- a/packages/shared/src/validation/quizzes.schemas.test.ts
+++ b/packages/shared/src/validation/quizzes.schemas.test.ts
@@ -1,18 +1,59 @@
 import { describe, expect, it } from 'vitest';
-import { submitQuizAttemptRequestSchema } from './quizzes.schemas.js';
+import {
+  getQuizRequestParamsSchema,
+  getQuizResultRequestParamsSchema,
+  startQuizAttemptRequestSchema,
+  submitQuizAttemptRequestParamsSchema,
+  submitQuizAttemptRequestSchema,
+} from './quizzes.schemas.js';
 
 describe('quiz validation schemas', () => {
+  const campaignItemId = '11111111-1111-4111-8111-111111111111';
+  const attemptId = '22222222-2222-4222-8222-222222222222';
+  const questionId = '33333333-3333-4333-8333-333333333333';
+  const optionId = '44444444-4444-4444-8444-444444444444';
+
+  it('accepts UUID quiz route params', () => {
+    expect(getQuizRequestParamsSchema.safeParse({ campaignItemId }).success).toBe(true);
+    expect(submitQuizAttemptRequestParamsSchema.safeParse({ attemptId }).success).toBe(true);
+    expect(getQuizResultRequestParamsSchema.safeParse({ attemptId }).success).toBe(true);
+  });
+
+  it('rejects malformed quiz route params', () => {
+    expect(getQuizRequestParamsSchema.safeParse({ campaignItemId: 'not-a-uuid' }).success).toBe(
+      false,
+    );
+    expect(
+      submitQuizAttemptRequestParamsSchema.safeParse({ attemptId: 'not-a-uuid' }).success,
+    ).toBe(false);
+  });
+
+  it('accepts empty quiz attempt start payloads', () => {
+    expect(startQuizAttemptRequestSchema.safeParse({}).success).toBe(true);
+    expect(startQuizAttemptRequestSchema.safeParse(undefined).success).toBe(true);
+  });
+
+  it('rejects quiz attempt start payloads with unexpected fields', () => {
+    const result = startQuizAttemptRequestSchema.safeParse({
+      startedAt: '2026-05-19T10:00:00.000Z',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('accepts a quiz submission with at least one answer', () => {
     const result = submitQuizAttemptRequestSchema.safeParse({
       answers: [
         {
-          questionId: '33333333-3333-3333-3333-333333333333',
-          selectedOptionIds: ['44444444-4444-4444-4444-444444444444'],
+          questionId,
+          selectedOptionIds: [optionId],
+          responseSummary: '  Chose the suspicious sender option  ',
         },
       ],
     });
 
     expect(result.success).toBe(true);
+    expect(result.data?.answers[0].responseSummary).toBe('Chose the suspicious sender option');
   });
 
   it('rejects an empty answers array', () => {
@@ -27,7 +68,56 @@ describe('quiz validation schemas', () => {
     const result = submitQuizAttemptRequestSchema.safeParse({
       answers: [
         {
-          questionId: '33333333-3333-3333-3333-333333333333',
+          questionId,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty selected option arrays', () => {
+    const result = submitQuizAttemptRequestSchema.safeParse({
+      answers: [
+        {
+          questionId,
+          selectedOptionIds: [],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-UUID question and option IDs', () => {
+    const result = submitQuizAttemptRequestSchema.safeParse({
+      answers: [
+        {
+          questionId: 'not-a-uuid',
+          selectedOptionIds: ['also-not-a-uuid'],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects quiz submission payloads with unexpected top-level fields', () => {
+    const result = submitQuizAttemptRequestSchema.safeParse({
+      answers: [{ questionId, selectedOptionIds: [optionId] }],
+      score: 100,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects quiz answer payloads with unexpected fields', () => {
+    const result = submitQuizAttemptRequestSchema.safeParse({
+      answers: [
+        {
+          questionId,
+          selectedOptionIds: [optionId],
+          isCorrect: true,
         },
       ],
     });

--- a/packages/shared/src/validation/quizzes.schemas.test.ts
+++ b/packages/shared/src/validation/quizzes.schemas.test.ts
@@ -62,6 +62,9 @@ describe('quiz validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Please select at least one answer.');
+    }
   });
 
   it('rejects answers missing required identifiers', () => {
@@ -87,6 +90,9 @@ describe('quiz validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Please select at least one answer.');
+    }
   });
 
   it('rejects non-UUID question and option IDs', () => {
@@ -100,6 +106,34 @@ describe('quiz validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.message)).toContain(
+        'Invalid identifier format.',
+      );
+    }
+  });
+
+  it('rejects answer free-text fields over maximum lengths', () => {
+    const result = submitQuizAttemptRequestSchema.safeParse({
+      answers: [
+        {
+          questionId,
+          selectedOptionIds: [optionId],
+          responseSummary: 'A'.repeat(1001),
+          typedResponse: 'B'.repeat(4001),
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.message)).toEqual(
+        expect.arrayContaining([
+          'Response summary must be at most 1000 characters.',
+          'Typed response must be at most 4000 characters.',
+        ]),
+      );
+    }
   });
 
   it('rejects quiz submission payloads with unexpected top-level fields', () => {

--- a/packages/shared/src/validation/quizzes.schemas.ts
+++ b/packages/shared/src/validation/quizzes.schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { idParamSchema } from './common.schemas.js';
+import { idParamSchema, optionalTrimmedStringSchema } from './common.schemas.js';
 
 export const getQuizRequestParamsSchema = z
   .object({
@@ -25,14 +25,20 @@ export const getQuizResultRequestParamsSchema = submitQuizAttemptRequestParamsSc
 export const quizAnswerInputSchema = z
   .object({
     questionId: idParamSchema,
-    selectedOptionIds: z.array(idParamSchema).min(1),
-    responseSummary: z.string().trim().max(1000).optional(),
-    typedResponse: z.string().trim().max(4000).optional(),
+    selectedOptionIds: z.array(idParamSchema).min(1, 'Please select at least one answer.'),
+    responseSummary: optionalTrimmedStringSchema(
+      1000,
+      'Response summary must be at most 1000 characters.',
+    ).optional(),
+    typedResponse: optionalTrimmedStringSchema(
+      4000,
+      'Typed response must be at most 4000 characters.',
+    ).optional(),
   })
   .strict();
 
 export const submitQuizAttemptRequestSchema = z
   .object({
-    answers: z.array(quizAnswerInputSchema).min(1),
+    answers: z.array(quizAnswerInputSchema).min(1, 'Please select at least one answer.'),
   })
   .strict();

--- a/packages/shared/src/validation/simulations.schemas.test.ts
+++ b/packages/shared/src/validation/simulations.schemas.test.ts
@@ -1,10 +1,58 @@
 import { describe, expect, it } from 'vitest';
 import {
   classifySimulatedEmailRequestSchema,
+  getSimulatedEmailRequestParamsSchema,
+  getSimulatedInboxRequestParamsSchema,
   recordSimulatedEmailInteractionRequestSchema,
 } from './simulations.schemas.js';
 
 describe('simulation validation schemas', () => {
+  const campaignItemId = '11111111-1111-4111-8111-111111111111';
+  const emailId = '22222222-2222-4222-8222-222222222222';
+
+  it('accepts UUID simulated inbox route params', () => {
+    const result = getSimulatedInboxRequestParamsSchema.safeParse({
+      campaignItemId,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects malformed simulated inbox route params', () => {
+    const result = getSimulatedInboxRequestParamsSchema.safeParse({
+      campaignItemId: 'not-a-uuid',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unexpected simulated inbox route params', () => {
+    const result = getSimulatedInboxRequestParamsSchema.safeParse({
+      campaignItemId,
+      emailId,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts UUID simulated email route params', () => {
+    const result = getSimulatedEmailRequestParamsSchema.safeParse({
+      campaignItemId,
+      emailId,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects malformed simulated email route params', () => {
+    const result = getSimulatedEmailRequestParamsSchema.safeParse({
+      campaignItemId,
+      emailId: 'not-a-uuid',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('accepts supported simulated email interaction events', () => {
     expect(
       recordSimulatedEmailInteractionRequestSchema.safeParse({
@@ -19,6 +67,23 @@ describe('simulation validation schemas', () => {
     ).toBe(true);
   });
 
+  it('rejects unsupported simulated email interaction events', () => {
+    const result = recordSimulatedEmailInteractionRequestSchema.safeParse({
+      eventType: 'TRAINING_VIEWED',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects simulated email interaction payloads with unexpected fields', () => {
+    const result = recordSimulatedEmailInteractionRequestSchema.safeParse({
+      eventType: 'SIMULATED_EMAIL_LINK_CLICKED',
+      campaignItemId,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('accepts campaign-scoped email classifications', () => {
     const result = classifySimulatedEmailRequestSchema.safeParse({
       selectedClassification: 'PHISHING',
@@ -26,5 +91,32 @@ describe('simulation validation schemas', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('trims optional classification free text', () => {
+    const result = classifySimulatedEmailRequestSchema.parse({
+      selectedClassification: 'SUSPICIOUS',
+      freeTextReason: '  Urgent tone and suspicious link  ',
+    });
+
+    expect(result.freeTextReason).toBe('Urgent tone and suspicious link');
+  });
+
+  it('rejects invalid classification values and red flag IDs', () => {
+    const result = classifySimulatedEmailRequestSchema.safeParse({
+      selectedClassification: 'MAYBE',
+      selectedRedFlagIds: ['not-a-uuid'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects classification payloads with unexpected fields', () => {
+    const result = classifySimulatedEmailRequestSchema.safeParse({
+      selectedClassification: 'SAFE',
+      expectedClassification: 'PHISHING',
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/shared/src/validation/simulations.schemas.test.ts
+++ b/packages/shared/src/validation/simulations.schemas.test.ts
@@ -73,6 +73,11 @@ describe('simulation validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'Please select a supported simulated email interaction event.',
+      );
+    }
   });
 
   it('rejects simulated email interaction payloads with unexpected fields', () => {
@@ -102,6 +107,27 @@ describe('simulation validation schemas', () => {
     expect(result.freeTextReason).toBe('Urgent tone and suspicious link');
   });
 
+  it('allows empty selected red flag arrays when no red flags are selected', () => {
+    const result = classifySimulatedEmailRequestSchema.safeParse({
+      selectedClassification: 'SAFE',
+      selectedRedFlagIds: [],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects classification free text over maximum length', () => {
+    const result = classifySimulatedEmailRequestSchema.safeParse({
+      selectedClassification: 'SUSPICIOUS',
+      freeTextReason: 'A'.repeat(1001),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Reason must be at most 1000 characters.');
+    }
+  });
+
   it('rejects invalid classification values and red flag IDs', () => {
     const result = classifySimulatedEmailRequestSchema.safeParse({
       selectedClassification: 'MAYBE',
@@ -109,6 +135,14 @@ describe('simulation validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.message)).toEqual(
+        expect.arrayContaining([
+          'Please select a valid email classification.',
+          'Invalid identifier format.',
+        ]),
+      );
+    }
   });
 
   it('rejects classification payloads with unexpected fields', () => {

--- a/packages/shared/src/validation/simulations.schemas.ts
+++ b/packages/shared/src/validation/simulations.schemas.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
-import { idParamSchema } from './common.schemas.js';
+import { idParamSchema, optionalTrimmedStringSchema } from './common.schemas.js';
 
-export const simulatedEmailInteractionEventTypeSchema = z.enum([
-  'SIMULATED_EMAIL_OPENED',
-  'SIMULATED_EMAIL_LINK_CLICKED',
-  'CREDENTIAL_SUBMISSION_ATTEMPTED',
-]);
+export const simulatedEmailInteractionEventTypeSchema = z.enum(
+  ['SIMULATED_EMAIL_OPENED', 'SIMULATED_EMAIL_LINK_CLICKED', 'CREDENTIAL_SUBMISSION_ATTEMPTED'],
+  {
+    errorMap: () => ({ message: 'Please select a supported simulated email interaction event.' }),
+  },
+);
 
 export const getSimulatedEmailRequestParamsSchema = z
   .object({
@@ -33,8 +34,13 @@ export const recordSimulatedEmailInteractionRequestSchema = z
 
 export const classifySimulatedEmailRequestSchema = z
   .object({
-    selectedClassification: z.enum(['SAFE', 'SUSPICIOUS', 'PHISHING']),
+    selectedClassification: z.enum(['SAFE', 'SUSPICIOUS', 'PHISHING'], {
+      errorMap: () => ({ message: 'Please select a valid email classification.' }),
+    }),
     selectedRedFlagIds: z.array(idParamSchema).optional(),
-    freeTextReason: z.string().trim().max(1000).optional(),
+    freeTextReason: optionalTrimmedStringSchema(
+      1000,
+      'Reason must be at most 1000 characters.',
+    ).optional(),
   })
   .strict();

--- a/packages/shared/src/validation/simulations.schemas.ts
+++ b/packages/shared/src/validation/simulations.schemas.ts
@@ -7,14 +7,18 @@ export const simulatedEmailInteractionEventTypeSchema = z.enum([
   'CREDENTIAL_SUBMISSION_ATTEMPTED',
 ]);
 
-export const getSimulatedEmailRequestParamsSchema = z.object({
-  campaignItemId: idParamSchema,
-  emailId: idParamSchema,
-});
+export const getSimulatedEmailRequestParamsSchema = z
+  .object({
+    campaignItemId: idParamSchema,
+    emailId: idParamSchema,
+  })
+  .strict();
 
-export const getSimulatedInboxRequestParamsSchema = z.object({
-  campaignItemId: idParamSchema,
-});
+export const getSimulatedInboxRequestParamsSchema = z
+  .object({
+    campaignItemId: idParamSchema,
+  })
+  .strict();
 
 export const recordSimulatedEmailInteractionRequestParamsSchema =
   getSimulatedEmailRequestParamsSchema;

--- a/packages/shared/src/validation/training.schemas.test.ts
+++ b/packages/shared/src/validation/training.schemas.test.ts
@@ -40,4 +40,13 @@ describe('training validation schemas', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('rejects unexpected training route params', () => {
+    const result = getTrainingDocumentRequestParamsSchema.safeParse({
+      campaignItemId: '11111111-1111-4111-8111-111111111111',
+      trainingDocumentId: '22222222-2222-4222-8222-222222222222',
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/shared/src/validation/training.schemas.test.ts
+++ b/packages/shared/src/validation/training.schemas.test.ts
@@ -39,6 +39,9 @@ describe('training validation schemas', () => {
     });
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Invalid identifier format.');
+    }
   });
 
   it('rejects unexpected training route params', () => {

--- a/packages/shared/src/validation/training.schemas.ts
+++ b/packages/shared/src/validation/training.schemas.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
+import { idParamSchema } from './common.schemas.js';
 
 export const trainingInteractionEventTypeSchema = z.enum(['TRAINING_VIEWED', 'TRAINING_COMPLETED']);
 
-const campaignItemIdParamSchema = z.string().trim().uuid();
-
-export const getTrainingDocumentRequestParamsSchema = z.object({
-  campaignItemId: campaignItemIdParamSchema,
-});
+export const getTrainingDocumentRequestParamsSchema = z
+  .object({
+    campaignItemId: idParamSchema,
+  })
+  .strict();
 
 export const recordTrainingInteractionRequestParamsSchema = getTrainingDocumentRequestParamsSchema;
 


### PR DESCRIPTION
## Summary

Tightened the shared Zod DTO validation schemas so request validation is stricter and more consistent across auth, campaign, simulation, training, and quiz flows.

Changes include:
- Added `.strict()` to request body and route param object schemas where extra fields should be rejected.
- Centralized reusable UUID and trimmed string validation helpers in shared common schemas.
- Tightened auth validation with normalized emails, trimmed names, max lengths, and a shared password policy.
- Replaced broad string validation with enums, UUID validation, min/max constraints, and regex checks where formats are stable.
- Added `.min(1)` checks for required non-empty quiz answer arrays.
- Expanded shared validation tests for valid payloads, invalid payloads, unexpected fields, UUID validation, regex validation, and password policy behavior.

## Linked Issue

Closes #131

## Type of change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Chore/Maintenance

## Testing

All tests pass locally.

## Checklist

- [x] I tested the change locally
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed