### PR TITLE
Chore/demo1 password security seed/adriano

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -11,7 +11,7 @@ Insightful Phish is a `pnpm workspace` monorepo with:
 - Prisma 7 for database schema management
 - Husky, lint-staged, and commitlint for local Git quality checks
 
-The local setup path applies the current committed database migrations and can seed repeatable Demo 1 data using the modular campaign model. Demo 1 data is campaign-based: trainees access seeded campaign items for simulated inbox, training document, and quiz flows where the current app and APIs support them.
+The local setup path applies the current committed database migrations and can seed repeatable Demo 1 data using the modular campaign model. Demo 1 data is campaign-based: trainees access seeded campaign items for simulated inbox, training document, and quiz flows where the current app and APIs support them. The populated trainee has seeded phishing awareness and password security campaigns, while the empty-state trainee remains unassigned.
 
 ## 1. Required tools
 
@@ -536,6 +536,13 @@ demo.admin@example.com
 
 All three use the password supplied through `DEMO_SEED_PASSWORD`.
 
+The populated trainee is assigned to two active seeded campaigns:
+
+- phishing awareness
+- password security
+
+The password security campaign is a simple sequence with an available training document followed by a statically locked quiz. Training completion records interaction data but does not unlock the quiz, because dynamic unlock logic is out of scope for this seed.
+
 Only run the Demo 1 seed against a local development database.
 
 ## 10. Run the backend
@@ -636,6 +643,7 @@ Before a local Demo 1 rehearsal, verify:
 - The backend responds at `http://localhost:4000/health`.
 - The frontend starts at `http://localhost:5173`.
 - `demo.populated.trainee@example.com` can log in with the local `DEMO_SEED_PASSWORD`.
+- The populated trainee can see both seeded campaigns where campaign discovery is supported.
 - `demo.empty.trainee@example.com` can log in and show the intended empty state where the current frontend supports it.
 - Seeded campaign-based content is reachable through the current app or APIs where implemented.
 - If UI/API verification is not wired yet, use Prisma Studio to inspect `Campaign`, `CampaignItem`, `CampaignAssignment`, `Simulation`, and `SimulatedInbox`.

--- a/apps/backend/SEEDING.md
+++ b/apps/backend/SEEDING.md
@@ -12,6 +12,7 @@ The Demo 1 seed creates repeatable local data for:
 - inbox and email detail views
 - training material views
 - quiz and result paths
+- password-security campaign views
 - classification feedback and red flag feedback
 
 The seed is designed for local Demo 1 development only.
@@ -60,8 +61,9 @@ The Demo 1 seed creates:
 - a populated trainee user and profile
 - an empty-state trainee user and profile
 - a demo admin user and admin profile
-- one Demo 1 campaign
-- one campaign assignment for the populated trainee
+- two Demo 1 campaigns assigned to the populated trainee:
+  - phishing awareness campaign
+  - password security campaign
 - no campaign assignment for the empty-state trainee
 - ordered campaign items for training, quiz, and simulated inbox components
 - reusable training documents
@@ -73,6 +75,42 @@ The Demo 1 seed creates:
 - a mix of phishing, suspicious, and safe simulated emails
 - expected email classifications
 - red flags for phishing and suspicious emails
+
+## Seeded Campaigns
+
+The populated trainee is assigned to two active Demo 1 campaigns.
+
+### Phishing Awareness Campaign
+
+The phishing awareness campaign demonstrates the broader Demo 1 flow for training, quiz, and simulated inbox content.
+
+### Password Security Campaign
+
+The password security campaign demonstrates a simple sequential path:
+
+1. password-security training document
+2. password-security quiz
+
+The password-security training item is seeded as `AVAILABLE`, so it is openable immediately under the current backend rules.
+
+The password-security quiz item is seeded as `LOCKED`. This locked state is static seed behavior. There is no dynamic unlock engine in this issue, and completing the password-security training document does not unlock later campaign items.
+
+Training completion records an `InteractionEvent`, but the current Demo 1 seed does not include prerequisite or sequential unlock logic.
+
+The empty-state trainee remains unassigned and should not receive either seeded campaign.
+
+## Password Training Content Metadata
+
+The password-security training document uses the current backend metadata fields:
+
+- `contentType`
+- `contentRef`
+- `contentSummary`
+- `estimatedReadTimeMinutes`
+- `difficultyLevel`
+- `status`
+
+Runtime markdown body loading is out of scope for this seed. The seed uses metadata and content references only.
 
 ## Commands
 

--- a/apps/backend/prisma/seed-data/demoSeedConfig.ts
+++ b/apps/backend/prisma/seed-data/demoSeedConfig.ts
@@ -50,8 +50,10 @@ export const DEMO_SEED_IDS = {
   ipAdminProfile: '22222222-2222-4222-8222-222222222225',
   campaign: '33333333-3333-4333-8333-333333333331',
   campaignB: '33333333-3333-4333-8333-333333333339',
+  passwordSecurityCampaign: '33333333-3333-4333-8333-333333333340',
   campaignAssignments: {
     populatedTrainee: '33333333-3333-4333-8333-333333333332',
+    passwordSecurity: '33333333-3333-4333-8333-333333333341',
   },
   campaignItems: {
     trainingDocument: '33333333-3333-4333-8333-333333333333',
@@ -60,14 +62,18 @@ export const DEMO_SEED_IDS = {
     simulatedInbox: '33333333-3333-4333-8333-333333333335',
     safeLinkHandlingQuiz: '33333333-3333-4333-8333-333333333337',
     campaignBTrainingDocument: '33333333-3333-4333-8333-333333333338',
+    passwordSecurityTrainingDocument: '33333333-3333-4333-8333-333333333342',
+    passwordSecurityQuiz: '33333333-3333-4333-8333-333333333343',
   },
   trainingDocuments: {
     warningSigns: '44444444-4444-4444-8444-444444444441',
     safeLinkHandling: '44444444-4444-4444-8444-444444444442',
+    passwordSecurity: '44444444-4444-4444-8444-444444444443',
   },
   quizzes: {
     warningSigns: '55555555-5555-4555-8555-555555555551',
     safeLinkHandling: '55555555-5555-4555-8555-555555555552',
+    passwordSecurity: '55555555-5555-4555-8555-555555555553',
   },
   quizQuestions: {
     spoofedSender: '55555555-5555-4555-8555-555555555561',
@@ -80,6 +86,10 @@ export const DEMO_SEED_IDS = {
     mfaPrompt: '55555555-5555-4555-8555-555555555568',
     safeCredentialPage: '55555555-5555-4555-8555-555555555569',
     shortenedUrl: '55555555-5555-4555-8555-555555555570',
+    passwordManagerPurpose: '55555555-5555-4555-8555-555555555571',
+    uniquePasswordValue: '55555555-5555-4555-8555-555555555572',
+    passphraseStrength: '55555555-5555-4555-8555-555555555573',
+    breachResponse: '55555555-5555-4555-8555-555555555574',
   },
   answerOptions: {
     spoofedSenderA: '55555555-5555-4555-8555-555555555601',
@@ -112,6 +122,18 @@ export const DEMO_SEED_IDS = {
     shortenedUrlA: '55555555-5555-4555-8555-555555555628',
     shortenedUrlB: '55555555-5555-4555-8555-555555555629',
     shortenedUrlC: '55555555-5555-4555-8555-555555555630',
+    passwordManagerPurposeA: '55555555-5555-4555-8555-555555555631',
+    passwordManagerPurposeB: '55555555-5555-4555-8555-555555555632',
+    passwordManagerPurposeC: '55555555-5555-4555-8555-555555555633',
+    uniquePasswordValueA: '55555555-5555-4555-8555-555555555634',
+    uniquePasswordValueB: '55555555-5555-4555-8555-555555555635',
+    uniquePasswordValueC: '55555555-5555-4555-8555-555555555636',
+    passphraseStrengthA: '55555555-5555-4555-8555-555555555637',
+    passphraseStrengthB: '55555555-5555-4555-8555-555555555638',
+    passphraseStrengthC: '55555555-5555-4555-8555-555555555639',
+    breachResponseA: '55555555-5555-4555-8555-555555555640',
+    breachResponseB: '55555555-5555-4555-8555-555555555641',
+    breachResponseC: '55555555-5555-4555-8555-555555555642',
   },
   simulation: '66666666-6666-4666-8666-666666666661',
   simulatedInbox: '66666666-6666-4666-8666-666666666662',
@@ -207,6 +229,17 @@ export const DEMO_SEED_CAMPAIGN_B = {
   status: CampaignStatus.ACTIVE,
 } as const;
 
+export const DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN = {
+  id: DEMO_SEED_IDS.passwordSecurityCampaign,
+  createdByUserId: DEMO_SEED_IDS.users.admin,
+  name: 'Demo 1 Password Security',
+  description:
+    'Sequential demo campaign for password manager habits, unique passwords, and breach response.',
+  campaignType: CampaignType.PREMADE_GENERAL,
+  difficultyLevel: DifficultyLevel.BEGINNER,
+  status: CampaignStatus.ACTIVE,
+} as const;
+
 export const DEMO_SEED_CAMPAIGN_ASSIGNMENT = {
   id: DEMO_SEED_IDS.campaignAssignments.populatedTrainee,
   campaignId: DEMO_SEED_IDS.campaign,
@@ -216,6 +249,229 @@ export const DEMO_SEED_CAMPAIGN_ASSIGNMENT = {
   assignmentStatus: AssignmentStatus.ASSIGNED,
   accessType: CampaignAccessType.ASSIGNED,
 } as const;
+
+export const DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT = {
+  id: DEMO_SEED_IDS.campaignAssignments.passwordSecurity,
+  campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+  traineeProfileId: DEMO_SEED_IDS.traineeProfiles.populated,
+  assignedByUserId: DEMO_SEED_IDS.users.admin,
+  currentCampaignItemId: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+  assignmentStatus: AssignmentStatus.ASSIGNED,
+  accessType: CampaignAccessType.ASSIGNED,
+} as const;
+
+export const DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT = {
+  id: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
+  createdByUserId: DEMO_SEED_IDS.users.admin,
+  title: 'Password Security Basics',
+  contentType: TrainingContentType.HTML,
+  contentRef: 'demo://training/password-security-basics',
+  contentSummary:
+    'How to use unique passwords, passphrases, password managers, MFA, and breach response habits.',
+  estimatedReadTimeMinutes: 5,
+  difficultyLevel: DifficultyLevel.BEGINNER,
+  status: TrainingDocumentStatus.AVAILABLE,
+} as const;
+
+export const DEMO_SEED_PASSWORD_SECURITY_QUIZ = {
+  id: DEMO_SEED_IDS.quizzes.passwordSecurity,
+  createdByUserId: DEMO_SEED_IDS.users.admin,
+  title: 'Password Security Basics Check',
+  description:
+    'Knowledge check on password managers, unique passwords, strong passphrases, and breach response.',
+  passThresholdPercentage: 75,
+  difficultyLevel: DifficultyLevel.BEGINNER,
+  status: QuizStatus.PUBLISHED,
+  questions: [
+    {
+      id: DEMO_SEED_IDS.quizQuestions.passwordManagerPurpose,
+      prompt: 'What is the main security benefit of using a password manager?',
+      questionType: QuestionType.SINGLE_CHOICE,
+      position: demoPosition(0),
+      points: 1,
+      shuffleOptions: false,
+      answerOptions: [
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeA,
+            label: 'A',
+            text: 'It helps create and store unique passwords for each account.',
+            isCorrect: true,
+            feedbackText: 'Password managers make unique passwords practical to use safely.',
+          },
+          0,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeB,
+            label: 'B',
+            text: 'It lets you reuse one password without extra risk.',
+            isCorrect: false,
+            feedbackText: 'Reusing one password still creates risk if that password is stolen.',
+          },
+          1,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeC,
+            label: 'C',
+            text: 'It removes the need to lock your device.',
+            isCorrect: false,
+            feedbackText: 'Device locking is still needed to protect signed-in sessions.',
+          },
+          2,
+        ),
+      ],
+    },
+    {
+      id: DEMO_SEED_IDS.quizQuestions.uniquePasswordValue,
+      prompt: 'Why should important accounts use different passwords?',
+      questionType: QuestionType.SINGLE_CHOICE,
+      position: demoPosition(1),
+      points: 1,
+      shuffleOptions: false,
+      answerOptions: [
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.uniquePasswordValueA,
+            label: 'A',
+            text: 'Different passwords limit damage if one service is breached.',
+            isCorrect: true,
+            feedbackText: 'Unique passwords keep one stolen password from opening other accounts.',
+          },
+          0,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.uniquePasswordValueB,
+            label: 'B',
+            text: 'Different passwords make MFA unnecessary.',
+            isCorrect: false,
+            feedbackText: 'MFA remains valuable even when every password is unique.',
+          },
+          1,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.uniquePasswordValueC,
+            label: 'C',
+            text: 'Different passwords only matter for personal accounts.',
+            isCorrect: false,
+            feedbackText: 'Work and personal accounts both benefit from unique passwords.',
+          },
+          2,
+        ),
+      ],
+    },
+    {
+      id: DEMO_SEED_IDS.quizQuestions.passphraseStrength,
+      prompt: 'Which password habit is strongest?',
+      questionType: QuestionType.SINGLE_CHOICE,
+      position: demoPosition(2),
+      points: 1,
+      shuffleOptions: false,
+      answerOptions: [
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passphraseStrengthA,
+            label: 'A',
+            text: 'Use a long, unique passphrase or generated password.',
+            isCorrect: true,
+            feedbackText: 'Length and uniqueness make passwords harder to guess or reuse.',
+          },
+          0,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passphraseStrengthB,
+            label: 'B',
+            text: 'Use the company name with the current year.',
+            isCorrect: false,
+            feedbackText: 'Predictable patterns are easier for attackers to guess.',
+          },
+          1,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passphraseStrengthC,
+            label: 'C',
+            text: 'Use the same memorable password everywhere.',
+            isCorrect: false,
+            feedbackText: 'A reused password can expose many accounts after one breach.',
+          },
+          2,
+        ),
+      ],
+    },
+    {
+      id: DEMO_SEED_IDS.quizQuestions.breachResponse,
+      prompt: 'What should you do after learning a password may have been exposed?',
+      questionType: QuestionType.SINGLE_CHOICE,
+      position: demoPosition(3),
+      points: 1,
+      shuffleOptions: false,
+      answerOptions: [
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.breachResponseA,
+            label: 'A',
+            text: 'Change that password and any reused copies, then report if it affects work.',
+            isCorrect: true,
+            feedbackText: 'Fast rotation and reporting reduce the chance of account takeover.',
+          },
+          0,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.breachResponseB,
+            label: 'B',
+            text: 'Wait to see whether someone logs in first.',
+            isCorrect: false,
+            feedbackText: 'Waiting gives attackers more time to use exposed credentials.',
+          },
+          1,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.breachResponseC,
+            label: 'C',
+            text: 'Email the password to your manager for checking.',
+            isCorrect: false,
+            feedbackText: 'Passwords should never be shared by email or chat.',
+          },
+          2,
+        ),
+      ],
+    },
+  ],
+} as const;
+
+export const DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS = [
+  {
+    id: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+    campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+    itemType: CampaignItemType.COMPONENT,
+    componentType: CampaignComponentType.TRAINING_DOCUMENT,
+    title: 'Read password security basics',
+    description: 'Start with the password security basics training document.',
+    position: demoPosition(0),
+    isRequired: true,
+    availabilityStatus: CampaignItemAvailabilityStatus.AVAILABLE,
+    trainingDocumentId: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
+  },
+  {
+    id: DEMO_SEED_IDS.campaignItems.passwordSecurityQuiz,
+    campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+    itemType: CampaignItemType.COMPONENT,
+    componentType: CampaignComponentType.QUIZ,
+    title: 'Complete the password security check',
+    description: 'Answer the password security basics quiz.',
+    position: demoPosition(1),
+    isRequired: true,
+    availabilityStatus: CampaignItemAvailabilityStatus.AVAILABLE,
+    quizId: DEMO_SEED_IDS.quizzes.passwordSecurity,
+  },
+] as const;
 
 export const DEMO_SEED_TRAINING_DOCUMENTS = [
   {

--- a/apps/backend/prisma/seed-data/demoSeedConfig.ts
+++ b/apps/backend/prisma/seed-data/demoSeedConfig.ts
@@ -90,6 +90,7 @@ export const DEMO_SEED_IDS = {
     uniquePasswordValue: '55555555-5555-4555-8555-555555555572',
     passphraseStrength: '55555555-5555-4555-8555-555555555573',
     breachResponse: '55555555-5555-4555-8555-555555555574',
+    passwordMfa: '55555555-5555-4555-8555-555555555575',
   },
   answerOptions: {
     spoofedSenderA: '55555555-5555-4555-8555-555555555601',
@@ -134,6 +135,9 @@ export const DEMO_SEED_IDS = {
     breachResponseA: '55555555-5555-4555-8555-555555555640',
     breachResponseB: '55555555-5555-4555-8555-555555555641',
     breachResponseC: '55555555-5555-4555-8555-555555555642',
+    passwordMfaA: '55555555-5555-4555-8555-555555555643',
+    passwordMfaB: '55555555-5555-4555-8555-555555555644',
+    passwordMfaC: '55555555-5555-4555-8555-555555555645',
   },
   simulation: '66666666-6666-4666-8666-666666666661',
   simulatedInbox: '66666666-6666-4666-8666-666666666662',
@@ -443,6 +447,46 @@ export const DEMO_SEED_PASSWORD_SECURITY_QUIZ = {
         ),
       ],
     },
+    {
+      id: DEMO_SEED_IDS.quizQuestions.passwordMfa,
+      prompt: 'How does MFA help protect an account password?',
+      questionType: QuestionType.SINGLE_CHOICE,
+      position: demoPosition(4),
+      points: 1,
+      shuffleOptions: false,
+      answerOptions: [
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passwordMfaA,
+            label: 'A',
+            text: 'It adds another check if a password is stolen.',
+            isCorrect: true,
+            feedbackText: 'MFA can block access even when an attacker knows the password.',
+          },
+          0,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passwordMfaB,
+            label: 'B',
+            text: 'It makes weak passwords safe to reuse.',
+            isCorrect: false,
+            feedbackText: 'MFA helps, but passwords should still be strong and unique.',
+          },
+          1,
+        ),
+        buildAnswerOptionSeed(
+          {
+            id: DEMO_SEED_IDS.answerOptions.passwordMfaC,
+            label: 'C',
+            text: 'It lets you approve every prompt automatically.',
+            isCorrect: false,
+            feedbackText: 'Unexpected prompts should be denied and reported.',
+          },
+          2,
+        ),
+      ],
+    },
   ],
 } as const;
 
@@ -468,7 +512,7 @@ export const DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS = [
     description: 'Answer the password security basics quiz.',
     position: demoPosition(1),
     isRequired: true,
-    availabilityStatus: CampaignItemAvailabilityStatus.AVAILABLE,
+    availabilityStatus: CampaignItemAvailabilityStatus.LOCKED,
     quizId: DEMO_SEED_IDS.quizzes.passwordSecurity,
   },
 ] as const;
@@ -498,6 +542,7 @@ export const DEMO_SEED_TRAINING_DOCUMENTS = [
     difficultyLevel: DifficultyLevel.BEGINNER,
     status: TrainingDocumentStatus.AVAILABLE,
   },
+  DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT,
 ] as const;
 
 export const DEMO_SEED_QUIZZES = [
@@ -926,6 +971,7 @@ export const DEMO_SEED_QUIZZES = [
       },
     ],
   },
+  DEMO_SEED_PASSWORD_SECURITY_QUIZ,
 ] as const;
 
 export const DEMO_SEED_SIMULATION = {
@@ -1133,4 +1179,7 @@ export const DEMO_SEED_CAMPAIGN_ITEMS = [
     availabilityStatus: CampaignItemAvailabilityStatus.AVAILABLE,
     trainingDocumentId: DEMO_SEED_IDS.trainingDocuments.safeLinkHandling,
   },
+
+  // Password Security Campaign
+  ...DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS,
 ] as const;

