### PR TITLE
Chore/frontend test helpers/zoe

### DIFF
--- a/apps/frontend/src/pages/testing/ResultsPage.test.tsx
+++ b/apps/frontend/src/pages/testing/ResultsPage.test.tsx
@@ -1,12 +1,11 @@
-import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ResultsPage from '../ResultsPage';
 import { getQuizResult } from '../../lib/quizApi';
 import type { QuizResult } from '../../lib/quizApi';
+import { renderWithRouter } from '../../testing/render';
 
 vi.mock('../../components/layout/AppLayout', () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -48,38 +47,35 @@ const resultFixture: QuizResult = {
 };
 
 function createDeferred<T>() {
-  let resolve: (value: T) => void;
-  let reject: (reason?: unknown) => void;
+  let resolve: ((value: T) => void) | undefined;
+  let reject: ((reason?: unknown) => void) | undefined;
 
   const promise = new Promise<T>((promiseResolve, promiseReject) => {
     resolve = promiseResolve;
     reject = promiseReject;
   });
 
+  if (!resolve || !reject) {
+    throw new Error('Deferred promise handlers were not initialised');
+  }
+
   return {
     promise,
-    resolve: resolve!,
-    reject: reject!,
+    resolve,
+    reject,
   };
 }
 
 function renderResultsPage() {
-  return render(
-    <MemoryRouter initialEntries={[`/quiz-attempts/${attemptId}/results`]}>
-      <Routes>
-        <Route path="/quiz-attempts/:attemptId/results" element={<ResultsPage />} />
-      </Routes>
-    </MemoryRouter>,
-  );
+  return renderWithRouter(<ResultsPage />, {
+    initialEntry: `/quiz-attempts/${attemptId}/results`,
+    routePath: '/quiz-attempts/:attemptId/results',
+  });
 }
 
 describe('ResultsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   it('shows a loading state before quiz results resolve', async () => {

--- a/apps/frontend/src/routes/testing/AppRoutes.test.tsx
+++ b/apps/frontend/src/routes/testing/AppRoutes.test.tsx
@@ -1,9 +1,9 @@
-import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
-import { MemoryRouter, useLocation } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithRouter } from '../../testing/render';
 
 vi.mock('../../App', () => ({
   StatusPage: () => <h1>Status Page</h1>,
@@ -81,7 +81,6 @@ vi.mock('../../lib/campaignsApi', () => ({
 }));
 
 import AppRoutes from '../AppRoutes';
-import { AuthContext } from '../../context/auth-context';
 import { getTraineeCampaignDetail, getTraineeCampaigns } from '../../lib/campaignsApi';
 
 const mockedGetTraineeCampaigns = vi.mocked(getTraineeCampaigns);
@@ -105,9 +104,14 @@ function renderAppRoutes({
   initialEntry: string;
   isAuthenticated?: boolean;
 }) {
-  return render(
-    <AuthContext.Provider
-      value={{
+  return renderWithRouter(
+    <>
+      <LocationDisplay />
+      <AppRoutes />
+    </>,
+    {
+      initialEntry,
+      auth: {
         isAuthenticated,
         token: isAuthenticated ? 'demo-token' : null,
         user: isAuthenticated
@@ -117,15 +121,8 @@ function renderAppRoutes({
               email: 'trainee@example.com',
             }
           : null,
-        login: vi.fn(),
-        logout: vi.fn(),
-      }}
-    >
-      <MemoryRouter initialEntries={[initialEntry]}>
-        <LocationDisplay />
-        <AppRoutes />
-      </MemoryRouter>
-    </AuthContext.Provider>,
+      },
+    },
   );
 }
 
@@ -155,10 +152,6 @@ describe('AppRoutes', () => {
       progressStatus: 'IN_PROGRESS',
       items: [],
     });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   it('renders the login screen at /login', async () => {

--- a/apps/frontend/src/testing/render.tsx
+++ b/apps/frontend/src/testing/render.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { AuthContext, type AuthContextType } from '../context/auth-context';
+
+type RenderWithRouterOptions = {
+  initialEntry?: string;
+  routePath?: string;
+  auth?: Partial<AuthContextType>;
+};
+
+export function createAuthContextValue(overrides: Partial<AuthContextType> = {}): AuthContextType {
+  const isAuthenticated = overrides.isAuthenticated ?? true;
+
+  return {
+    isAuthenticated,
+    token: isAuthenticated ? 'test-token' : null,
+    user: isAuthenticated
+      ? {
+          firstName: 'Test',
+          lastName: 'User',
+          email: 'test@example.com',
+        }
+      : null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function renderWithRouter(
+  ui: ReactElement,
+  { initialEntry = '/', routePath, auth }: RenderWithRouterOptions = {},
+) {
+  const routedUi = routePath ? (
+    <Routes>
+      <Route path={routePath} element={ui} />
+    </Routes>
+  ) : (
+    ui
+  );
+
+  const wrappedUi =
+    auth === undefined ? (
+      routedUi
+    ) : (
+      <AuthContext.Provider value={createAuthContextValue(auth)}>{routedUi}</AuthContext.Provider>
+    );
+
+  return render(<MemoryRouter initialEntries={[initialEntry]}>{wrappedUi}</MemoryRouter>);
+}

--- a/apps/frontend/src/testing/setupTests.ts
+++ b/apps/frontend/src/testing/setupTests.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   ],
   test: {
     environment: 'jsdom',
+    setupFiles: ['./src/testing/setupTests.ts'],
     coverage: {
       reporter: ['text', 'json', 'html', 'lcov', 'json-summary'],
     },


### PR DESCRIPTION
## Summary

* added a shared frontend Vitest setup file for common Testing Library setup and cleanup
* added reusable frontend render helpers for router/auth-heavy tests
* migrated representative route tests to use the shared helper pattern

This reduces repeated setup boilerplate in frontend tests and prepares the test structure needed before the Playwright/axe work in #164.

## Linked Issue

Closes #163
Related to #164

## Type of change

* [ ] Feature
* [ ] Bug Fix
* [ ] Documentation
* [x] Chore/Maintenance

## Testing

* `pnpm --filter @insightful-phish/frontend test`
* `pnpm --filter @insightful-phish/frontend typecheck`
* `pnpm lint:frontend`
* `pnpm format:check`

## Review Notes

Please focus on whether the shared test setup and render helpers are small, readable, and appropriate for future frontend route/auth/layout-heavy tests.

Notes:

* no application behaviour was changed
* fetch, storage, auth, and component mocks remain local to individual tests
* only representative tests were migrated; this PR intentionally does not rewrite the full frontend test suite
* this PR closes #163 and unblocks follow-up Playwright/axe setup work in #164

## Checklist

* [x] I tested the change locally
* [x] No unrelated changes are included
* [x] Relevant tests were added or updated if applicable
* [x] Documentation was updated if needed
* [x] No secrets, credentials, or sensitive values were committed
