### PR TITLE
Chore/uc02 training content resolver/rudolph

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsc",
+    "build": "tsc && node ./scripts/copy-training-content.mjs",
     "start": "node dist/src/server.js",
     "lint": "echo \"No lint configured for backend yet\"",
     "typecheck": "tsc --noEmit",

--- a/apps/backend/prisma/seed-data/demoSeedConfig.ts
+++ b/apps/backend/prisma/seed-data/demoSeedConfig.ts
@@ -268,7 +268,7 @@ export const DEMO_SEED_PASSWORD_SECURITY_TRAINING_DOCUMENT = {
   id: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
   createdByUserId: DEMO_SEED_IDS.users.admin,
   title: 'Password Security Basics',
-  contentType: TrainingContentType.HTML,
+  contentType: TrainingContentType.MARKDOWN,
   contentRef: 'demo://training/password-security-basics',
   contentSummary:
     'How to use unique passwords, passphrases, password managers, MFA, and breach response habits.',
@@ -522,7 +522,7 @@ export const DEMO_SEED_TRAINING_DOCUMENTS = [
     id: DEMO_SEED_IDS.trainingDocuments.warningSigns,
     createdByUserId: DEMO_SEED_IDS.users.admin,
     title: 'Phishing Email Warning Signs',
-    contentType: TrainingContentType.HTML,
+    contentType: TrainingContentType.MARKDOWN,
     contentRef: 'demo://training/phishing-warning-signs',
     contentSummary:
       'How to spot spoofed senders, urgent language, suspicious links, and risky attachments.',
@@ -534,7 +534,7 @@ export const DEMO_SEED_TRAINING_DOCUMENTS = [
     id: DEMO_SEED_IDS.trainingDocuments.safeLinkHandling,
     createdByUserId: DEMO_SEED_IDS.users.admin,
     title: 'Safe Credential and Link Handling',
-    contentType: TrainingContentType.HTML,
+    contentType: TrainingContentType.MARKDOWN,
     contentRef: 'demo://training/safe-link-handling',
     contentSummary:
       'Practical steps for checking links, protecting credentials, and verifying sign-in prompts.',

--- a/apps/backend/scripts/copy-training-content.mjs
+++ b/apps/backend/scripts/copy-training-content.mjs
@@ -1,0 +1,22 @@
+import { mkdir, cp, access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+
+const sourceDir = path.resolve('src/content/training');
+const targetDir = path.resolve('dist/src/content/training');
+
+async function ensureSourceExists() {
+  try {
+    await access(sourceDir, constants.R_OK);
+  } catch (error) {
+    throw new Error(`Training content source directory not found: ${sourceDir}`);
+  }
+}
+
+async function copyTrainingContent() {
+  await ensureSourceExists();
+  await mkdir(targetDir, { recursive: true });
+  await cp(sourceDir, targetDir, { recursive: true });
+}
+
+await copyTrainingContent();

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -272,6 +272,11 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
           'TRAINING_DOCUMENT_NOT_FOUND',
           'Training document was not found',
         ),
+        TrainingContentUnavailableErrorResponse: errorResponseSchema(
+          'ApiErrorResponse',
+          'TRAINING_CONTENT_UNAVAILABLE',
+          'Training content could not be loaded',
+        ),
         TrainingRateLimitErrorResponse: errorResponseSchema(
           'RateLimitErrorResponse',
           'TRAINING_RATE_LIMITED',
@@ -928,7 +933,15 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         },
         TrainingDocument: {
           type: 'object',
-          required: ['id', 'title', 'contentType', 'contentRef', 'difficultyLevel', 'status'],
+          required: [
+            'id',
+            'title',
+            'contentType',
+            'contentRef',
+            'content',
+            'difficultyLevel',
+            'status',
+          ],
           properties: {
             id: {
               ...uuidString('33333333-3333-4333-8333-333333333333'),
@@ -943,6 +956,11 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             contentRef: {
               type: 'string',
               example: 'training/training-doc-1',
+            },
+            content: {
+              type: 'string',
+              nullable: true,
+              example: '## Phishing warning signs\n- Verify sender domains\n- Avoid urgent threats',
             },
             contentSummary: {
               ...nullableString('Common phishing indicators and safe response steps.'),
@@ -1714,6 +1732,10 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         TrainingDocumentNotFound: responseComponent(
           'Training document is missing, unavailable, or not accessible to the trainee.',
           'TrainingDocumentNotFoundErrorResponse',
+        ),
+        TrainingContentUnavailable: responseComponent(
+          'Training document content could not be loaded.',
+          'TrainingContentUnavailableErrorResponse',
         ),
         TrainingRateLimited: responseComponent(
           'Too many trainee training requests.',

--- a/apps/backend/src/content/training/password-security-basics.md
+++ b/apps/backend/src/content/training/password-security-basics.md
@@ -1,0 +1,29 @@
+# Password Security Basics
+
+Strong password habits protect your accounts, even when attackers have partial information.
+
+## Build Strong Passwords
+
+- Use long passphrases with 14+ characters.
+- Combine unrelated words with numbers or symbols.
+- Avoid personal details like names, birthdays, or pet names.
+- Never reuse the same password across systems.
+
+## Use a Password Manager
+
+- Store unique passwords safely and generate strong ones.
+- Protect the manager with a long, unique master password.
+- Enable MFA on the password manager account.
+
+## MFA Adds a Second Layer
+
+- Use authenticator apps or hardware keys when possible.
+- Treat MFA codes like passwords: never share them.
+
+## If You Suspect Compromise
+
+- Change the password right away.
+- Update other accounts that reused the same password.
+- Review account activity and report it.
+
+Password security is not about memorizing complex strings. It is about using unique, long credentials and good tools.

--- a/apps/backend/src/content/training/phishing-warning-signs.md
+++ b/apps/backend/src/content/training/phishing-warning-signs.md
@@ -1,0 +1,30 @@
+# Phishing Warning Signs
+
+Phishing emails try to trick you into clicking a link, opening a file, or sharing sensitive data. Use these warning signs to slow down and verify before you act.
+
+## Common Red Flags
+
+- Unexpected urgency or threats ("act now" or "account will be closed").
+- Requests for passwords, MFA codes, or personal details.
+- Sender address does not match the company or looks misspelled.
+- Links that do not match the displayed text when you hover.
+- Attachments you were not expecting, especially ZIP or macro files.
+- Generic greetings like "Dear user" instead of your name.
+- Unusual payment requests, gift cards, or wire transfers.
+
+## Quick Verification Steps
+
+1. Pause and read the message carefully.
+2. Check the sender domain letter by letter.
+3. Hover over links to see the real destination.
+4. Use a trusted channel to verify (call, chat, or known portal).
+5. Report the message using your company process.
+
+## Safe Response Checklist
+
+- Do not reply directly to the email.
+- Do not open suspicious attachments.
+- Do not share MFA codes or passwords.
+- When in doubt, ask for a second opinion.
+
+Remember: attackers rely on speed and confusion. A short pause can prevent a serious incident.

--- a/apps/backend/src/content/training/safe-link-handling.md
+++ b/apps/backend/src/content/training/safe-link-handling.md
@@ -1,0 +1,26 @@
+# Safe Link Handling
+
+Links are a common way attackers deliver malware or steal credentials. Use the habits below to reduce risk.
+
+## Before You Click
+
+- Hover over the link to view the full URL.
+- Check for lookalike domains (for example, "paypaI.com" with a capital I).
+- Watch for extra words or subdomains ("secure.login.example.com.attacker.com").
+- Be cautious with URL shorteners unless you trust the sender.
+
+## Preferred Safe Actions
+
+- Type known URLs directly in the browser.
+- Use bookmarks for frequently used sites.
+- If a link came in an unexpected message, verify it first.
+- Open links in a protected environment if your company provides one.
+
+## When You Already Clicked
+
+- Do not enter credentials if anything looks off.
+- Close the tab and report the message.
+- If you entered credentials, change your password immediately.
+- Notify your security or IT team so they can help.
+
+Good link habits are simple and fast. The goal is to verify, not to distrust everything.

--- a/apps/backend/src/controllers/trainee-training.controller.ts
+++ b/apps/backend/src/controllers/trainee-training.controller.ts
@@ -4,6 +4,7 @@ import {
   recordTrainingInteraction,
   TrainingDocumentAccessNotFoundError,
 } from '../services/trainee-training.service.js';
+import { TrainingContentResolveError } from '../services/content-resolver.service.js';
 
 function requireAuthenticatedUserId(req: Request, res: Response) {
   if (!req.auth) {
@@ -22,6 +23,13 @@ function handleTrainingError(error: unknown, res: Response) {
     return res.status(404).json({
       error: 'TRAINING_DOCUMENT_NOT_FOUND',
       message: 'Training document was not found',
+    });
+  }
+
+  if (error instanceof TrainingContentResolveError) {
+    return res.status(500).json({
+      error: 'TRAINING_CONTENT_UNAVAILABLE',
+      message: 'Training content could not be loaded',
     });
   }
 

--- a/apps/backend/src/services/content-resolver.service.ts
+++ b/apps/backend/src/services/content-resolver.service.ts
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+
+export class TrainingContentResolveError extends Error {
+  constructor(message = 'Training content could not be loaded') {
+    super(message);
+    this.name = 'TrainingContentResolveError';
+  }
+}
+
+const demoContentMap: Record<string, URL> = {
+  'demo://training/phishing-warning-signs': new URL(
+    '../content/training/phishing-warning-signs.md',
+    import.meta.url,
+  ),
+  'demo://training/safe-link-handling': new URL(
+    '../content/training/safe-link-handling.md',
+    import.meta.url,
+  ),
+  'demo://training/password-security-basics': new URL(
+    '../content/training/password-security-basics.md',
+    import.meta.url,
+  ),
+};
+
+export async function resolveContent(contentRef: string): Promise<string | null> {
+  const contentUrl = demoContentMap[contentRef];
+
+  if (!contentUrl) {
+    return null;
+  }
+
+  try {
+    return await readFile(contentUrl, 'utf8');
+  } catch (error) {
+    throw new TrainingContentResolveError();
+  }
+}

--- a/apps/backend/src/services/content-resolver.service.ts
+++ b/apps/backend/src/services/content-resolver.service.ts
@@ -22,7 +22,16 @@ const demoContentMap: Record<string, URL> = {
   ),
 };
 
-export async function resolveContent(contentRef: string): Promise<string | null> {
+const MARKDOWN_CONTENT_TYPE = 'MARKDOWN';
+
+export async function resolveContent(
+  contentType: string,
+  contentRef: string,
+): Promise<string | null> {
+  if (contentType !== MARKDOWN_CONTENT_TYPE) {
+    return null;
+  }
+
   const contentUrl = demoContentMap[contentRef];
 
   if (!contentUrl) {

--- a/apps/backend/src/services/trainee-training.service.ts
+++ b/apps/backend/src/services/trainee-training.service.ts
@@ -4,6 +4,7 @@ import type {
   TrainingInteractionEventTypeDto,
 } from '@insightful-phish/shared';
 import * as TraineeTrainingRepository from '../repositories/trainee-training.repository.js';
+import { resolveContent } from './content-resolver.service.js';
 
 type TrainingCampaignItem = NonNullable<
   Awaited<ReturnType<typeof TraineeTrainingRepository.findTrainingCampaignItemById>>
@@ -70,8 +71,9 @@ function toTrainingDocumentResponse(input: {
     trainingDocument: NonNullable<TrainingCampaignItem['trainingDocument']>;
   };
   campaignAssignment: CampaignAssignment;
+  content: string | null;
 }): GetTrainingDocumentResponseDto {
-  const { campaignItem, campaignAssignment } = input;
+  const { campaignItem, campaignAssignment, content } = input;
   const { trainingDocument } = campaignItem;
 
   return {
@@ -82,6 +84,7 @@ function toTrainingDocumentResponse(input: {
       title: trainingDocument.title,
       contentType: trainingDocument.contentType,
       contentRef: trainingDocument.contentRef,
+      content,
       contentSummary: trainingDocument.contentSummary,
       estimatedReadTimeMinutes: trainingDocument.estimatedReadTimeMinutes,
       difficultyLevel: trainingDocument.difficultyLevel,
@@ -102,10 +105,12 @@ export async function getTrainingDocumentForCampaignItem(
   campaignItemId: string,
 ): Promise<GetTrainingDocumentResponseDto> {
   const access = await resolveTrainingDocumentAccess(userId, campaignItemId);
+  const content = await resolveContent(access.trainingDocument.contentRef);
 
   return toTrainingDocumentResponse({
     campaignItem: access.campaignItem,
     campaignAssignment: access.campaignAssignment,
+    content,
   });
 }
 

--- a/apps/backend/src/services/trainee-training.service.ts
+++ b/apps/backend/src/services/trainee-training.service.ts
@@ -105,7 +105,10 @@ export async function getTrainingDocumentForCampaignItem(
   campaignItemId: string,
 ): Promise<GetTrainingDocumentResponseDto> {
   const access = await resolveTrainingDocumentAccess(userId, campaignItemId);
-  const content = await resolveContent(access.trainingDocument.contentRef);
+  const content = await resolveContent(
+    access.trainingDocument.contentType,
+    access.trainingDocument.contentRef,
+  );
 
   return toTrainingDocumentResponse({
     campaignItem: access.campaignItem,

--- a/apps/backend/tests/integration/uc02-training.integration.test.ts
+++ b/apps/backend/tests/integration/uc02-training.integration.test.ts
@@ -1,6 +1,5 @@
 import request from 'supertest';
-import { readFile, rename } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createApp } from '../../src/app.js';
 import { prisma } from '../../src/lib/prisma.js';
@@ -188,25 +187,25 @@ describe('UC-02 Training Document Integration Tests', () => {
     expect(response.body.trainingDocument.content).toBeNull();
   });
 
-  it('returns a controlled error when content files are missing', async () => {
-    const originalPath = fileURLToPath(phishingContentUrl);
-    const tempPath = `${originalPath}.bak`;
+  it('returns null content when contentType is not MARKDOWN', async () => {
+    const htmlDoc = await createTrainingDocument({
+      status: TrainingDocumentStatus.AVAILABLE,
+      contentType: TrainingContentType.HTML,
+      contentRef: 'demo://training/phishing-warning-signs',
+    });
 
-    await rename(originalPath, tempPath);
+    const htmlItem = await createCampaignItem({
+      campaignId,
+      componentType: CampaignComponentType.TRAINING_DOCUMENT,
+      trainingDocumentId: htmlDoc.id,
+    });
 
-    try {
-      const response = await request(createApp())
-        .get(`/trainee/campaign-items/${campaignItemId}/training-document`)
-        .set('Authorization', `Bearer ${token}`);
+    const response = await request(createApp())
+      .get(`/trainee/campaign-items/${htmlItem.id}/training-document`)
+      .set('Authorization', `Bearer ${token}`);
 
-      expect(response.status).toBe(500);
-      expect(response.body).toEqual({
-        error: 'TRAINING_CONTENT_UNAVAILABLE',
-        message: 'Training content could not be loaded',
-      });
-    } finally {
-      await rename(tempPath, originalPath);
-    }
+    expect(response.status).toBe(200);
+    expect(response.body.trainingDocument.content).toBeNull();
   });
 
   it('marks a training document as viewed and asserts persisted interaction in database', async () => {

--- a/apps/backend/tests/integration/uc02-training.integration.test.ts
+++ b/apps/backend/tests/integration/uc02-training.integration.test.ts
@@ -1,4 +1,6 @@
 import request from 'supertest';
+import { readFile, rename } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createApp } from '../../src/app.js';
 import { prisma } from '../../src/lib/prisma.js';
@@ -13,10 +15,12 @@ import {
   CampaignStatus,
   TrainingDocumentStatus,
   CampaignComponentType,
+  TrainingContentType,
 } from '../../src/generated/prisma/enums.js';
 
 describe('UC-02 Training Document Integration Tests', () => {
   let token: string;
+  let campaignId: string;
   let campaignItemId: string;
   let campaignAssignmentId: string;
   let traineeProfileId: string;
@@ -24,6 +28,7 @@ describe('UC-02 Training Document Integration Tests', () => {
   let trainingDocTitle: string;
   let trainingDocContentType: any;
   let trainingDocContentRef: string;
+  let trainingDocContent: string;
   let trainingDocContentSummary: string | null;
   let trainingDocEstimatedReadTimeMinutes: number | null;
   let trainingDocDifficultyLevel: any;
@@ -34,7 +39,13 @@ describe('UC-02 Training Document Integration Tests', () => {
   let campaignItemIsRequired: boolean;
   let campaignItemAvailabilityStatus: any;
 
+  const phishingContentUrl = new URL(
+    '../../src/content/training/phishing-warning-signs.md',
+    import.meta.url,
+  );
+
   beforeEach(async () => {
+    trainingDocContent = await readFile(phishingContentUrl, 'utf8');
     const { user, traineeProfile } = await createTrainee();
 
     const campaign = await createCampaign({
@@ -43,6 +54,8 @@ describe('UC-02 Training Document Integration Tests', () => {
 
     const trainingDoc = await createTrainingDocument({
       status: TrainingDocumentStatus.AVAILABLE,
+      contentType: TrainingContentType.MARKDOWN,
+      contentRef: 'demo://training/phishing-warning-signs',
     });
 
     const campaignItem = await createCampaignItem({
@@ -65,6 +78,7 @@ describe('UC-02 Training Document Integration Tests', () => {
 
     token = loginResponse.body.token;
     campaignItemId = campaignItem.id;
+    campaignId = campaign.id;
     campaignAssignmentId = assignment.id;
     traineeProfileId = traineeProfile.id;
     trainingDocId = trainingDoc.id;
@@ -137,6 +151,7 @@ describe('UC-02 Training Document Integration Tests', () => {
         title: trainingDocTitle,
         contentType: trainingDocContentType,
         contentRef: trainingDocContentRef,
+        content: trainingDocContent,
         contentSummary: trainingDocContentSummary,
         estimatedReadTimeMinutes: trainingDocEstimatedReadTimeMinutes,
         difficultyLevel: trainingDocDifficultyLevel,
@@ -150,6 +165,48 @@ describe('UC-02 Training Document Integration Tests', () => {
         availabilityStatus: campaignItemAvailabilityStatus,
       },
     });
+  });
+
+  it('returns null content for unsupported training refs', async () => {
+    const unsupportedDoc = await createTrainingDocument({
+      status: TrainingDocumentStatus.AVAILABLE,
+      contentType: TrainingContentType.MARKDOWN,
+      contentRef: 'test://training/unsupported',
+    });
+
+    const unsupportedItem = await createCampaignItem({
+      campaignId,
+      componentType: CampaignComponentType.TRAINING_DOCUMENT,
+      trainingDocumentId: unsupportedDoc.id,
+    });
+
+    const response = await request(createApp())
+      .get(`/trainee/campaign-items/${unsupportedItem.id}/training-document`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.trainingDocument.content).toBeNull();
+  });
+
+  it('returns a controlled error when content files are missing', async () => {
+    const originalPath = fileURLToPath(phishingContentUrl);
+    const tempPath = `${originalPath}.bak`;
+
+    await rename(originalPath, tempPath);
+
+    try {
+      const response = await request(createApp())
+        .get(`/trainee/campaign-items/${campaignItemId}/training-document`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        error: 'TRAINING_CONTENT_UNAVAILABLE',
+        message: 'Training content could not be loaded',
+      });
+    } finally {
+      await rename(tempPath, originalPath);
+    }
   });
 
   it('marks a training document as viewed and asserts persisted interaction in database', async () => {

--- a/apps/backend/tests/unit/content-resolver.service.test.ts
+++ b/apps/backend/tests/unit/content-resolver.service.test.ts
@@ -5,9 +5,8 @@ vi.mock('node:fs/promises', () => ({
 }));
 
 const { readFile } = await import('node:fs/promises');
-const { resolveContent, TrainingContentResolveError } = await import(
-  '../../src/services/content-resolver.service.js'
-);
+const { resolveContent, TrainingContentResolveError } =
+  await import('../../src/services/content-resolver.service.js');
 
 describe('content resolver service', () => {
   beforeEach(() => {

--- a/apps/backend/tests/unit/content-resolver.service.test.ts
+++ b/apps/backend/tests/unit/content-resolver.service.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+const { readFile } = await import('node:fs/promises');
+const { resolveContent, TrainingContentResolveError } = await import(
+  '../../src/services/content-resolver.service.js'
+);
+
+describe('content resolver service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when contentType is not MARKDOWN', async () => {
+    const result = await resolveContent('HTML', 'demo://training/phishing-warning-signs');
+
+    expect(result).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('returns null for unknown refs', async () => {
+    const result = await resolveContent('MARKDOWN', 'demo://training/unknown');
+
+    expect(result).toBeNull();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('returns markdown for allowlisted refs', async () => {
+    vi.mocked(readFile).mockResolvedValueOnce('demo content');
+
+    const result = await resolveContent('MARKDOWN', 'demo://training/phishing-warning-signs');
+
+    expect(result).toBe('demo content');
+    expect(readFile).toHaveBeenCalledWith(expect.any(URL), 'utf8');
+  });
+
+  it('throws a controlled error when markdown cannot be read', async () => {
+    vi.mocked(readFile).mockRejectedValueOnce(new Error('read failed'));
+
+    await expect(
+      resolveContent('MARKDOWN', 'demo://training/phishing-warning-signs'),
+    ).rejects.toBeInstanceOf(TrainingContentResolveError);
+  });
+});

--- a/apps/backend/tests/unit/seed.helpers.test.ts
+++ b/apps/backend/tests/unit/seed.helpers.test.ts
@@ -280,7 +280,7 @@ describe('demo seed helpers', () => {
       id: DEMO_SEED_IDS.trainingDocuments.passwordSecurity,
       createdByUserId: DEMO_SEED_IDS.users.admin,
       title: 'Password Security Basics',
-      contentType: 'HTML',
+      contentType: 'MARKDOWN',
       contentRef: 'demo://training/password-security-basics',
       difficultyLevel: 'BEGINNER',
       status: 'AVAILABLE',

--- a/apps/backend/tests/unit/trainee-training.routes.test.ts
+++ b/apps/backend/tests/unit/trainee-training.routes.test.ts
@@ -23,8 +23,23 @@ const prismaMock = vi.hoisted(() => ({
   },
 }));
 
+const contentResolverMock = vi.hoisted(() => ({
+  resolveContent: vi.fn(),
+  TrainingContentResolveError: class TrainingContentResolveError extends Error {
+    constructor(message = 'Training content could not be loaded') {
+      super(message);
+      this.name = 'TrainingContentResolveError';
+    }
+  },
+}));
+
 vi.mock('../../src/lib/prisma.js', () => ({
   prisma: prismaMock,
+}));
+
+vi.mock('../../src/services/content-resolver.service.js', () => ({
+  resolveContent: contentResolverMock.resolveContent,
+  TrainingContentResolveError: contentResolverMock.TrainingContentResolveError,
 }));
 
 const user = {
@@ -108,6 +123,7 @@ describe('Trainee training document routes', () => {
     clearTraineeTrainingRateLimitStore();
     mockAuthenticatedUser();
     mockTrainingAccess();
+    contentResolverMock.resolveContent.mockResolvedValue('## Demo training content');
   });
 
   it('gets a training document resolved through the campaign item', async () => {
@@ -116,6 +132,7 @@ describe('Trainee training document routes', () => {
       .set('Authorization', authHeader());
 
     expect(response.status).toBe(200);
+    expect(contentResolverMock.resolveContent).toHaveBeenCalledWith('training/training-doc-1');
     expect(prismaMock.campaignItem.findUnique).toHaveBeenCalledWith({
       where: {
         id: campaignItemId,
@@ -137,6 +154,7 @@ describe('Trainee training document routes', () => {
         title: 'Identifying Phishing Emails',
         contentType: 'MARKDOWN',
         contentRef: 'training/training-doc-1',
+        content: '## Demo training content',
         contentSummary: 'Common phishing indicators and safe response steps.',
         estimatedReadTimeMinutes: 8,
         difficultyLevel: 'BEGINNER',
@@ -149,6 +167,33 @@ describe('Trainee training document routes', () => {
         isRequired: true,
         availabilityStatus: 'AVAILABLE',
       },
+    });
+  });
+
+  it('returns null content when the reference is not supported', async () => {
+    contentResolverMock.resolveContent.mockResolvedValueOnce(null);
+
+    const response = await request(createApp())
+      .get(trainingDocumentPath())
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(200);
+    expect(response.body.trainingDocument.content).toBeNull();
+  });
+
+  it('returns a controlled error when training content cannot be loaded', async () => {
+    contentResolverMock.resolveContent.mockRejectedValueOnce(
+      new contentResolverMock.TrainingContentResolveError(),
+    );
+
+    const response = await request(createApp())
+      .get(trainingDocumentPath())
+      .set('Authorization', authHeader());
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      error: 'TRAINING_CONTENT_UNAVAILABLE',
+      message: 'Training content could not be loaded',
     });
   });
 

--- a/apps/backend/tests/unit/trainee-training.routes.test.ts
+++ b/apps/backend/tests/unit/trainee-training.routes.test.ts
@@ -132,7 +132,10 @@ describe('Trainee training document routes', () => {
       .set('Authorization', authHeader());
 
     expect(response.status).toBe(200);
-    expect(contentResolverMock.resolveContent).toHaveBeenCalledWith('training/training-doc-1');
+    expect(contentResolverMock.resolveContent).toHaveBeenCalledWith(
+      'MARKDOWN',
+      'training/training-doc-1',
+    );
     expect(prismaMock.campaignItem.findUnique).toHaveBeenCalledWith({
       where: {
         id: campaignItemId,

--- a/docs/demo1/API.md
+++ b/docs/demo1/API.md
@@ -394,7 +394,8 @@ Training completion records interaction data, but this issue does not add sequen
     "id": "train-001",
     "title": "Identifying Phishing Emails",
     "contentType": "MARKDOWN",
-    "contentRef": "training/train-001",
+    "contentRef": "demo://training/phishing-warning-signs",
+    "content": "# Phishing Warning Signs\n\nPhishing emails try to create urgency. Watch for mismatched domains and unexpected attachments.",
     "contentSummary": "Common phishing indicators and safe response steps.",
     "estimatedReadTimeMinutes": 8,
     "difficultyLevel": "BEGINNER",
@@ -410,6 +411,38 @@ Training completion records interaction data, but this issue does not add sequen
 }
 ```
 
+When the training document reference is not supported by the backend allowlist, the response still succeeds and returns `content: null`:
+
+```json
+{
+  "campaignItemId": "item-002",
+  "campaignAssignmentId": "assignment-001",
+  "trainingDocument": {
+    "id": "train-002",
+    "title": "External Training Resource",
+    "contentType": "URL",
+    "contentRef": "https://training.example.com/phishing",
+    "content": null,
+    "contentSummary": "External phishing training resource.",
+    "estimatedReadTimeMinutes": 5,
+    "difficultyLevel": "BEGINNER",
+    "status": "AVAILABLE"
+  },
+  "campaignItem": {
+    "title": "External Training Resource",
+    "description": "Open the external guide.",
+    "position": 2,
+    "isRequired": false,
+    "availabilityStatus": "AVAILABLE"
+  }
+}
+```
+
+Content field behavior:
+
+- When the `contentRef` matches an allowlisted Demo 1 ref, the backend returns the resolved markdown string.
+- When the `contentRef` is not allowlisted, `content` is `null` to indicate there is no backend-readable content.
+
 The backend resolves access through the campaign item placement:
 
 `Trainee -> CampaignAssignment -> Campaign -> CampaignItem -> TrainingDocumentComponent -> TrainingDocument`
@@ -417,6 +450,15 @@ The backend resolves access through the campaign item placement:
 In the current Prisma implementation, the conceptual `TrainingDocumentComponent` is represented by a `CampaignItem` with `itemType = COMPONENT`, `componentType = TRAINING_DOCUMENT`, and `trainingDocumentId`.
 
 Training documents are reusable content records. They are not owned by learning paths or training modules, and this endpoint does not require a linked quiz. Missing, unavailable, non-training, or unauthorised campaign items should return a safe `404` so the API does not leak content existence. The endpoint may return `429` if the trainee training route rate limit is exceeded.
+
+Expected status codes and error responses:
+
+- `200 OK`: Training document response with `content` resolved or `null`.
+- `400 Bad Request`: Invalid campaign item UUID format.
+- `401 Unauthorized`: Missing or invalid authentication.
+- `404 Not Found`: The training document is missing, unavailable, or not accessible for the trainee.
+- `429 Too Many Requests`: Training route rate limit exceeded.
+- `500 Internal Server Error`: `TRAINING_CONTENT_UNAVAILABLE` when demo content fails to resolve, or an unexpected error.
 
 ### `POST /trainee/campaign-items/:campaignItemId/training-document/viewed`
 

--- a/packages/shared/src/training.ts
+++ b/packages/shared/src/training.ts
@@ -24,6 +24,7 @@ export interface TrainingDocumentContentDto {
   title: string;
   contentType: TrainingContentTypeDto;
   contentRef: string;
+  content: string | null;
   contentSummary?: string | null;
   estimatedReadTimeMinutes?: number | null;
   difficultyLevel: DifficultyLevelDto;


### PR DESCRIPTION
## Summary

Added backend-resolved training content for Demo 1: a safe allowlisted resolver now serves markdown content via `trainingDocument.content`, seeded demo training docs switched to `MARKDOWN`, and backend-owned markdown files were added. Updated unit/integration tests, Swagger schema, and Demo 1 API docs to reflect the new response shape and error handling for missing content.

## Linked Issue

Closes #140

## Type of change

- [x] Feature
- [ ] Bug Fix
- [x] Documentation
- [x] Chore/Maintenance

## Testing

- `pnpm --filter @insightful-phish/shared typecheck`
- `pnpm --filter @insightful-phish/shared test`
- `pnpm --filter @insightful-phish/backend typecheck`
- `pnpm --filter @insightful-phish/backend test`
- `TEST_DATABASE_URL=postgresql://insightful_phish:insightful_phish@localhost:5432/insightful_phish_test DATABASE_URL=postgresql://insightful_phish:insightful_phish@localhost:5432/insightful_phish_test pnpm --filter @insightful-phish/backend test:integration`
- `pnpm exec prettier --check docs/demo1/API.md`

## Review Notes

- Focus on `content` field behavior and controlled errors for missing demo content.
- Verify allowlist mapping and markdown file content correctness.
- Check UC-02 integration test expectations for resolved content and `null` handling.

## Checklist

- [x] I tested the change locally
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed

<!-- WHO TO REQUEST FOR REVIEW -->
<!-- * Frontend/UI/UX/Styling: Connor or Zoë -->
<!-- * Backend/API/System Logic: Adriano or Rudolph -->
<!-- * Database/Prisma/Models: Adriano or Johan -->
<!-- * Testing/Validation/QA: Zoë -->
<!-- * Repo/DevOps/CI/CD/Actions: Johan -->
<!-- * Documentation/Diagrams: Johan and -->
<!--                         : Connor for Design/Brand -->
<!--                         : Zoë for SRS -->
<!--                         : Rudolph for API/Architecture -->
<!--                         : Adriano for Domain Model -->