--- a/apps/backend/prisma/seed-data/demoSeedCore.ts
+++ b/apps/backend/prisma/seed-data/demoSeedCore.ts
@@ -32,11 +32,14 @@ export type DemoSeedSummary = {
     readonly email: string;
     readonly role: string;
   }>;
-  readonly campaign: {
+  readonly assignedCampaigns: ReadonlyArray<{
+    readonly id: string;
     readonly name: string;
+    readonly assignmentId: string;
     readonly itemCount: number;
     readonly assignedTraineeEmail: string;
-  };
+    readonly lockedItemCount: number;
+  }>;
   readonly content: {
     readonly trainingDocumentCount: number;
     readonly quizCount: number;
@@ -100,13 +103,18 @@ export function buildDemoSeedSummary(): DemoSeedSummary {
         role: DEMO_SEED_USERS.admin.userType,
       },
     ],
-    campaign: {
-      name: DEMO_SEED_CAMPAIGN.name,
-      itemCount: DEMO_SEED_CAMPAIGN_ITEMS.filter(
-        (item) => item.campaignId === DEMO_SEED_IDS.campaign,
-      ).length,
-      assignedTraineeEmail: DEMO_SEED_CREDENTIALS.populatedTrainee.email,
-    },
+    assignedCampaigns: [
+      buildAssignedCampaignSummary({
+        campaign: DEMO_SEED_CAMPAIGN,
+        assignmentId: DEMO_SEED_CAMPAIGN_ASSIGNMENT.id,
+        assignedTraineeEmail: DEMO_SEED_CREDENTIALS.populatedTrainee.email,
+      }),
+      buildAssignedCampaignSummary({
+        campaign: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN,
+        assignmentId: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT.id,
+        assignedTraineeEmail: DEMO_SEED_CREDENTIALS.populatedTrainee.email,
+      }),
+    ],
     content: {
       trainingDocumentCount: DEMO_SEED_TRAINING_DOCUMENTS.length,
       quizCount: DEMO_SEED_QUIZZES.length,
@@ -129,6 +137,25 @@ export function buildDemoSeedSummary(): DemoSeedSummary {
         0,
       ),
     },
+  };
+}
+
+function buildAssignedCampaignSummary(input: {
+  campaign: typeof DEMO_SEED_CAMPAIGN | typeof DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN;
+  assignmentId: string;
+  assignedTraineeEmail: string;
+}): DemoSeedSummary['assignedCampaigns'][number] {
+  const campaignItems = DEMO_SEED_CAMPAIGN_ITEMS.filter(
+    (item) => item.campaignId === input.campaign.id,
+  );
+
+  return {
+    id: input.campaign.id,
+    name: input.campaign.name,
+    assignmentId: input.assignmentId,
+    itemCount: campaignItems.length,
+    assignedTraineeEmail: input.assignedTraineeEmail,
+    lockedItemCount: campaignItems.filter((item) => item.availabilityStatus === 'LOCKED').length,
   };
 }
 

