### PR TITLE
Chore/testing frontend/zoe

### DIFF
--- a/apps/frontend/src/pages/testing/EmailDetailPage.test.tsx
+++ b/apps/frontend/src/pages/testing/EmailDetailPage.test.tsx
@@ -1,0 +1,146 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import EmailDetailPage from '../EmailDetailPage';
+import {
+  getSimulatedEmail,
+  recordSimulatedEmailInteraction,
+} from '../../services/campaigns.service';
+
+const CAMPAIGN_ITEM_ID = 'campaign-item-123';
+const EMAIL_ID = 'email-123';
+let authToken: string | null = 'demo-token';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+
+  return {
+    ...actual,
+    useParams: () => ({
+      campaignItemId: CAMPAIGN_ITEM_ID,
+      emailId: EMAIL_ID,
+    }),
+  };
+});
+
+vi.mock('../../components/layout/AppLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../components/ui/PageBackButton', () => ({
+  default: () => <div>Back</div>,
+}));
+
+vi.mock('../../context/useAuth', () => ({
+  useAuth: () => ({
+    token: authToken,
+  }),
+}));
+
+vi.mock('../../services/campaigns.service', () => ({
+  getSimulatedEmail: vi.fn(),
+  recordSimulatedEmailInteraction: vi.fn(),
+}));
+
+const mockedGetSimulatedEmail = vi.mocked(getSimulatedEmail);
+const mockedRecordSimulatedEmailInteraction = vi.mocked(recordSimulatedEmailInteraction);
+
+const emailFixture = {
+  id: EMAIL_ID,
+  campaignItemId: CAMPAIGN_ITEM_ID,
+  campaignAssignmentId: 'assignment-1',
+  inboxId: 'inbox-1',
+  senderLabel: 'Finance Team',
+  senderAddress: 'finance@example.com',
+  subject: 'payroll access locked',
+  preview: 'Review the payroll portal update.',
+  bodyHtml:
+    '<p>Please <strong>review</strong> your payroll access.</p><script>window.hacked = true;</script><a href="https://example.com">Open portal</a>',
+  simulatedLinkTarget: 'https://example.com',
+  hasAttachment: false,
+  receivedAt: '2026-05-20T10:30:00.000Z',
+  difficultyLevel: 'BEGINNER',
+} as const;
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return {
+    promise,
+    resolve: resolve!,
+    reject: reject!,
+  };
+}
+
+describe('EmailDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authToken = 'demo-token';
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockedRecordSimulatedEmailInteraction.mockResolvedValue({
+      success: true,
+      eventType: 'SIMULATED_EMAIL_OPENED',
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows a loading state while the simulated email is being fetched', async () => {
+    const deferred = createDeferred<typeof emailFixture>();
+
+    mockedGetSimulatedEmail.mockReturnValueOnce(deferred.promise);
+
+    render(<EmailDetailPage />);
+
+    expect(screen.getByText('LOADING EMAIL...')).toBeInTheDocument();
+
+    deferred.resolve(emailFixture);
+
+    expect(await screen.findByText('Finance Team')).toBeInTheDocument();
+  });
+
+  it('renders the email details, sanitizes the body, and records the open event', async () => {
+    mockedGetSimulatedEmail.mockResolvedValue(emailFixture);
+
+    render(<EmailDetailPage />);
+
+    expect(await screen.findByText('Finance Team')).toBeInTheDocument();
+    expect(screen.getByText('Payroll Access Locked')).toBeInTheDocument();
+    expect(screen.getByText('Open portal')).toBeInTheDocument();
+    expect(document.querySelector('.email-body script')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockedGetSimulatedEmail).toHaveBeenCalledWith(
+        CAMPAIGN_ITEM_ID,
+        EMAIL_ID,
+        'demo-token',
+      );
+      expect(mockedRecordSimulatedEmailInteraction).toHaveBeenCalledWith(
+        CAMPAIGN_ITEM_ID,
+        EMAIL_ID,
+        'SIMULATED_EMAIL_OPENED',
+        'demo-token',
+      );
+    });
+  });
+
+  it('shows an error state when the simulated email cannot be loaded', async () => {
+    mockedGetSimulatedEmail.mockRejectedValueOnce(new Error('load failed'));
+
+    render(<EmailDetailPage />);
+
+    expect(await screen.findByText('FAILED TO LOAD EMAIL')).toBeInTheDocument();
+    expect(mockedRecordSimulatedEmailInteraction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/testing/InboxPage.test.tsx
+++ b/apps/frontend/src/pages/testing/InboxPage.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { GetSimulatedInboxResponseDto } from '@insightful-phish/shared';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import InboxPage from '../InboxPage';
@@ -42,7 +43,7 @@ vi.mock('../../services/campaigns.service', () => ({
 
 const mockedGetSimulatedInbox = vi.mocked(getSimulatedInbox);
 
-const inboxFixture = {
+const inboxFixture: GetSimulatedInboxResponseDto = {
   emails: [
     {
       id: 'email-1',
@@ -67,7 +68,7 @@ const inboxFixture = {
       isOpened: true,
     },
   ],
-} as const;
+};
 
 function createDeferred<T>() {
   let resolve: (value: T) => void;

--- a/apps/frontend/src/pages/testing/InboxPage.test.tsx
+++ b/apps/frontend/src/pages/testing/InboxPage.test.tsx
@@ -1,0 +1,164 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import InboxPage from '../InboxPage';
+import { getSimulatedInbox } from '../../services/campaigns.service';
+
+const navigateMock = vi.fn();
+const CAMPAIGN_ITEM_ID = 'campaign-item-123';
+let authToken: string | null = 'demo-token';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => ({
+      campaignItemId: CAMPAIGN_ITEM_ID,
+    }),
+  };
+});
+
+vi.mock('../../components/layout/AppLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../components/ui/PageBackButton', () => ({
+  default: () => <div>Back</div>,
+}));
+
+vi.mock('../../context/useAuth', () => ({
+  useAuth: () => ({
+    token: authToken,
+  }),
+}));
+
+vi.mock('../../services/campaigns.service', () => ({
+  getSimulatedInbox: vi.fn(),
+}));
+
+const mockedGetSimulatedInbox = vi.mocked(getSimulatedInbox);
+
+const inboxFixture = {
+  emails: [
+    {
+      id: 'email-1',
+      inboxId: 'inbox-1',
+      senderLabel: 'Finance Team',
+      senderAddress: 'finance@example.com',
+      subject: 'urgent payroll action',
+      preview: 'Verify your account before 5 PM.',
+      receivedAt: '2026-05-20T10:30:00.000Z',
+      difficultyLevel: 'BEGINNER',
+      isOpened: false,
+    },
+    {
+      id: 'email-2',
+      inboxId: 'inbox-1',
+      senderLabel: 'Human Resources',
+      senderAddress: 'hr@example.com',
+      subject: 'benefits update',
+      preview: 'The annual benefits guide is ready.',
+      receivedAt: '2026-05-19T08:00:00.000Z',
+      difficultyLevel: 'BEGINNER',
+      isOpened: true,
+    },
+  ],
+} as const;
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return {
+    promise,
+    resolve: resolve!,
+    reject: reject!,
+  };
+}
+
+describe('InboxPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authToken = 'demo-token';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a loading state while the simulated inbox is being fetched', async () => {
+    const deferred = createDeferred<typeof inboxFixture>();
+
+    mockedGetSimulatedInbox.mockReturnValueOnce(deferred.promise);
+
+    render(<InboxPage />);
+
+    expect(screen.getByText('LOADING INBOX...')).toBeInTheDocument();
+
+    deferred.resolve(inboxFixture);
+
+    expect(await screen.findByRole('button', { name: /finance team/i })).toBeInTheDocument();
+  });
+
+  it('renders emails, filters results, and navigates to the selected email', async () => {
+    const user = userEvent.setup();
+
+    mockedGetSimulatedInbox.mockResolvedValue(inboxFixture);
+
+    render(<InboxPage />);
+
+    expect(
+      await screen.findByRole('button', {
+        name: /finance team urgent payroll action verify your account before 5 pm\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /human resources benefits update/i }),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText(/search/i), 'finance');
+
+    expect(screen.getByRole('button', { name: /finance team/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: /human resources benefits update/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /finance team/i }));
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith(
+        `/trainee/campaign-items/${CAMPAIGN_ITEM_ID}/simulated-emails/email-1`,
+      );
+    });
+  });
+
+  it('shows an empty state when there are no inbox matches', async () => {
+    mockedGetSimulatedInbox.mockResolvedValue({
+      emails: [],
+    });
+
+    render(<InboxPage />);
+
+    expect(await screen.findByText('NO EMAILS MATCH YOUR SEARCH')).toBeInTheDocument();
+  });
+
+  it('shows an error state instead of fetching when auth is missing', async () => {
+    authToken = null;
+
+    render(<InboxPage />);
+
+    expect(await screen.findByText('FAILED TO LOAD INBOX')).toBeInTheDocument();
+    expect(mockedGetSimulatedInbox).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/testing/LoginPage.test.tsx
+++ b/apps/frontend/src/pages/testing/LoginPage.test.tsx
@@ -1,0 +1,125 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import LoginPage from '../LoginPage';
+
+const navigateMock = vi.fn();
+const loginMock = vi.fn();
+const fetchMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('../../context/useAuth', () => ({
+  useAuth: () => ({
+    login: loginMock,
+  }),
+}));
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows validation errors before submitting invalid credentials', async () => {
+    const user = userEvent.setup();
+
+    renderLoginPage();
+
+    await user.type(screen.getByLabelText(/email address/i), 'not-an-email');
+    await user.type(screen.getByLabelText(/^password$/i), 'legacy-password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    expect(screen.getByText('Please enter a valid email address.')).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('logs the learner in and routes to campaigns after a successful login', async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        token: 'demo-token',
+        user: {
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'trainee@example.com',
+        },
+      }),
+    });
+
+    renderLoginPage();
+
+    await user.type(screen.getByLabelText(/email address/i), '  TRAINEE@example.com  ');
+    await user.type(screen.getByLabelText(/^password$/i), 'legacy-password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(loginMock).toHaveBeenCalledWith('demo-token', {
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'trainee@example.com',
+      });
+      expect(navigateMock).toHaveBeenCalledWith('/campaigns');
+    });
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/auth/login');
+    expect(requestInit?.method).toBe('POST');
+    expect(requestInit?.headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(String(requestInit?.body))).toEqual({
+      email: 'trainee@example.com',
+      password: 'legacy-password',
+    });
+  });
+
+  it('shows an invalid-credentials message when the backend returns 401', async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({
+        message: 'Invalid credentials',
+      }),
+    });
+
+    renderLoginPage();
+
+    await user.type(screen.getByLabelText(/email address/i), 'trainee@example.com');
+    await user.type(screen.getByLabelText(/^password$/i), 'wrong-password');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    expect(await screen.findByText('INVALID EMAIL OR PASSWORD')).toBeInTheDocument();
+    expect(loginMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/testing/QuizApi.test.ts
+++ b/apps/frontend/src/pages/testing/QuizApi.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getQuiz } from '../../lib/quizApi';
+
+const campaignItemId = '33333333-3333-4333-8333-333333333334';
+
+function installLocalStorageMock(authToken: string | null = null) {
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn((key: string) => (key === 'authToken' ? authToken : null)),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  });
+}
+
+function mockJsonResponse(body: unknown, ok = true, status = 200) {
+  return Promise.resolve({
+    ok,
+    status,
+    headers: {
+      get: () => 'application/json',
+    },
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+describe('quizApi', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    installLocalStorageMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches quiz content through the campaign item quiz endpoint', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      await mockJsonResponse({
+        id: '55555555-5555-4555-8555-555555555551',
+        campaignItemId,
+        campaignAssignmentId: '22222222-2222-4222-8222-222222222222',
+        title: 'Phishing basics quiz',
+        description: 'Check your phishing awareness.',
+        passThresholdPercentage: 70,
+        difficultyLevel: 'BEGINNER',
+        status: 'AVAILABLE',
+        questions: [
+          {
+            id: 'question-1',
+            text: 'Which email is suspicious?',
+            options: [
+              {
+                id: 'option-1',
+                label: 'A',
+                text: 'Urgent password reset email.',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const quiz = await getQuiz(campaignItemId);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(`/trainee/campaign-items/${campaignItemId}/quiz`),
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+
+    expect(quiz.title).toBe('Phishing basics quiz');
+    expect(quiz.questions[0].options[0].text).toBe('Urgent password reset email.');
+  });
+
+  it('sends bearer token when a token already exists', async () => {
+    installLocalStorageMock('demo-token');
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      await mockJsonResponse({
+        id: '55555555-5555-4555-8555-555555555551',
+        campaignItemId,
+        title: 'Phishing basics quiz',
+        questions: [],
+      }),
+    );
+
+    await getQuiz(campaignItemId);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer demo-token',
+        }),
+      }),
+    );
+  });
+
+  it('rejects quiz fetch responses that expose correctness before submission', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      await mockJsonResponse({
+        id: '55555555-5555-4555-8555-555555555551',
+        campaignItemId,
+        title: 'Leaky quiz',
+        questions: [
+          {
+            id: 'question-1',
+            text: 'Which option is correct?',
+            options: [
+              {
+                id: 'option-1',
+                label: 'A',
+                text: 'This should not expose correctness.',
+                isCorrect: true,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    await expect(getQuiz(campaignItemId)).rejects.toThrow(/exposed "isCorrect" before submission/i);
+  });
+
+  it('rejects quiz fetch responses that expose feedback before submission', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      await mockJsonResponse({
+        id: '55555555-5555-4555-8555-555555555551',
+        campaignItemId,
+        title: 'Leaky quiz',
+        questions: [
+          {
+            id: 'question-1',
+            text: 'Which option is correct?',
+            options: [
+              {
+                id: 'option-1',
+                label: 'A',
+                text: 'This should not expose feedback.',
+                feedbackText: 'This feedback should only appear after submission.',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    await expect(getQuiz(campaignItemId)).rejects.toThrow(
+      /exposed "feedbackText" before submission/i,
+    );
+  });
+});

--- a/apps/frontend/src/pages/testing/QuizPage.test.tsx
+++ b/apps/frontend/src/pages/testing/QuizPage.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import QuizPage from '../QuizPage';
@@ -18,6 +19,22 @@ const mockedSubmitQuizAttempt = vi.mocked(submitQuizAttempt);
 
 const campaignItemId = '33333333-3333-4333-8333-333333333334';
 const attemptId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return {
+    promise,
+    resolve: resolve!,
+    reject: reject!,
+  };
+}
 
 const quizFixture = {
   id: '55555555-5555-4555-8555-555555555551',
@@ -104,6 +121,23 @@ afterEach(() => {
 });
 
 describe('QuizPage', () => {
+  it('shows a loading state before the quiz content resolves', async () => {
+    const deferred = createDeferred<typeof quizFixture>();
+
+    mockedGetQuiz.mockReturnValueOnce(deferred.promise);
+
+    renderQuizPage();
+
+    expect(screen.getByRole('heading', { level: 2, name: /loading quiz/i })).toBeInTheDocument();
+    expect(screen.getByText(/your quiz questions are being loaded/i)).toBeInTheDocument();
+
+    deferred.resolve(quizFixture);
+
+    expect(
+      await screen.findByRole('heading', { name: /phishing basics quiz/i }),
+    ).toBeInTheDocument();
+  });
+
   it('loads quiz content through the campaign item id', async () => {
     renderQuizPage();
 
@@ -145,6 +179,31 @@ describe('QuizPage', () => {
 
     expect(mockedStartQuizAttempt).not.toHaveBeenCalled();
     expect(mockedSubmitQuizAttempt).not.toHaveBeenCalled();
+  });
+
+  it('allows learners to select answers and updates progress text', async () => {
+    const user = userEvent.setup();
+
+    renderQuizPage();
+
+    expect(
+      await screen.findByRole('heading', { name: /phishing basics quiz/i }),
+    ).toBeInTheDocument();
+
+    const firstAnswer = screen.getByLabelText(
+      /A\. A message asking you to verify your password urgently\./i,
+    );
+    const secondAnswer = screen.getByLabelText(/A\. The sender and link destination\./i);
+
+    await user.click(firstAnswer);
+
+    expect(firstAnswer).toBeChecked();
+    expect(screen.getByText(/question 1 of 2 answered/i)).toBeInTheDocument();
+
+    await user.click(secondAnswer);
+
+    expect(secondAnswer).toBeChecked();
+    expect(screen.getByText(/question 2 of 2 answered/i)).toBeInTheDocument();
   });
 
   it('starts an attempt and submits selected single-choice answers', async () => {
@@ -208,7 +267,10 @@ describe('QuizPage', () => {
     const submitButton = screen.getByRole('button', { name: /submit quiz/i });
 
     fireEvent.click(submitButton);
-    fireEvent.click(submitButton);
+
+    expect(await screen.findByRole('button', { name: /submitting/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /submitting/i }));
 
     await waitFor(() => {
       expect(mockedSubmitQuizAttempt).toHaveBeenCalledTimes(1);

--- a/apps/frontend/src/pages/testing/RegisterPage.test.tsx
+++ b/apps/frontend/src/pages/testing/RegisterPage.test.tsx
@@ -1,0 +1,147 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RegisterPage from '../RegisterPage';
+
+const navigateMock = vi.fn();
+const fetchMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function renderRegisterPage() {
+  return render(
+    <MemoryRouter>
+      <RegisterPage />
+    </MemoryRouter>,
+  );
+}
+
+async function fillRegistrationForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/first name\(s\)/i), '  Jane  ');
+  await user.type(screen.getByLabelText(/last name/i), '  Doe  ');
+  await user.type(screen.getByLabelText(/email address/i), '  TRAINEE@example.com  ');
+}
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('shows schema validation errors before submitting invalid input', async () => {
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+
+    await user.type(screen.getByLabelText(/first name\(s\)/i), 'Jane');
+    await user.type(screen.getByLabelText(/last name/i), 'Doe');
+    await user.type(screen.getByLabelText(/email address/i), 'not-an-email');
+    await user.type(screen.getByLabelText(/^password$/i), 'StrongPass123!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'StrongPass123!');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByText('Please enter a valid email address.')).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks submission when the confirmation password does not match', async () => {
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+
+    await fillRegistrationForm(user);
+    await user.type(screen.getByLabelText(/^password$/i), 'StrongPass123!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'DifferentPass123!');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(screen.getByText('PASSWORDS DO NOT MATCH')).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('submits registration details and redirects to login on success', async () => {
+    vi.useFakeTimers();
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        user: {
+          id: 'user-1',
+        },
+      }),
+    });
+
+    renderRegisterPage();
+
+    fireEvent.change(screen.getByLabelText(/first name\(s\)/i), {
+      target: { value: '  Jane  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: '  Doe  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/email address/i), {
+      target: { value: '  TRAINEE@example.com  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'StrongPass123!' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'StrongPass123!' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/auth/register');
+    expect(requestInit?.method).toBe('POST');
+    expect(JSON.parse(String(requestInit?.body))).toEqual({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'trainee@example.com',
+      password: 'StrongPass123!',
+    });
+
+    await vi.runAllTimersAsync();
+
+    expect(navigateMock).toHaveBeenCalledWith('/login');
+  });
+
+  it('shows a duplicate-account message when the backend returns 409', async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        message: 'Conflict',
+      }),
+    });
+
+    renderRegisterPage();
+
+    await fillRegistrationForm(user);
+    await user.type(screen.getByLabelText(/^password$/i), 'StrongPass123!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'StrongPass123!');
+    await user.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(
+      await screen.findByText('AN ACCOUNT WITH THIS EMAIL ALREADY EXISTS'),
+    ).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/testing/ResultsPage.test.tsx
+++ b/apps/frontend/src/pages/testing/ResultsPage.test.tsx
@@ -1,154 +1,135 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getQuiz } from '../../lib/quizApi';
+import ResultsPage from '../ResultsPage';
+import { getQuizResult } from '../../lib/quizApi';
 
+vi.mock('../../components/layout/AppLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../lib/quizApi', () => ({
+  getQuizResult: vi.fn(),
+}));
+
+const mockedGetQuizResult = vi.mocked(getQuizResult);
+const attemptId = 'attempt-123';
 const campaignItemId = '33333333-3333-4333-8333-333333333334';
 
-function installLocalStorageMock(authToken: string | null = null) {
-  vi.stubGlobal('localStorage', {
-    getItem: vi.fn((key: string) => (key === 'authToken' ? authToken : null)),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn(),
-  });
-}
-
-function mockJsonResponse(body: unknown, ok = true, status = 200) {
-  return Promise.resolve({
-    ok,
-    status,
-    headers: {
-      get: () => 'application/json',
+const resultFixture = {
+  attemptId,
+  quizId: 'quiz-1',
+  campaignAssignmentId: 'assignment-1',
+  campaignItemId,
+  scorePercentage: 83.6,
+  passed: true,
+  summary: 'Great job identifying the suspicious message and unsafe link.',
+  answers: [
+    {
+      questionId: 'question-1',
+      isCorrect: true,
+      awardedPoints: 5,
+      feedbackShown: 'You correctly identified the phishing indicator.',
+      selectedOptions: [
+        {
+          optionId: 'option-1',
+          label: 'A',
+          text: 'Urgent password reset email.',
+          isCorrect: true,
+          feedbackText: 'This was the suspicious option.',
+        },
+      ],
     },
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body)),
-  } as unknown as Response);
+  ],
+} as const;
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return {
+    promise,
+    resolve: resolve!,
+    reject: reject!,
+  };
 }
 
-describe('quizApi', () => {
+function renderResultsPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/quiz-attempts/${attemptId}/results`]}>
+      <Routes>
+        <Route path="/quiz-attempts/:attemptId/results" element={<ResultsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ResultsPage', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-    installLocalStorageMock();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    cleanup();
   });
 
-  it('fetches quiz content through the campaign item quiz endpoint', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      await mockJsonResponse({
-        id: '55555555-5555-4555-8555-555555555551',
-        campaignItemId,
-        campaignAssignmentId: '22222222-2222-4222-8222-222222222222',
-        title: 'Phishing basics quiz',
-        description: 'Check your phishing awareness.',
-        passThresholdPercentage: 70,
-        difficultyLevel: 'BEGINNER',
-        status: 'AVAILABLE',
-        questions: [
-          {
-            id: 'question-1',
-            text: 'Which email is suspicious?',
-            options: [
-              {
-                id: 'option-1',
-                label: 'A',
-                text: 'Urgent password reset email.',
-              },
-            ],
-          },
-        ],
-      }),
-    );
+  it('shows a loading state before quiz results resolve', async () => {
+    const deferred = createDeferred<typeof resultFixture>();
 
-    const quiz = await getQuiz(campaignItemId);
+    mockedGetQuizResult.mockReturnValueOnce(deferred.promise);
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining(`/trainee/campaign-items/${campaignItemId}/quiz`),
-      expect.objectContaining({
-        method: 'GET',
-      }),
-    );
+    renderResultsPage();
 
-    expect(quiz.title).toBe('Phishing basics quiz');
-    expect(quiz.questions[0].options[0].text).toBe('Urgent password reset email.');
+    expect(screen.getByRole('heading', { level: 2, name: /loading results/i })).toBeInTheDocument();
+    expect(screen.getByText(/your quiz result feedback is being loaded/i)).toBeInTheDocument();
+
+    deferred.resolve(resultFixture);
+
+    expect(await screen.findByRole('heading', { level: 1, name: /passed/i })).toBeInTheDocument();
   });
 
-  it('sends bearer token when a token already exists', async () => {
-    installLocalStorageMock('demo-token');
+  it('renders the learner score, feedback, and navigation back to the quiz', async () => {
+    mockedGetQuizResult.mockResolvedValue(resultFixture);
 
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      await mockJsonResponse({
-        id: '55555555-5555-4555-8555-555555555551',
-        campaignItemId,
-        title: 'Phishing basics quiz',
-        questions: [],
-      }),
-    );
+    renderResultsPage();
 
-    await getQuiz(campaignItemId);
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer demo-token',
-        }),
-      }),
+    expect(await screen.findByText('84%')).toBeInTheDocument();
+    expect(screen.getByText(resultFixture.summary)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /answer feedback/i })).toBeInTheDocument();
+    expect(screen.getByText('Selected correct option')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to quiz/i })).toHaveAttribute(
+      'href',
+      `/quizzes/${campaignItemId}`,
     );
   });
 
-  it('rejects quiz fetch responses that expose correctness before submission', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      await mockJsonResponse({
-        id: '55555555-5555-4555-8555-555555555551',
-        campaignItemId,
-        title: 'Leaky quiz',
-        questions: [
-          {
-            id: 'question-1',
-            text: 'Which option is correct?',
-            options: [
-              {
-                id: 'option-1',
-                label: 'A',
-                text: 'This should not expose correctness.',
-                isCorrect: true,
-              },
-            ],
-          },
-        ],
-      }),
-    );
+  it('shows an error state and retries loading when requested', async () => {
+    const user = userEvent.setup();
 
-    await expect(getQuiz(campaignItemId)).rejects.toThrow(/exposed "isCorrect" before submission/i);
-  });
+    mockedGetQuizResult.mockRejectedValueOnce(new Error('Results are temporarily unavailable.'));
+    mockedGetQuizResult.mockResolvedValueOnce(resultFixture);
 
-  it('rejects quiz fetch responses that expose feedback before submission', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      await mockJsonResponse({
-        id: '55555555-5555-4555-8555-555555555551',
-        campaignItemId,
-        title: 'Leaky quiz',
-        questions: [
-          {
-            id: 'question-1',
-            text: 'Which option is correct?',
-            options: [
-              {
-                id: 'option-1',
-                label: 'A',
-                text: 'This should not expose feedback.',
-                feedbackText: 'This feedback should only appear after submission.',
-              },
-            ],
-          },
-        ],
-      }),
-    );
+    renderResultsPage();
 
-    await expect(getQuiz(campaignItemId)).rejects.toThrow(
-      /exposed "feedbackText" before submission/i,
-    );
+    expect(
+      await screen.findByRole('heading', { level: 2, name: /unable to load results/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Results are temporarily unavailable.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    await waitFor(() => {
+      expect(mockedGetQuizResult).toHaveBeenCalledTimes(2);
+    });
+
+    expect(await screen.findByText('84%')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/testing/ResultsPage.test.tsx
+++ b/apps/frontend/src/pages/testing/ResultsPage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ResultsPage from '../ResultsPage';
 import { getQuizResult } from '../../lib/quizApi';
+import type { QuizResult } from '../../lib/quizApi';
 
 vi.mock('../../components/layout/AppLayout', () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -19,7 +20,7 @@ const mockedGetQuizResult = vi.mocked(getQuizResult);
 const attemptId = 'attempt-123';
 const campaignItemId = '33333333-3333-4333-8333-333333333334';
 
-const resultFixture = {
+const resultFixture: QuizResult = {
   attemptId,
   quizId: 'quiz-1',
   campaignAssignmentId: 'assignment-1',
@@ -44,7 +45,7 @@ const resultFixture = {
       ],
     },
   ],
-} as const;
+};
 
 function createDeferred<T>() {
   let resolve: (value: T) => void;
@@ -102,7 +103,9 @@ describe('ResultsPage', () => {
     renderResultsPage();
 
     expect(await screen.findByText('84%')).toBeInTheDocument();
-    expect(screen.getByText(resultFixture.summary)).toBeInTheDocument();
+    expect(
+      screen.getByText('Great job identifying the suspicious message and unsafe link.'),
+    ).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /answer feedback/i })).toBeInTheDocument();
     expect(screen.getByText('Selected correct option')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /back to quiz/i })).toHaveAttribute(

--- a/apps/frontend/src/routes/testing/AppRoutes.test.tsx
+++ b/apps/frontend/src/routes/testing/AppRoutes.test.tsx
@@ -1,0 +1,306 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../App', () => ({
+  StatusPage: () => <h1>Status Page</h1>,
+  default: () => null,
+}));
+
+vi.mock('../../components/layout/AppLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../components/ui/CampaignAccordion', () => ({
+  default: ({
+    subtitle,
+    children,
+    isOpen,
+    onToggle,
+  }: {
+    subtitle: string;
+    children?: ReactNode;
+    isOpen: boolean;
+    onToggle: () => void;
+  }) => (
+    <section>
+      <button type="button" onClick={onToggle}>
+        {subtitle}
+      </button>
+      {isOpen ? <div>{children}</div> : null}
+    </section>
+  ),
+}));
+
+vi.mock('../../components/ui/TrainingPartAccordion', () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../components/ui/TrainingActionRow', () => ({
+  default: ({
+    label,
+    onClick,
+    disabled,
+  }: {
+    label: string;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {label}
+    </button>
+  ),
+}));
+
+vi.mock('../../pages/InboxPage', () => ({
+  default: () => <h1>Simulated Email Inbox</h1>,
+}));
+
+vi.mock('../../pages/EmailDetailPage', () => ({
+  default: () => <h1>Simulated Email</h1>,
+}));
+
+vi.mock('../../pages/TrainingDocumentPage', () => ({
+  default: () => <h1>Training Document Page</h1>,
+}));
+
+vi.mock('../../pages/QuizPage', () => ({
+  default: () => <h1>Quiz Page</h1>,
+}));
+
+vi.mock('../../pages/ResultsPage', () => ({
+  default: () => <h1>Quiz Results</h1>,
+}));
+
+vi.mock('../../lib/campaignsApi', () => ({
+  getTraineeCampaigns: vi.fn(),
+  getTraineeCampaignDetail: vi.fn(),
+}));
+
+import AppRoutes from '../AppRoutes';
+import { AuthContext } from '../../context/auth-context';
+import { getTraineeCampaignDetail, getTraineeCampaigns } from '../../lib/campaignsApi';
+
+const mockedGetTraineeCampaigns = vi.mocked(getTraineeCampaigns);
+const mockedGetTraineeCampaignDetail = vi.mocked(getTraineeCampaignDetail);
+
+const CAMPAIGN_ID = '11111111-1111-4111-8111-111111111111';
+const TRAINING_CAMPAIGN_ITEM_ID = '33333333-3333-4333-8333-333333333333';
+const QUIZ_CAMPAIGN_ITEM_ID = '33333333-3333-4333-8333-333333333334';
+const ATTEMPT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function LocationDisplay() {
+  const location = useLocation();
+
+  return <div data-testid="location-path">{location.pathname}</div>;
+}
+
+function renderAppRoutes({
+  initialEntry,
+  isAuthenticated = true,
+}: {
+  initialEntry: string;
+  isAuthenticated?: boolean;
+}) {
+  return render(
+    <AuthContext.Provider
+      value={{
+        isAuthenticated,
+        token: isAuthenticated ? 'demo-token' : null,
+        user: isAuthenticated
+          ? {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              email: 'trainee@example.com',
+            }
+          : null,
+        login: vi.fn(),
+        logout: vi.fn(),
+      }}
+    >
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <LocationDisplay />
+        <AppRoutes />
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  );
+}
+
+describe('AppRoutes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedGetTraineeCampaigns.mockResolvedValue({
+      campaigns: [
+        {
+          campaignId: CAMPAIGN_ID,
+          name: 'Quarterly Awareness',
+          campaignType: 'PREMADE_GENERAL',
+          difficultyLevel: 'BEGINNER',
+          status: 'ACTIVE',
+          progressStatus: 'IN_PROGRESS',
+        },
+      ],
+    });
+
+    mockedGetTraineeCampaignDetail.mockResolvedValue({
+      campaignId: CAMPAIGN_ID,
+      name: 'Quarterly Awareness',
+      campaignType: 'PREMADE_GENERAL',
+      difficultyLevel: 'BEGINNER',
+      status: 'ACTIVE',
+      progressStatus: 'IN_PROGRESS',
+      items: [],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the login screen at /login', async () => {
+    renderAppRoutes({
+      initialEntry: '/login',
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /welcome back/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the register screen at /register', async () => {
+    renderAppRoutes({
+      initialEntry: '/register',
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /^welcome$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the campaigns screen at /campaigns', async () => {
+    renderAppRoutes({
+      initialEntry: '/campaigns',
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /campaigns/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the simulated inbox at the mounted inbox route', async () => {
+    renderAppRoutes({
+      initialEntry: `/trainee/campaign-items/${TRAINING_CAMPAIGN_ITEM_ID}/simulated-inbox`,
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /simulated email inbox/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the simulated email detail at the mounted email detail route', async () => {
+    renderAppRoutes({
+      initialEntry: `/trainee/campaign-items/${TRAINING_CAMPAIGN_ITEM_ID}/simulated-emails/email-123`,
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /simulated email/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the training document page at the mounted training route', async () => {
+    renderAppRoutes({
+      initialEntry: `/training/${TRAINING_CAMPAIGN_ITEM_ID}`,
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /training document page/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the quiz page at /quizzes/:quizId', async () => {
+    renderAppRoutes({
+      initialEntry: `/quizzes/${QUIZ_CAMPAIGN_ITEM_ID}`,
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /quiz page/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the quiz results page at /quiz-attempts/:attemptId/results', async () => {
+    renderAppRoutes({
+      initialEntry: `/quiz-attempts/${ATTEMPT_ID}/results`,
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /quiz results/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('navigates from a campaign training item to the mounted frontend training route, not the backend activity path', async () => {
+    const user = userEvent.setup();
+    const backendTrainingApiPath = `/trainee/campaign-items/${TRAINING_CAMPAIGN_ITEM_ID}/training-document`;
+    const frontendTrainingPath = `/training/${TRAINING_CAMPAIGN_ITEM_ID}`;
+
+    mockedGetTraineeCampaignDetail.mockResolvedValueOnce({
+      campaignId: CAMPAIGN_ID,
+      name: 'Quarterly Awareness',
+      campaignType: 'PREMADE_GENERAL',
+      difficultyLevel: 'BEGINNER',
+      status: 'ACTIVE',
+      progressStatus: 'IN_PROGRESS',
+      items: [
+        {
+          campaignItemId: TRAINING_CAMPAIGN_ITEM_ID,
+          campaignId: CAMPAIGN_ID,
+          itemType: 'COMPONENT',
+          title: 'Read phishing warning signs',
+          position: 0,
+          isRequired: true,
+          availabilityStatus: 'AVAILABLE',
+          isOpenable: true,
+          progressStatus: 'NOT_STARTED',
+          componentType: 'TRAINING_DOCUMENT',
+          activityApiPath: backendTrainingApiPath,
+          trainingDocument: {
+            id: '44444444-4444-4444-8444-444444444441',
+            title: 'Phishing warning signs',
+            contentSummary: 'Learn how to spot suspicious messages.',
+            estimatedReadTimeMinutes: 4,
+            difficultyLevel: 'BEGINNER',
+            status: 'AVAILABLE',
+          },
+        },
+      ],
+    });
+
+    renderAppRoutes({
+      initialEntry: '/campaigns',
+    });
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /quarterly awareness/i,
+      }),
+    );
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /learn: "read phishing warning signs"/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-path')).toHaveTextContent(frontendTrainingPath);
+    });
+
+    expect(screen.getByTestId('location-path')).not.toHaveTextContent(backendTrainingApiPath);
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /training document page/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.exclusions=**/apps/backend/prisma/migrations/**/*.sql,apps/backend/prisma/migrations/**/*.sql,**/dist/**,**/build/**,**/coverage/**,pnpm-lock.yaml
-sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,**/*.test.js,**/tests/**,**/__tests__/**
+sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.test.js,**/tests/**,**/__tests__/**
 
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=*:S1590


### PR DESCRIPTION
## Summary

This PR expands Demo 1 frontend test coverage across the main learner-facing flows and app-level routing.

Changes include:
- added auth flow tests for login and registration validation, success, and error states
- added learner activity tests for simulated inbox and email detail behaviour
- expanded quiz and quiz results coverage, including loading, selection, submission, result, and error states
- added route-level `AppRoutes` smoke tests for mounted learner routes
- added a navigation regression test to ensure campaign items route to mounted SPA paths instead of backend API paths
- moved quiz API-specific assertions into a correctly named test file
- fixed test fixture typing/formatting so frontend checks pass cleanly

## Linked Issue

Closes #

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Chore/Maintenance

## Testing

The following checks were run:

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm --filter @insightful-phish/backend test:integration`
- [x] `pnpm --filter @insightful-phish/frontend build`

## Review Notes

Reviewers should focus on:

- whether the new tests cover the intended Demo 1 learner flows without duplicating too much page-level detail
- whether the route-level `AppRoutes` smoke tests correctly catch broken mounted routes
- whether the campaign-item navigation regression test protects against accidentally routing to backend API paths such as `/trainee/campaign-items/...`
- whether the mocks and fixtures stay aligned with the current frontend API contracts

No production frontend code was changed.

No Playwright or new test tooling was added.

## Checklist

- [x] I tested the change locally
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed