### PR TITLE
Campaign List/Items Integration

### DIFF
--- a/apps/frontend/src/components/ui/CampaignAccordion.tsx
+++ b/apps/frontend/src/components/ui/CampaignAccordion.tsx
@@ -126,18 +126,31 @@ function CampaignAccordion({
 
       {/* CONTENT */}
 
-      {isOpen && (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateRows: isOpen ? '1fr' : '0fr',
+          opacity: isOpen ? 1 : 0,
+          transition: 'grid-template-rows 0.35s ease, opacity 0.25s ease',
+        }}
+      >
         <div
           style={{
-            padding: '1rem',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '1rem',
+            overflow: 'hidden',
           }}
         >
-          {children}
+          <div
+            style={{
+              padding: '1rem',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '1rem',
+            }}
+          >
+            {children}
+          </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/components/ui/CampaignAccordion.tsx
+++ b/apps/frontend/src/components/ui/CampaignAccordion.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
 
 type CampaignAccordionProps = {
@@ -7,8 +5,9 @@ type CampaignAccordionProps = {
   subtitle: string;
   status: string;
   accentColor: string;
-  children: React.ReactNode;
-  defaultOpen?: boolean;
+  children?: React.ReactNode;
+  isOpen: boolean;
+  onToggle: () => void;
 };
 
 function CampaignAccordion({
@@ -17,10 +16,9 @@ function CampaignAccordion({
   status,
   accentColor,
   children,
-  defaultOpen = false,
+  isOpen,
+  onToggle,
 }: CampaignAccordionProps) {
-  const [open, setOpen] = useState(defaultOpen);
-
   return (
     <div
       style={{
@@ -45,7 +43,7 @@ function CampaignAccordion({
       {/* HEADER */}
 
       <div
-        onClick={() => setOpen(!open)}
+        onClick={onToggle}
         style={{
           cursor: 'pointer',
           display: 'flex',
@@ -108,7 +106,7 @@ function CampaignAccordion({
             {status}
           </div>
 
-          {open ? (
+          {isOpen ? (
             <KeyboardArrowUp
               style={{
                 color: 'white',
@@ -128,7 +126,7 @@ function CampaignAccordion({
 
       {/* CONTENT */}
 
-      {open && (
+      {isOpen && (
         <div
           style={{
             padding: '1rem',

--- a/apps/frontend/src/components/ui/CampaignActionRow.tsx
+++ b/apps/frontend/src/components/ui/CampaignActionRow.tsx
@@ -1,13 +1,20 @@
-import { KeyboardArrowRight } from '@mui/icons-material';
+import { KeyboardArrowRight, LockOutlined } from '@mui/icons-material';
 
 type CampaignActionRowProps = {
   title: string;
   status: string;
   disabled?: boolean;
+  showLockIcon?: boolean;
   onClick?: () => void;
 };
 
-function CampaignActionRow({ title, status, disabled = false, onClick }: CampaignActionRowProps) {
+function CampaignActionRow({
+  title,
+  status,
+  disabled = false,
+  showLockIcon = false,
+  onClick,
+}: CampaignActionRowProps) {
   return (
     <div
       onClick={!disabled ? onClick : undefined}
@@ -18,7 +25,7 @@ function CampaignActionRow({ title, status, disabled = false, onClick }: Campaig
         justifyContent: 'space-between',
         alignItems: 'center',
         padding: '1.2rem 1.6rem',
-        cursor: disabled ? 'default' : 'pointer',
+        cursor: disabled ? 'not-allowed' : 'pointer',
         transition: '0.2s ease',
       }}
     >
@@ -60,13 +67,21 @@ function CampaignActionRow({ title, status, disabled = false, onClick }: Campaig
           {status}
         </div>
 
-        <KeyboardArrowRight
-          style={{
-            color: disabled ? '#8E63B3' : '#C98FFF',
-
-            fontSize: '2.4rem',
-          }}
-        />
+        {showLockIcon ? (
+          <LockOutlined
+            style={{
+              color: '#8E63B3',
+              fontSize: '2rem',
+            }}
+          />
+        ) : (
+          <KeyboardArrowRight
+            style={{
+              color: disabled ? '#8E63B3' : '#C98FFF',
+              fontSize: '2.4rem',
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/ui/TrainingActionRow.tsx
+++ b/apps/frontend/src/components/ui/TrainingActionRow.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, LockOutlined } from '@mui/icons-material';
+import { ChevronRight, LockOutlined, MenuBookSharp, QuizSharp } from '@mui/icons-material';
 
 type TrainingActionRowProps = {
   label: string;
@@ -6,6 +6,7 @@ type TrainingActionRowProps = {
   disabled?: boolean;
   showLockIcon?: boolean;
   large?: boolean;
+  iconType?: 'learn' | 'quiz';
   onClick?: () => void;
 };
 
@@ -15,8 +16,17 @@ function TrainingActionRow({
   disabled = false,
   showLockIcon = false,
   large = false,
+  iconType,
   onClick,
 }: TrainingActionRowProps) {
+  const cleanedLabel = label.replace(/"/g, '');
+
+  const labelParts = cleanedLabel.split(': ');
+
+  const labelPrefix = labelParts[0];
+
+  const labelTitle = labelParts.slice(1).join(': ');
+
   return (
     <div
       onClick={disabled ? undefined : onClick}
@@ -38,34 +48,54 @@ function TrainingActionRow({
           gap: '1rem',
         }}
       >
+        {iconType === 'learn' && (
+          <MenuBookSharp
+            style={{
+              color: disabled ? '#9A7AB8' : '#C98FFF',
+              fontSize: large ? '2rem' : '1.8rem',
+            }}
+          />
+        )}
+        {iconType === 'quiz' && (
+          <QuizSharp
+            style={{
+              color: disabled ? '#9A7AB8' : '#C98FFF',
+              fontSize: large ? '2rem' : '1.8rem',
+            }}
+          />
+        )}
         <div
           style={{
             color: disabled ? '#9A7AB8' : 'white',
             fontFamily: 'Overpass',
             fontSize: large ? '1.8rem' : '1.4rem',
-            fontWeight: 500,
             letterSpacing: '0.08rem',
-            width: '120px',
-            flexShrink: 0,
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.45rem',
+            flexWrap: 'wrap',
           }}
         >
-          {label}
-        </div>
-
-        {!large && (
-          <div
+          <span
             style={{
-              color: disabled ? '#8E63B3' : '#C98FFF',
-              fontFamily: 'Jost',
-              fontSize: '1rem',
               fontWeight: 500,
-              letterSpacing: '0.08rem',
-              minWidth: '260px',
+              color: disabled ? '#9A7AB8' : 'white',
             }}
           >
-            {status}
-          </div>
-        )}
+            {labelPrefix}:
+          </span>
+
+          <span
+            style={{
+              fontWeight: 400,
+              color: disabled ? '#9A7AB8' : 'white',
+            }}
+          >
+            {labelTitle}
+          </span>
+        </div>
       </div>
 
       <div
@@ -75,19 +105,17 @@ function TrainingActionRow({
           gap: '1rem',
         }}
       >
-        {large && (
-          <div
-            style={{
-              color: disabled ? '#8E63B3' : '#C98FFF',
-              fontFamily: 'Jost',
-              fontSize: '1rem',
-              fontWeight: 500,
-              letterSpacing: '0.08rem',
-            }}
-          >
-            {status}
-          </div>
-        )}
+        <div
+          style={{
+            color: disabled ? '#8E63B3' : '#C98FFF',
+            fontFamily: 'Jost',
+            fontSize: '1rem',
+            fontWeight: 500,
+            letterSpacing: '0.08rem',
+          }}
+        >
+          {status}
+        </div>
         {showLockIcon ? (
           <LockOutlined
             style={{

--- a/apps/frontend/src/components/ui/TrainingActionRow.tsx
+++ b/apps/frontend/src/components/ui/TrainingActionRow.tsx
@@ -1,4 +1,10 @@
-import { ChevronRight, LockOutlined, MenuBookSharp, QuizSharp } from '@mui/icons-material';
+import {
+  ChevronRight,
+  LockOutlined,
+  MenuBookSharp,
+  QuizSharp,
+  GamepadSharp,
+} from '@mui/icons-material';
 
 type TrainingActionRowProps = {
   label: string;
@@ -6,7 +12,7 @@ type TrainingActionRowProps = {
   disabled?: boolean;
   showLockIcon?: boolean;
   large?: boolean;
-  iconType?: 'learn' | 'quiz';
+  iconType?: 'learn' | 'quiz' | 'simulation';
   onClick?: () => void;
 };
 
@@ -58,6 +64,14 @@ function TrainingActionRow({
         )}
         {iconType === 'quiz' && (
           <QuizSharp
+            style={{
+              color: disabled ? '#9A7AB8' : '#C98FFF',
+              fontSize: large ? '2rem' : '1.8rem',
+            }}
+          />
+        )}
+        {iconType === 'simulation' && (
+          <GamepadSharp
             style={{
               color: disabled ? '#9A7AB8' : '#C98FFF',
               fontSize: large ? '2rem' : '1.8rem',

--- a/apps/frontend/src/components/ui/TrainingActionRow.tsx
+++ b/apps/frontend/src/components/ui/TrainingActionRow.tsx
@@ -1,9 +1,10 @@
-import { ChevronRight } from '@mui/icons-material';
+import { ChevronRight, LockOutlined } from '@mui/icons-material';
 
 type TrainingActionRowProps = {
   label: string;
   status: string;
   disabled?: boolean;
+  showLockIcon?: boolean;
   large?: boolean;
   onClick?: () => void;
 };
@@ -12,12 +13,13 @@ function TrainingActionRow({
   label,
   status,
   disabled = false,
+  showLockIcon = false,
   large = false,
   onClick,
 }: TrainingActionRowProps) {
   return (
     <div
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       style={{
         backgroundColor: disabled ? '#2A0844' : 'rgba(53, 0, 94, 0.75)',
         opacity: disabled ? 0.65 : 1,
@@ -25,7 +27,7 @@ function TrainingActionRow({
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
-        cursor: disabled ? 'default' : 'pointer',
+        cursor: disabled ? 'not-allowed' : 'pointer',
         transition: '0.2s ease',
       }}
     >
@@ -86,13 +88,21 @@ function TrainingActionRow({
             {status}
           </div>
         )}
-
-        <ChevronRight
-          style={{
-            color: disabled ? '#8E63B3' : '#C98FFF',
-            fontSize: '2.5rem',
-          }}
-        />
+        {showLockIcon ? (
+          <LockOutlined
+            style={{
+              color: '#8E63B3',
+              fontSize: '2.2rem',
+            }}
+          />
+        ) : (
+          <ChevronRight
+            style={{
+              color: disabled ? '#8E63B3' : '#C98FFF',
+              fontSize: '2.5rem',
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/ui/TrainingActionRow.tsx
+++ b/apps/frontend/src/components/ui/TrainingActionRow.tsx
@@ -94,16 +94,16 @@ function TrainingActionRow({
         >
           <span
             style={{
-              fontWeight: 500,
-              color: disabled ? '#9A7AB8' : 'white',
+              fontWeight: 800,
+              color: disabled ? '#9A7AB8' : '#c383ff',
             }}
           >
-            {labelPrefix}:
+            {labelPrefix}
           </span>
 
           <span
             style={{
-              fontWeight: 400,
+              fontWeight: 100,
               color: disabled ? '#9A7AB8' : 'white',
             }}
           >

--- a/apps/frontend/src/components/ui/TrainingPartAccordion.tsx
+++ b/apps/frontend/src/components/ui/TrainingPartAccordion.tsx
@@ -96,18 +96,31 @@ function TrainingPartAccordion({
 
       {/* CONTENT */}
 
-      {open && (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateRows: open ? '1fr' : '0fr',
+          opacity: open ? 1 : 0,
+          transition: 'grid-template-rows 0.35s ease, opacity 0.25s ease',
+        }}
+      >
         <div
           style={{
-            padding: '0 1.6rem 1.4rem 1.6rem',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '0.8rem',
+            overflow: 'hidden',
           }}
         >
-          {children}
+          <div
+            style={{
+              padding: '0 1.6rem 1.4rem 1.6rem',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '0.8rem',
+            }}
+          >
+            {children}
+          </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/components/ui/TrainingPartAccordion.tsx
+++ b/apps/frontend/src/components/ui/TrainingPartAccordion.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 
-import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
+import { KeyboardArrowDown, KeyboardArrowUp, LockOutlined } from '@mui/icons-material';
 
 type TrainingPartAccordionProps = {
   title: string;
   status: string;
   children: React.ReactNode;
   defaultOpen?: boolean;
+  disabled?: boolean;
 };
 
 function TrainingPartAccordion({
@@ -14,6 +15,7 @@ function TrainingPartAccordion({
   status,
   children,
   defaultOpen = false,
+  disabled = false,
 }: TrainingPartAccordionProps) {
   const [open, setOpen] = useState(defaultOpen);
 
@@ -26,13 +28,14 @@ function TrainingPartAccordion({
       {/* HEADER */}
 
       <div
-        onClick={() => setOpen(!open)}
+        onClick={disabled ? undefined : () => setOpen(!open)}
         style={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
           padding: '1.2rem 1.6rem',
-          cursor: 'pointer',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          opacity: disabled ? 0.65 : 1,
         }}
       >
         <div
@@ -66,7 +69,14 @@ function TrainingPartAccordion({
             {status}
           </div>
 
-          {open ? (
+          {disabled ? (
+            <LockOutlined
+              style={{
+                color: '#8E63B3',
+                fontSize: '2rem',
+              }}
+            />
+          ) : open ? (
             <KeyboardArrowUp
               style={{
                 color: '#C98FFF',

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -39,8 +39,8 @@ function toTitleCase(value: string): string {
   });
 }
 
-function isCampaignItemDisabled(availabilityStatus: string): boolean {
-  return availabilityStatus !== 'AVAILABLE';
+function isCampaignItemDisabled(availabilityStatus: string, isOpenable: boolean): boolean {
+  return availabilityStatus !== 'AVAILABLE' || !isOpenable;
 }
 
 function renderCampaignItems(
@@ -54,6 +54,7 @@ function renderCampaignItems(
           key={item.campaignItemId}
           title={toTitleCase(item.title)}
           status={formatCampaignStatus(item.progressStatus)}
+          disabled={!item.isOpenable}
         >
           {renderCampaignItems(item.children, navigate)}
         </TrainingPartAccordion>
@@ -64,7 +65,7 @@ function renderCampaignItems(
       return null;
     }
 
-    const disabled = isCampaignItemDisabled(item.availabilityStatus);
+    const disabled = isCampaignItemDisabled(item.availabilityStatus, item.isOpenable);
 
     if (item.componentType === 'TRAINING_DOCUMENT') {
       return (
@@ -73,6 +74,7 @@ function renderCampaignItems(
           label="Learn"
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
+          showLockIcon={disabled}
           onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
         />
       );
@@ -85,6 +87,7 @@ function renderCampaignItems(
           label="Quiz"
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
+          showLockIcon={disabled}
           onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
         />
       );
@@ -97,6 +100,7 @@ function renderCampaignItems(
           title={toTitleCase(item.title)}
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
+          showLockIcon={disabled}
           onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
         />
       );

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -9,7 +9,6 @@ import type {
 import AppLayout from '../components/layout/AppLayout';
 import CampaignAccordion from '../components/ui/CampaignAccordion';
 import TrainingActionRow from '../components/ui/TrainingActionRow';
-import CampaignActionRow from '../components/ui/CampaignActionRow';
 import TrainingPartAccordion from '../components/ui/TrainingPartAccordion';
 
 import { useAuth } from '../context/useAuth';
@@ -96,12 +95,13 @@ function renderCampaignItems(
 
     if (item.componentType === 'SIMULATED_INBOX') {
       return (
-        <CampaignActionRow
+        <TrainingActionRow
           key={item.campaignItemId}
-          title={toTitleCase(item.title)}
+          label={`Simulation: ${toTitleCase(item.title)}`}
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
           showLockIcon={disabled}
+          iconType="simulation"
           onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
         />
       );

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import type { TraineeCampaignSummaryDto } from '@insightful-phish/shared';
+import type {
+  GetTraineeCampaignDetailResponseDto,
+  TraineeCampaignSummaryDto,
+} from '@insightful-phish/shared';
 
 import AppLayout from '../components/layout/AppLayout';
 import CampaignAccordion from '../components/ui/CampaignAccordion';
+import TrainingActionRow from '../components/ui/TrainingActionRow';
+import CampaignActionRow from '../components/ui/CampaignActionRow';
 
 import { useAuth } from '../context/useAuth';
-import { getTraineeCampaigns } from '../services/campaigns.service';
+import { getTraineeCampaign, getTraineeCampaigns } from '../services/campaigns.service';
 
 const ACCENT_COLORS = ['#00FFA6', '#FF00D4', '#00D1FF', '#FF9F1C'];
 
@@ -35,6 +40,12 @@ function CampaignsPage() {
   const [campaigns, setCampaigns] = useState<TraineeCampaignSummaryDto[]>([]);
 
   const [openCampaigns, setOpenCampaigns] = useState<Record<string, boolean>>({});
+
+  const [campaignDetails, setCampaignDetails] = useState<
+    Record<string, GetTraineeCampaignDetailResponseDto>
+  >({});
+
+  const [loadingCampaignDetails, setLoadingCampaignDetails] = useState<Record<string, boolean>>({});
 
   const [loading, setLoading] = useState(true);
 
@@ -64,11 +75,39 @@ function CampaignsPage() {
     void loadCampaigns();
   }, [token]);
 
-  function toggleCampaign(campaignId: string) {
+  async function toggleCampaign(campaignId: string) {
+    const isCurrentlyOpen = Boolean(openCampaigns[campaignId]);
+
     setOpenCampaigns((previous) => ({
       ...previous,
       [campaignId]: !previous[campaignId],
     }));
+
+    if (isCurrentlyOpen || campaignDetails[campaignId] || !token) {
+      return;
+    }
+
+    try {
+      setLoadingCampaignDetails((previous) => ({
+        ...previous,
+        [campaignId]: true,
+      }));
+
+      const detail = await getTraineeCampaign(campaignId, token);
+      console.log('CAMPAIGN DETAIL:', detail);
+
+      setCampaignDetails((previous) => ({
+        ...previous,
+        [campaignId]: detail,
+      }));
+    } catch {
+      setError('FAILED TO LOAD CAMPAIGN DETAILS');
+    } finally {
+      setLoadingCampaignDetails((previous) => ({
+        ...previous,
+        [campaignId]: false,
+      }));
+    }
   }
 
   return (
@@ -132,8 +171,61 @@ function CampaignsPage() {
               status={formatCampaignStatus(campaign.progressStatus)}
               accentColor={ACCENT_COLORS[index % ACCENT_COLORS.length]}
               isOpen={Boolean(openCampaigns[campaign.campaignId])}
-              onToggle={() => toggleCampaign(campaign.campaignId)}
-            />
+              onToggle={() => void toggleCampaign(campaign.campaignId)}
+            >
+              {loadingCampaignDetails[campaign.campaignId] && (
+                <div
+                  style={{
+                    color: '#C98FFF',
+                    fontFamily: 'Jost',
+                    padding: '1rem',
+                  }}
+                >
+                  LOADING CAMPAIGN...
+                </div>
+              )}
+
+              {campaignDetails[campaign.campaignId]?.items.map((item) => {
+                if (item.itemType !== 'COMPONENT') {
+                  return null;
+                }
+
+                if (item.componentType === 'TRAINING_DOCUMENT') {
+                  return (
+                    <TrainingActionRow
+                      key={item.campaignItemId}
+                      label="Learn"
+                      status={formatCampaignStatus(item.progressStatus)}
+                      onClick={() => navigate(item.activityApiPath)}
+                    />
+                  );
+                }
+
+                if (item.componentType === 'QUIZ') {
+                  return (
+                    <TrainingActionRow
+                      key={item.campaignItemId}
+                      label="Quiz"
+                      status={formatCampaignStatus(item.progressStatus)}
+                      onClick={() => navigate(item.activityApiPath)}
+                    />
+                  );
+                }
+
+                if (item.componentType === 'SIMULATED_INBOX') {
+                  return (
+                    <CampaignActionRow
+                      key={item.campaignItemId}
+                      title={item.title}
+                      status={formatCampaignStatus(item.progressStatus)}
+                      onClick={() => navigate(item.activityApiPath)}
+                    />
+                  );
+                }
+
+                return null;
+              })}
+            </CampaignAccordion>
           ))}
       </div>
     </AppLayout>

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -1,15 +1,76 @@
-import AppLayout from '../components/layout/AppLayout';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import type { TraineeCampaignSummaryDto } from '@insightful-phish/shared';
+
+import AppLayout from '../components/layout/AppLayout';
 import CampaignAccordion from '../components/ui/CampaignAccordion';
 
-import TrainingPartAccordion from '../components/ui/TrainingPartAccordion';
+import { useAuth } from '../context/useAuth';
+import { getTraineeCampaigns } from '../services/campaigns.service';
 
-import TrainingActionRow from '../components/ui/TrainingActionRow';
-import CampaignActionRow from '../components/ui/CampaignActionRow';
+const ACCENT_COLORS = ['#00FFA6', '#FF00D4', '#00D1FF', '#FF9F1C'];
+
+function formatCampaignStatus(status?: string | null): string {
+  switch (status) {
+    case 'COMPLETED':
+      return 'COMPLETED';
+
+    case 'IN_PROGRESS':
+    case 'VIEWED':
+    case 'INTERACTED':
+      return 'STARTED';
+
+    case 'NOT_STARTED':
+    default:
+      return 'NOT STARTED';
+  }
+}
 
 function CampaignsPage() {
   const navigate = useNavigate();
+
+  const { token } = useAuth();
+
+  const [campaigns, setCampaigns] = useState<TraineeCampaignSummaryDto[]>([]);
+
+  const [openCampaigns, setOpenCampaigns] = useState<Record<string, boolean>>({});
+
+  const [loading, setLoading] = useState(true);
+
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function loadCampaigns() {
+      if (!token) {
+        setError('NOT AUTHENTICATED');
+
+        setLoading(false);
+
+        return;
+      }
+
+      try {
+        const data = await getTraineeCampaigns(token);
+
+        setCampaigns(data.campaigns);
+      } catch {
+        setError('FAILED TO LOAD CAMPAIGNS');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void loadCampaigns();
+  }, [token]);
+
+  function toggleCampaign(campaignId: string) {
+    setOpenCampaigns((previous) => ({
+      ...previous,
+      [campaignId]: !previous[campaignId],
+    }));
+  }
+
   return (
     <AppLayout>
       <div
@@ -23,8 +84,6 @@ function CampaignsPage() {
           userSelect: 'none',
         }}
       >
-        {/* HEADING */}
-
         <h1
           style={{
             margin: 0,
@@ -39,61 +98,43 @@ function CampaignsPage() {
           Campaigns
         </h1>
 
-        {/* CAMPAIGN 1 */}
-        <CampaignAccordion
-          title="Campaign 1"
-          subtitle="Phishing"
-          status="STARTED"
-          accentColor="#00FFA6"
-        >
-          <TrainingPartAccordion title="Part 1: Introduction to Phishing" status="COMPLETED">
-            <TrainingActionRow label="Learn" status="COMPLETED" />
+        {loading && (
+          <div
+            style={{
+              color: '#C98FFF',
+              fontFamily: 'Jost',
+              fontSize: '1.2rem',
+            }}
+          >
+            LOADING CAMPAIGNS...
+          </div>
+        )}
 
-            <TrainingActionRow label="Quiz" status="COMPLETED" />
-          </TrainingPartAccordion>
+        {error && (
+          <div
+            style={{
+              color: '#FF7A7A',
+              fontFamily: 'Jost',
+              fontSize: '1.2rem',
+            }}
+          >
+            {error}
+          </div>
+        )}
 
-          <TrainingPartAccordion title="Part 2: Spotting Suspicious Emails" status="COMPLETED">
-            <TrainingActionRow label="Learn" status="COMPLETED" />
-
-            <TrainingActionRow label="Quiz" status="COMPLETED" />
-          </TrainingPartAccordion>
-
-          <CampaignActionRow
-            title="Simulated Email Inbox"
-            status=""
-            onClick={() => navigate('/simulation/inbox')}
-          />
-
-          <CampaignActionRow title="Final Quiz" status="NOT STARTED" />
-        </CampaignAccordion>
-
-        {/* CAMPAIGN 2 */}
-        <CampaignAccordion
-          title="Campaign 2"
-          subtitle="Password Security"
-          status="STARTED"
-          accentColor="#FF00D4"
-        >
-          <TrainingPartAccordion title="Part 1: What is Password Security?" status="COMPLETED">
-            <TrainingActionRow label="Learn" status="COMPLETED" />
-
-            <TrainingActionRow label="Quiz" status="COMPLETED" />
-          </TrainingPartAccordion>
-
-          <TrainingPartAccordion title="Part 2: Is your Password Secure?" status="STARTED">
-            <TrainingActionRow label="Learn" status="STARTED" />
-
-            <TrainingActionRow label="Quiz" status="COMPLETE LEARN FIRST" disabled />
-          </TrainingPartAccordion>
-
-          <CampaignActionRow
-            title="Password Security Simulation"
-            status="COMPLETE ALL PARTS FIRST"
-            disabled
-          />
-
-          <CampaignActionRow title="Final Quiz" status="COMPLETE ALL PARTS FIRST" disabled />
-        </CampaignAccordion>
+        {!loading &&
+          !error &&
+          campaigns.map((campaign, index) => (
+            <CampaignAccordion
+              key={campaign.campaignId}
+              title={`Campaign ${index + 1}`}
+              subtitle={campaign.name}
+              status={formatCampaignStatus(campaign.progressStatus)}
+              accentColor={ACCENT_COLORS[index % ACCENT_COLORS.length]}
+              isOpen={Boolean(openCampaigns[campaign.campaignId])}
+              onToggle={() => toggleCampaign(campaign.campaignId)}
+            />
+          ))}
       </div>
     </AppLayout>
   );

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -54,7 +54,6 @@ function renderCampaignItems(
           key={item.campaignItemId}
           title={toTitleCase(item.title)}
           status={formatCampaignStatus(item.progressStatus)}
-          disabled={!item.isOpenable}
         >
           {renderCampaignItems(item.children, navigate)}
         </TrainingPartAccordion>
@@ -71,7 +70,7 @@ function renderCampaignItems(
       return (
         <TrainingActionRow
           key={item.campaignItemId}
-          label="Learn"
+          label={`Learn: "${toTitleCase(item.title)}"`}
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
           showLockIcon={disabled}
@@ -84,7 +83,7 @@ function renderCampaignItems(
       return (
         <TrainingActionRow
           key={item.campaignItemId}
-          label="Quiz"
+          label={`Quiz: "${toTitleCase(item.title)}"`}
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
           showLockIcon={disabled}

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -10,6 +10,7 @@ import AppLayout from '../components/layout/AppLayout';
 import CampaignAccordion from '../components/ui/CampaignAccordion';
 import TrainingActionRow from '../components/ui/TrainingActionRow';
 import CampaignActionRow from '../components/ui/CampaignActionRow';
+import TrainingPartAccordion from '../components/ui/TrainingPartAccordion';
 
 import { useAuth } from '../context/useAuth';
 import { getTraineeCampaign, getTraineeCampaigns } from '../services/campaigns.service';
@@ -30,6 +31,73 @@ function formatCampaignStatus(status?: string | null): string {
     default:
       return 'NOT STARTED';
   }
+}
+
+function isCampaignItemDisabled(availabilityStatus: string): boolean {
+  return availabilityStatus !== 'AVAILABLE';
+}
+
+function renderCampaignItems(
+  items: GetTraineeCampaignDetailResponseDto['items'],
+  navigate: ReturnType<typeof useNavigate>,
+) {
+  return items.map((item) => {
+    if (item.itemType === 'GROUP') {
+      return (
+        <TrainingPartAccordion
+          key={item.campaignItemId}
+          title={item.title}
+          status={formatCampaignStatus(item.progressStatus)}
+        >
+          {renderCampaignItems(item.children, navigate)}
+        </TrainingPartAccordion>
+      );
+    }
+
+    if (item.itemType !== 'COMPONENT') {
+      return null;
+    }
+
+    const disabled = isCampaignItemDisabled(item.availabilityStatus);
+
+    if (item.componentType === 'TRAINING_DOCUMENT') {
+      return (
+        <TrainingActionRow
+          key={item.campaignItemId}
+          label="Learn"
+          status={formatCampaignStatus(item.progressStatus)}
+          disabled={disabled}
+          onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
+        />
+      );
+    }
+
+    if (item.componentType === 'QUIZ') {
+      return (
+        <TrainingActionRow
+          key={item.campaignItemId}
+          label="Quiz"
+          status={formatCampaignStatus(item.progressStatus)}
+          disabled={disabled}
+          onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
+        />
+      );
+    }
+
+    if (item.componentType === 'SIMULATED_INBOX') {
+      return (
+        <CampaignActionRow
+          key={item.campaignItemId}
+          title={item.title}
+          status={formatCampaignStatus(item.progressStatus)}
+          disabled={disabled}
+          onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
+        />
+      );
+    }
+
+    return null;
+  });
 }
 
 function CampaignsPage() {
@@ -185,46 +253,8 @@ function CampaignsPage() {
                 </div>
               )}
 
-              {campaignDetails[campaign.campaignId]?.items.map((item) => {
-                if (item.itemType !== 'COMPONENT') {
-                  return null;
-                }
-
-                if (item.componentType === 'TRAINING_DOCUMENT') {
-                  return (
-                    <TrainingActionRow
-                      key={item.campaignItemId}
-                      label="Learn"
-                      status={formatCampaignStatus(item.progressStatus)}
-                      onClick={() => navigate(item.activityApiPath)}
-                    />
-                  );
-                }
-
-                if (item.componentType === 'QUIZ') {
-                  return (
-                    <TrainingActionRow
-                      key={item.campaignItemId}
-                      label="Quiz"
-                      status={formatCampaignStatus(item.progressStatus)}
-                      onClick={() => navigate(item.activityApiPath)}
-                    />
-                  );
-                }
-
-                if (item.componentType === 'SIMULATED_INBOX') {
-                  return (
-                    <CampaignActionRow
-                      key={item.campaignItemId}
-                      title={item.title}
-                      status={formatCampaignStatus(item.progressStatus)}
-                      onClick={() => navigate(item.activityApiPath)}
-                    />
-                  );
-                }
-
-                return null;
-              })}
+              {campaignDetails[campaign.campaignId] &&
+                renderCampaignItems(campaignDetails[campaign.campaignId].items, navigate)}
             </CampaignAccordion>
           ))}
       </div>

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -162,7 +162,6 @@ function CampaignsPage() {
       }));
 
       const detail = await getTraineeCampaign(campaignId, token);
-      console.log('CAMPAIGN DETAIL:', detail);
 
       setCampaignDetails((previous) => ({
         ...previous,

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -74,6 +74,7 @@ function renderCampaignItems(
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
           showLockIcon={disabled}
+          iconType="learn"
           onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
         />
       );
@@ -87,6 +88,7 @@ function renderCampaignItems(
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
           showLockIcon={disabled}
+          iconType="quiz"
           onClick={disabled ? undefined : () => navigate(item.activityApiPath)}
         />
       );

--- a/apps/frontend/src/pages/CampaignsPage.tsx
+++ b/apps/frontend/src/pages/CampaignsPage.tsx
@@ -33,6 +33,12 @@ function formatCampaignStatus(status?: string | null): string {
   }
 }
 
+function toTitleCase(value: string): string {
+  return value.replace(/\w\S*/g, (word) => {
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  });
+}
+
 function isCampaignItemDisabled(availabilityStatus: string): boolean {
   return availabilityStatus !== 'AVAILABLE';
 }
@@ -46,7 +52,7 @@ function renderCampaignItems(
       return (
         <TrainingPartAccordion
           key={item.campaignItemId}
-          title={item.title}
+          title={toTitleCase(item.title)}
           status={formatCampaignStatus(item.progressStatus)}
         >
           {renderCampaignItems(item.children, navigate)}
@@ -88,7 +94,7 @@ function renderCampaignItems(
       return (
         <CampaignActionRow
           key={item.campaignItemId}
-          title={item.title}
+          title={toTitleCase(item.title)}
           status={formatCampaignStatus(item.progressStatus)}
           disabled={disabled}
           onClick={disabled ? undefined : () => navigate(item.activityApiPath)}

--- a/apps/frontend/src/services/campaigns.service.ts
+++ b/apps/frontend/src/services/campaigns.service.ts
@@ -1,0 +1,41 @@
+import type {
+  GetTraineeCampaignDetailResponseDto,
+  GetTraineeCampaignsResponseDto,
+} from '@insightful-phish/shared';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export async function getTraineeCampaigns(token: string): Promise<GetTraineeCampaignsResponseDto> {
+  const response = await fetch(`${API_BASE_URL}/trainee/campaigns`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const data = (await response.json()) as GetTraineeCampaignsResponseDto;
+
+  if (!response.ok) {
+    throw new Error('FAILED TO FETCH CAMPAIGNS');
+  }
+
+  return data;
+}
+
+export async function getTraineeCampaign(
+  campaignId: string,
+  token: string,
+): Promise<GetTraineeCampaignDetailResponseDto> {
+  const response = await fetch(`${API_BASE_URL}/trainee/campaigns/${campaignId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const data = (await response.json()) as GetTraineeCampaignDetailResponseDto;
+
+  if (!response.ok) {
+    throw new Error('FAILED TO FETCH CAMPAIGN');
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary

* Integrated the campaigns page with the trainee campaigns backend API
* Replaced hardcoded campaign accordions with dynamically fetched campaign data
* Added authenticated campaign fetching using stored JWT tokens
* Added loading and error handling states for campaign requests
* Refactored CampaignAccordion to support controlled expansion state
* Implemented lazy loading of campaign details when a campaign is expanded
* Added local caching for fetched campaign details to avoid repeated requests
* Rendered training documents, quizzes, and simulations dynamically from backend campaign items
* Connected training items to existing TrainingActionRow components
* Connected simulation items to existing CampaignActionRow components
* Added dynamic campaign progress status rendering from backend data
* Preserved the original campaigns page UI and styling during integration
* Removed remaining hardcoded campaign item content
* Added frontend-managed rotating accent colours for campaign cards
* Added a dedicated campaigns service for backend communication

## Type of change

- [X] Feature
- [X] Implementation
- [ ] Bug Fix
- [ ] Documentation
- [ ] Chore/Maintenance


## Checklist
- [X] No unrelated changes are included
- [ ] Relevant tests were added or updated if applicable (NOT YET, ONLY LATER)
- [ ] Documentation was updated if needed
- [X] No secrets, credentials, or sensitive values were committed