--- a/apps/backend/prisma/seed-data/demoSeedCore.ts
+++ b/apps/backend/prisma/seed-data/demoSeedCore.ts
@@ -7,6 +7,8 @@ import {
   DEMO_SEED_CAMPAIGN_ITEMS,
   DEMO_SEED_CREDENTIALS,
   DEMO_SEED_IDS,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT,
   DEMO_SEED_QUIZZES,
   DEMO_SEED_SIMULATED_EMAILS,
   DEMO_SEED_SIMULATED_INBOX,
@@ -51,6 +53,12 @@ const DEMO_USER_EMAILS = Object.values(DEMO_SEED_CREDENTIALS).map(
 );
 const DEMO_TRAINEE_PROFILE_IDS = Object.values(DEMO_SEED_IDS.traineeProfiles);
 const DEMO_GENERAL_TRAINEE_PROFILE_IDS = Object.values(DEMO_SEED_IDS.generalTraineeProfiles);
+const DEMO_CAMPAIGN_IDS = [
+  DEMO_SEED_IDS.campaign,
+  DEMO_SEED_IDS.campaignB,
+  DEMO_SEED_IDS.passwordSecurityCampaign,
+];
+const DEMO_CAMPAIGN_ASSIGNMENT_IDS = Object.values(DEMO_SEED_IDS.campaignAssignments);
 const DEMO_CAMPAIGN_ITEM_IDS = Object.values(DEMO_SEED_IDS.campaignItems);
 const DEMO_TRAINING_DOCUMENT_IDS = Object.values(DEMO_SEED_IDS.trainingDocuments);
 const DEMO_QUIZ_IDS = Object.values(DEMO_SEED_IDS.quizzes);
@@ -127,33 +135,20 @@ export function buildDemoSeedSummary(): DemoSeedSummary {
 async function deleteDemoCore(tx: DemoSeedTransaction): Promise<void> {
   await tx.campaignAssignment.deleteMany({
     where: {
-      OR: [
-        { id: DEMO_SEED_IDS.campaignAssignments.populatedTrainee },
-        { campaignId: DEMO_SEED_IDS.campaign },
-        { campaignId: DEMO_SEED_IDS.campaignB },
-        {
-          traineeProfileId: {
-            in: DEMO_TRAINEE_PROFILE_IDS,
-          },
-        },
-      ],
+      OR: [{ id: { in: DEMO_CAMPAIGN_ASSIGNMENT_IDS } }, { campaignId: { in: DEMO_CAMPAIGN_IDS } }],
     },
   });
 
   await tx.campaignItem.deleteMany({
     where: {
-      OR: [
-        { id: { in: DEMO_CAMPAIGN_ITEM_IDS } },
-        { campaignId: DEMO_SEED_IDS.campaign },
-        { campaignId: DEMO_SEED_IDS.campaignB },
-      ],
+      OR: [{ id: { in: DEMO_CAMPAIGN_ITEM_IDS } }, { campaignId: { in: DEMO_CAMPAIGN_IDS } }],
     },
   });
 
   await tx.campaign.deleteMany({
     where: {
       id: {
-        in: [DEMO_SEED_IDS.campaign, DEMO_SEED_IDS.campaignB],
+        in: DEMO_CAMPAIGN_IDS,
       },
     },
   });
@@ -326,6 +321,9 @@ async function createDemoCampaign(tx: DemoSeedTransaction): Promise<void> {
   await tx.campaign.create({
     data: DEMO_SEED_CAMPAIGN_B,
   });
+  await tx.campaign.create({
+    data: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN,
+  });
 }
 
 async function createDemoContent(tx: DemoSeedTransaction): Promise<void> {
@@ -426,5 +424,8 @@ async function createDemoCampaignItems(tx: DemoSeedTransaction): Promise<void> {
 async function createDemoCampaignAssignment(tx: DemoSeedTransaction): Promise<void> {
   await tx.campaignAssignment.create({
     data: DEMO_SEED_CAMPAIGN_ASSIGNMENT,
+  });
+  await tx.campaignAssignment.create({
+    data: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT,
   });
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -17,9 +17,14 @@ function printDemoSeedSummary(summary: DemoSeedSummary): void {
 
   console.log(`Demo-only password source: ${getDemoSeedAuthEnvVarName()}`);
   console.log('No password hashes printed.');
-  console.log(
-    `Campaign: ${summary.campaign.name}, items: ${summary.campaign.itemCount}, assigned trainee: ${summary.campaign.assignedTraineeEmail}`,
-  );
+  console.log('Seeded assigned campaigns:');
+  for (const campaign of summary.assignedCampaigns) {
+    const lockedItemNote =
+      campaign.lockedItemCount > 0 ? `, locked items: ${campaign.lockedItemCount}` : '';
+    console.log(
+      `- ${campaign.name} (${campaign.id}), assignment: ${campaign.assignmentId}, items: ${campaign.itemCount}${lockedItemNote}, assigned trainee: ${campaign.assignedTraineeEmail}`,
+    );
+  }
   console.log(
     `Content: ${summary.content.trainingDocumentCount} training documents, ${summary.content.quizCount} quizzes, ${summary.content.quizQuestionCount} questions, ${summary.content.answerOptionCount} answer options, ${summary.content.simulatedEmailCount} simulated emails, ${summary.content.redFlagCount} red flags.`,
   );

--- a/apps/backend/tests/unit/seed.helpers.test.ts
+++ b/apps/backend/tests/unit/seed.helpers.test.ts
@@ -12,6 +12,7 @@ import {
   normaliseDemoEmail,
 } from '../../prisma/seed-data/demoSeedHelpers.js';
 import {
+  DEMO_SEED_CAMPAIGN_ASSIGNMENT,
   DEMO_SEED_CAMPAIGN_ITEMS,
   DEMO_SEED_IDS,
   DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN,
@@ -342,5 +343,42 @@ describe('demo seed helpers', () => {
       availabilityStatus: 'LOCKED',
       quizId: DEMO_SEED_IDS.quizzes.passwordSecurity,
     });
+  });
+
+  it('includes the password security content in the wired Demo 1 seed arrays', () => {
+    expect(DEMO_SEED_QUIZZES.map((quiz) => quiz.id)).toContain(
+      DEMO_SEED_IDS.quizzes.passwordSecurity,
+    );
+    expect(DEMO_SEED_CAMPAIGN_ITEMS.map((item) => item.id)).toEqual(
+      expect.arrayContaining([
+        DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+        DEMO_SEED_IDS.campaignItems.passwordSecurityQuiz,
+      ]),
+    );
+  });
+
+  it('assigns only the populated trainee to both Demo 1 seeded campaigns', () => {
+    const seededAssignments: ReadonlyArray<{ campaignId: string; traineeProfileId: string }> = [
+      DEMO_SEED_CAMPAIGN_ASSIGNMENT,
+      DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT,
+    ];
+
+    expect(seededAssignments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          campaignId: DEMO_SEED_IDS.campaign,
+          traineeProfileId: DEMO_SEED_IDS.traineeProfiles.populated,
+        }),
+        expect.objectContaining({
+          campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+          traineeProfileId: DEMO_SEED_IDS.traineeProfiles.populated,
+        }),
+      ]),
+    );
+    expect(
+      seededAssignments.some(
+        (assignment) => assignment.traineeProfileId === DEMO_SEED_IDS.traineeProfiles.emptyState,
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/backend/tests/unit/seed.helpers.test.ts
+++ b/apps/backend/tests/unit/seed.helpers.test.ts
@@ -254,6 +254,7 @@ describe('demo seed helpers', () => {
       uniquePasswordValueQuestion: DEMO_SEED_IDS.quizQuestions.uniquePasswordValue,
       passphraseStrengthQuestion: DEMO_SEED_IDS.quizQuestions.passphraseStrength,
       breachResponseQuestion: DEMO_SEED_IDS.quizQuestions.breachResponse,
+      passwordMfaQuestion: DEMO_SEED_IDS.quizQuestions.passwordMfa,
       passwordManagerPurposeA: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeA,
       passwordManagerPurposeB: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeB,
       passwordManagerPurposeC: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeC,
@@ -266,6 +267,9 @@ describe('demo seed helpers', () => {
       breachResponseA: DEMO_SEED_IDS.answerOptions.breachResponseA,
       breachResponseB: DEMO_SEED_IDS.answerOptions.breachResponseB,
       breachResponseC: DEMO_SEED_IDS.answerOptions.breachResponseC,
+      passwordMfaA: DEMO_SEED_IDS.answerOptions.passwordMfaA,
+      passwordMfaB: DEMO_SEED_IDS.answerOptions.passwordMfaB,
+      passwordMfaC: DEMO_SEED_IDS.answerOptions.passwordMfaC,
     });
   });
 
@@ -294,7 +298,7 @@ describe('demo seed helpers', () => {
       difficultyLevel: 'BEGINNER',
       status: 'PUBLISHED',
     });
-    expect(DEMO_SEED_PASSWORD_SECURITY_QUIZ.questions.length).toBeGreaterThanOrEqual(4);
+    expect(DEMO_SEED_PASSWORD_SECURITY_QUIZ.questions.length).toBeGreaterThanOrEqual(5);
 
     for (const question of DEMO_SEED_PASSWORD_SECURITY_QUIZ.questions) {
       expect(question.questionType).toBe('SINGLE_CHOICE');
@@ -318,12 +322,16 @@ describe('demo seed helpers', () => {
       traineeProfileId: DEMO_SEED_IDS.traineeProfiles.populated,
       currentCampaignItemId: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
     });
+    expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT.traineeProfileId).not.toBe(
+      DEMO_SEED_IDS.traineeProfiles.emptyState,
+    );
     expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS).toHaveLength(2);
     expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS[0]).toMatchObject({
       id: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
       campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
       componentType: 'TRAINING_DOCUMENT',
       position: 100,
+      availabilityStatus: 'AVAILABLE',
       trainingDocumentId: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
     });
     expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS[1]).toMatchObject({
@@ -331,6 +339,7 @@ describe('demo seed helpers', () => {
       campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
       componentType: 'QUIZ',
       position: 200,
+      availabilityStatus: 'LOCKED',
       quizId: DEMO_SEED_IDS.quizzes.passwordSecurity,
     });
   });

--- a/apps/backend/tests/unit/seed.helpers.test.ts
+++ b/apps/backend/tests/unit/seed.helpers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { buildDemoSeedSummary } from '../../prisma/seed-data/demoSeedCore.js';
 import {
   assertDemoSeedRuntimeIsSafe,
   assertDemoSeedIdsAreUuids,
@@ -380,5 +381,39 @@ describe('demo seed helpers', () => {
         (assignment) => assignment.traineeProfileId === DEMO_SEED_IDS.traineeProfiles.emptyState,
       ),
     ).toBe(false);
+  });
+
+  it('builds a plural seed summary for both assigned Demo 1 campaigns', () => {
+    const summary = buildDemoSeedSummary();
+
+    expect(summary).not.toHaveProperty('campaign');
+    expect(summary.assignedCampaigns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: DEMO_SEED_IDS.campaign,
+          name: 'Demo 1 Phishing Awareness',
+          assignmentId: DEMO_SEED_IDS.campaignAssignments.populatedTrainee,
+          assignedTraineeEmail: 'demo.populated.trainee@example.com',
+        }),
+        expect.objectContaining({
+          id: DEMO_SEED_IDS.passwordSecurityCampaign,
+          name: 'Demo 1 Password Security',
+          assignmentId: DEMO_SEED_IDS.campaignAssignments.passwordSecurity,
+          assignedTraineeEmail: 'demo.populated.trainee@example.com',
+          itemCount: 2,
+          lockedItemCount: 1,
+        }),
+      ]),
+    );
+    expect(summary.assignedCampaigns).toHaveLength(2);
+  });
+
+  it('keeps password values and hashes out of the seed summary', () => {
+    const serializedSummary = JSON.stringify(buildDemoSeedSummary());
+
+    expect(serializedSummary).not.toContain(getDemoSeedAuthEnvVarName());
+    expect(serializedSummary).not.toContain('DEMO_SEED_PASSWORD');
+    expect(serializedSummary).not.toContain('scrypt$');
+    expect(serializedSummary).not.toContain('passwordHash');
   });
 });

--- a/apps/backend/tests/unit/seed.helpers.test.ts
+++ b/apps/backend/tests/unit/seed.helpers.test.ts
@@ -13,6 +13,12 @@ import {
 } from '../../prisma/seed-data/demoSeedHelpers.js';
 import {
   DEMO_SEED_CAMPAIGN_ITEMS,
+  DEMO_SEED_IDS,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS,
+  DEMO_SEED_PASSWORD_SECURITY_QUIZ,
+  DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT,
   DEMO_SEED_QUIZZES,
   DEMO_SEED_SIMULATED_EMAILS,
 } from '../../prisma/seed-data/demoSeedConfig.js';
@@ -234,5 +240,98 @@ describe('demo seed helpers', () => {
     expect(hasTrainingLink).toBe(true);
     expect(hasQuizLink).toBe(true);
     expect(hasSimulationLink).toBe(true);
+  });
+
+  it('defines stable UUID-like IDs for the password security campaign content', () => {
+    assertDemoSeedIdsAreUuids({
+      passwordSecurityCampaign: DEMO_SEED_IDS.passwordSecurityCampaign,
+      passwordSecurityCampaignAssignment: DEMO_SEED_IDS.campaignAssignments.passwordSecurity,
+      passwordSecurityTrainingDocument: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
+      passwordSecurityQuiz: DEMO_SEED_IDS.quizzes.passwordSecurity,
+      passwordSecurityTrainingItem: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+      passwordSecurityQuizItem: DEMO_SEED_IDS.campaignItems.passwordSecurityQuiz,
+      passwordManagerPurposeQuestion: DEMO_SEED_IDS.quizQuestions.passwordManagerPurpose,
+      uniquePasswordValueQuestion: DEMO_SEED_IDS.quizQuestions.uniquePasswordValue,
+      passphraseStrengthQuestion: DEMO_SEED_IDS.quizQuestions.passphraseStrength,
+      breachResponseQuestion: DEMO_SEED_IDS.quizQuestions.breachResponse,
+      passwordManagerPurposeA: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeA,
+      passwordManagerPurposeB: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeB,
+      passwordManagerPurposeC: DEMO_SEED_IDS.answerOptions.passwordManagerPurposeC,
+      uniquePasswordValueA: DEMO_SEED_IDS.answerOptions.uniquePasswordValueA,
+      uniquePasswordValueB: DEMO_SEED_IDS.answerOptions.uniquePasswordValueB,
+      uniquePasswordValueC: DEMO_SEED_IDS.answerOptions.uniquePasswordValueC,
+      passphraseStrengthA: DEMO_SEED_IDS.answerOptions.passphraseStrengthA,
+      passphraseStrengthB: DEMO_SEED_IDS.answerOptions.passphraseStrengthB,
+      passphraseStrengthC: DEMO_SEED_IDS.answerOptions.passphraseStrengthC,
+      breachResponseA: DEMO_SEED_IDS.answerOptions.breachResponseA,
+      breachResponseB: DEMO_SEED_IDS.answerOptions.breachResponseB,
+      breachResponseC: DEMO_SEED_IDS.answerOptions.breachResponseC,
+    });
+  });
+
+  it('defines valid password security training metadata without inline body content', () => {
+    expect(DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT).toMatchObject({
+      id: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
+      createdByUserId: DEMO_SEED_IDS.users.admin,
+      title: 'Password Security Basics',
+      contentType: 'HTML',
+      contentRef: 'demo://training/password-security-basics',
+      difficultyLevel: 'BEGINNER',
+      status: 'AVAILABLE',
+    });
+    expect(DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.contentSummary).toContain('password');
+    expect(DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.estimatedReadTimeMinutes).toBeGreaterThan(
+      0,
+    );
+    expect(DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT).not.toHaveProperty('contentMarkdown');
+  });
+
+  it('defines a published password security quiz with feedback and one correct answer per question', () => {
+    expect(DEMO_SEED_PASSWORD_SECURITY_QUIZ).toMatchObject({
+      id: DEMO_SEED_IDS.quizzes.passwordSecurity,
+      createdByUserId: DEMO_SEED_IDS.users.admin,
+      title: 'Password Security Basics Check',
+      difficultyLevel: 'BEGINNER',
+      status: 'PUBLISHED',
+    });
+    expect(DEMO_SEED_PASSWORD_SECURITY_QUIZ.questions.length).toBeGreaterThanOrEqual(4);
+
+    for (const question of DEMO_SEED_PASSWORD_SECURITY_QUIZ.questions) {
+      expect(question.questionType).toBe('SINGLE_CHOICE');
+      expect(question.answerOptions.length).toBeGreaterThanOrEqual(3);
+      expect(question.answerOptions.filter((option) => option.isCorrect)).toHaveLength(1);
+      expect(question.answerOptions.every((option) => option.feedbackText)).toBe(true);
+    }
+  });
+
+  it('defines password security campaign constants as a simple training then quiz path', () => {
+    expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN).toMatchObject({
+      id: DEMO_SEED_IDS.passwordSecurityCampaign,
+      createdByUserId: DEMO_SEED_IDS.users.admin,
+      name: 'Demo 1 Password Security',
+      campaignType: 'PREMADE_GENERAL',
+      status: 'ACTIVE',
+    });
+    expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT).toMatchObject({
+      id: DEMO_SEED_IDS.campaignAssignments.passwordSecurity,
+      campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+      traineeProfileId: DEMO_SEED_IDS.traineeProfiles.populated,
+      currentCampaignItemId: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+    });
+    expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS).toHaveLength(2);
+    expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS[0]).toMatchObject({
+      id: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+      campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+      componentType: 'TRAINING_DOCUMENT',
+      position: 100,
+      trainingDocumentId: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
+    });
+    expect(DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS[1]).toMatchObject({
+      id: DEMO_SEED_IDS.campaignItems.passwordSecurityQuiz,
+      campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+      componentType: 'QUIZ',
+      position: 200,
+      quizId: DEMO_SEED_IDS.quizzes.passwordSecurity,
+    });
   });
 });

--- a/apps/backend/tests/unit/trainee-campaign.routes.test.ts
+++ b/apps/backend/tests/unit/trainee-campaign.routes.test.ts
@@ -1,5 +1,13 @@
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEMO_SEED_IDS,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT,
+  DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS,
+  DEMO_SEED_PASSWORD_SECURITY_QUIZ,
+  DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT,
+} from '../../prisma/seed-data/demoSeedConfig.js';
 import { createApp } from '../../src/app.js';
 import { generateAuthToken } from '../../src/services/auth-token.service.js';
 
@@ -85,6 +93,33 @@ function baseAssignment() {
       startDate: new Date('2026-05-16T08:00:00.000Z'),
       endDate: null,
       items: campaignSummaryItems(),
+    },
+  };
+}
+
+function passwordSecuritySummaryAssignment() {
+  return {
+    id: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT.id,
+    currentCampaignItemId: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT.currentCampaignItemId,
+    assignedAt: new Date('2026-05-17T08:00:00.000Z'),
+    dueDate: null,
+    startedAt: null,
+    completedAt: null,
+    assignmentStatus: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT.assignmentStatus,
+    accessType: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ASSIGNMENT.accessType,
+    campaign: {
+      id: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.id,
+      name: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.name,
+      description: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.description,
+      campaignType: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.campaignType,
+      difficultyLevel: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.difficultyLevel,
+      status: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.status,
+      startDate: null,
+      endDate: null,
+      items: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS.map((item) => ({
+        id: item.id,
+        availabilityStatus: item.availabilityStatus,
+      })),
     },
   };
 }
@@ -184,12 +219,79 @@ function campaignItems() {
   ];
 }
 
+function passwordSecurityCampaignItems() {
+  const [trainingItem, quizItem] = DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN_ITEMS;
+
+  return [
+    {
+      id: quizItem.id,
+      campaignId: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.id,
+      parentGroupId: null,
+      itemType: quizItem.itemType,
+      componentType: quizItem.componentType,
+      groupType: null,
+      completionRule: null,
+      title: quizItem.title,
+      description: quizItem.description,
+      position: quizItem.position,
+      isRequired: quizItem.isRequired,
+      availabilityStatus: quizItem.availabilityStatus,
+      trainingDocument: null,
+      quiz: {
+        id: DEMO_SEED_PASSWORD_SECURITY_QUIZ.id,
+        title: DEMO_SEED_PASSWORD_SECURITY_QUIZ.title,
+        description: DEMO_SEED_PASSWORD_SECURITY_QUIZ.description,
+        passThresholdPercentage: DEMO_SEED_PASSWORD_SECURITY_QUIZ.passThresholdPercentage,
+        difficultyLevel: DEMO_SEED_PASSWORD_SECURITY_QUIZ.difficultyLevel,
+        status: DEMO_SEED_PASSWORD_SECURITY_QUIZ.status,
+        _count: { questions: DEMO_SEED_PASSWORD_SECURITY_QUIZ.questions.length },
+      },
+      simulation: null,
+    },
+    {
+      id: trainingItem.id,
+      campaignId: DEMO_SEED_PASSWORD_SECURITY_CAMPAIGN.id,
+      parentGroupId: null,
+      itemType: trainingItem.itemType,
+      componentType: trainingItem.componentType,
+      groupType: null,
+      completionRule: null,
+      title: trainingItem.title,
+      description: trainingItem.description,
+      position: trainingItem.position,
+      isRequired: trainingItem.isRequired,
+      availabilityStatus: trainingItem.availabilityStatus,
+      trainingDocument: {
+        id: DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.id,
+        title: DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.title,
+        contentSummary: DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.contentSummary,
+        estimatedReadTimeMinutes:
+          DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.estimatedReadTimeMinutes,
+        difficultyLevel: DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.difficultyLevel,
+        status: DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT.status,
+      },
+      quiz: null,
+      simulation: null,
+    },
+  ];
+}
+
 function detailedAssignment() {
   return {
     ...baseAssignment(),
     campaign: {
       ...baseAssignment().campaign,
       items: campaignItems(),
+    },
+  };
+}
+
+function passwordSecurityDetailedAssignment() {
+  return {
+    ...passwordSecuritySummaryAssignment(),
+    campaign: {
+      ...passwordSecuritySummaryAssignment().campaign,
+      items: passwordSecurityCampaignItems(),
     },
   };
 }
@@ -242,6 +344,41 @@ describe('Trainee campaign discovery routes', () => {
     });
   });
 
+  it('returns multiple assigned campaigns for the populated Demo 1 trainee', async () => {
+    prismaMock.campaignAssignment.findMany.mockResolvedValue([
+      baseAssignment(),
+      passwordSecuritySummaryAssignment(),
+    ]);
+
+    const response = await request(createApp())
+      .get('/trainee/campaigns')
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(200);
+    expect(response.body.campaigns).toHaveLength(2);
+    expect(response.body.campaigns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          campaignId,
+          name: 'Phishing Fundamentals',
+          assignment: expect.objectContaining({
+            assignmentId,
+          }),
+        }),
+        expect.objectContaining({
+          campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+          name: 'Demo 1 Password Security',
+          itemCount: 2,
+          availableItemCount: 1,
+          assignment: expect.objectContaining({
+            assignmentId: DEMO_SEED_IDS.campaignAssignments.passwordSecurity,
+            currentCampaignItemId: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+          }),
+        }),
+      ]),
+    );
+  });
+
   it('returns an empty campaign list for an active trainee with no accessible campaigns', async () => {
     prismaMock.campaignAssignment.findMany.mockResolvedValue([]);
 
@@ -274,6 +411,62 @@ describe('Trainee campaign discovery routes', () => {
       name: 'Phishing Fundamentals',
       assignment: {
         assignmentId,
+      },
+    });
+  });
+
+  it('returns password security campaign detail with ordered static availability and openability', async () => {
+    prismaMock.campaignAssignment.findFirst.mockResolvedValue(passwordSecurityDetailedAssignment());
+
+    const response = await request(createApp())
+      .get(`/trainee/campaigns/${DEMO_SEED_IDS.passwordSecurityCampaign}`)
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.campaignAssignment.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+          traineeProfileId,
+        }),
+      }),
+    );
+    expect(response.body).toMatchObject({
+      campaignId: DEMO_SEED_IDS.passwordSecurityCampaign,
+      name: 'Demo 1 Password Security',
+      assignment: {
+        assignmentId: DEMO_SEED_IDS.campaignAssignments.passwordSecurity,
+        currentCampaignItemId: DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+      },
+    });
+    expect(response.body.items.map((item: any) => item.campaignItemId)).toEqual([
+      DEMO_SEED_IDS.campaignItems.passwordSecurityTrainingDocument,
+      DEMO_SEED_IDS.campaignItems.passwordSecurityQuiz,
+    ]);
+    expect(response.body.items[0]).toMatchObject({
+      componentType: 'TRAINING_DOCUMENT',
+      position: 100,
+      availabilityStatus: 'AVAILABLE',
+      isOpenable: true,
+      trainingDocument: {
+        id: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
+        title: 'Password Security Basics',
+        contentSummary: expect.any(String),
+        estimatedReadTimeMinutes: expect.any(Number),
+        difficultyLevel: 'BEGINNER',
+        status: 'AVAILABLE',
+      },
+    });
+    expect(response.body.items[1]).toMatchObject({
+      componentType: 'QUIZ',
+      position: 200,
+      availabilityStatus: 'LOCKED',
+      isOpenable: false,
+      quiz: {
+        id: DEMO_SEED_IDS.quizzes.passwordSecurity,
+        title: 'Password Security Basics Check',
+        status: 'PUBLISHED',
+        questionCount: DEMO_SEED_PASSWORD_SECURITY_QUIZ.questions.length,
       },
     });
   });

--- a/docs/demo1/API.md
+++ b/docs/demo1/API.md
@@ -95,6 +95,24 @@ These endpoints are **discovery endpoints**. Their primary purpose is to allow t
 
 All trainee campaign endpoints require authentication.
 
+### Demo 1 Seeded Campaign Notes
+
+After running the Demo 1 seed, the populated trainee has two active assigned campaigns:
+
+- phishing awareness campaign
+- password security campaign
+
+The empty-state trainee still has no campaign assignments.
+
+The password security campaign is intentionally simple:
+
+1. password-security training document
+2. password-security quiz
+
+The training item is seeded as `AVAILABLE` and should be openable through campaign detail when the backing training document is available. The quiz item is seeded as `LOCKED`, so it should not be openable unless a future dynamic unlock engine is implemented.
+
+Training completion records interaction data, but this issue does not add sequential unlock behavior. The campaign discovery endpoint should show both assigned campaigns for the populated trainee after reseeding, and the campaign detail endpoint should show the password campaign items in training-to-quiz order with their seeded availability and openability.
+
 ### `GET /trainee/campaigns`
 
 - **Purpose**: Allows the frontend dashboard to discover active campaigns assigned or available to the authenticated active trainee.


### PR DESCRIPTION
## Summary

Closes #138

Adds a second Demo 1 seeded campaign for password security.

The existing populated trainee seed data already demonstrates the phishing-awareness campaign, but that campaign uses a more modular/hierarchical structure with grouped and ungrouped items. This PR adds a clearer sequential Demo 1 example by seeding a separate password-security campaign with a simple training-to-quiz path.

The new campaign is assigned to the populated trainee and is intended to help demo and test multiple assigned campaigns, campaign discovery, and basic sequential-looking activity structure without introducing a full prerequisite or unlock engine.

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Documentation
- [x] Chore / maintenance

## What Changed

### Added a new Demo 1 password-security campaign

Added a second active Demo 1 seeded campaign, for example:

- `Demo 1 Password Security`

This campaign demonstrates a simple two-step flow:

1. Password-security training document
2. Password-security quiz

The populated trainee now has access to both:

- the existing phishing-awareness campaign
- the new password-security campaign

The empty-state trainee remains unassigned so empty-state frontend flows can still be tested.

### Added password-security training content

Added a password-security training document using the current backend training document metadata model.

The training document includes backend-supported metadata such as:

- `contentType`
- `contentRef`
- `contentSummary`
- `estimatedReadTimeMinutes`
- `difficultyLevel`
- `status`

The training document uses a repo-consistent demo content reference such as a `demo://training/...` style reference.

This PR does **not** add runtime markdown body loading and does **not** add `contentMarkdown` to the backend DTO.

### Added password-security quiz content

Added a password-security quiz with:

- published quiz status
- meaningful password-security questions
- answer options
- correct answers
- answer-level feedback

This gives the new campaign enough quiz data to support a basic training-to-quiz demo path.

### Added ordered campaign items

The new password-security campaign has top-level campaign items in a clear order:

- position `100`: password-security training document
- position `200`: password-security quiz

The training document item is seeded as `AVAILABLE`, so it is openable under the current backend rules.

The quiz item is seeded as `LOCKED` initially. This is intentional because the backend currently records training completion events but does not implement dynamic unlock/prerequisite logic.

### Preserved current Demo 1 behavior

This PR does not rework the existing phishing-awareness campaign structure.

The existing phishing campaign remains assigned to the populated trainee and continues to demonstrate the modular campaign-item model with grouped and ungrouped items.

The new password-security campaign provides a simpler sequential example alongside it.

### Seed repeatability

The new seed records use stable deterministic demo IDs and are integrated into the existing repeatable seed flow.

The seed remains designed to be rerunnable without duplicating Demo 1 records.

### Documentation updates

Updated seed documentation to explain:

- the new password-security campaign
- the simple training-to-quiz campaign structure
- the `AVAILABLE` training item
- the initially `LOCKED` quiz item
- the fact that dynamic unlock behavior is not implemented in this issue
- the empty-state trainee remains unassigned

## What Was Not Changed

This PR does **not** add:

- a prerequisite engine
- dynamic campaign item unlock logic
- a campaign progress model/table
- frontend changes
- campaign authoring/admin UI
- runtime markdown file loading
- markdown body content in backend training responses
- production content management

This PR does **not** change the existing activity endpoints or the existing phishing-awareness campaign behavior.

## Files Changed

### Seed data

- `apps/backend/prisma/seed-data/demoSeedConfig.ts`
- `apps/backend/prisma/seed-data/demoSeedCore.ts`

### Seed tests

- `apps/backend/tests/unit/seed.helpers.test.ts`
- campaign discovery tests if applicable

### Documentation

- `apps/backend/SEEDING.md`
- `SETUP.md` if updated
- `docs/demo1/API.md` if updated

## Testing

Ran locally:

```bash
pnpm --filter @insightful-phish/backend typecheck
pnpm --filter @insightful-phish/backend test:unit
pnpm --filter @insightful-phish/backend test