### PR TITLE
Chore/sonarqube reporting/johan

### DIFF
--- a/apps/backend/src/middleware/validateRequest.ts
+++ b/apps/backend/src/middleware/validateRequest.ts
@@ -23,26 +23,6 @@ export function validateBody<T>(schema: ZodSchema<T>) {
   };
 }
 
-export function validateParams<T>(schema: ZodSchema<T>) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const result = schema.safeParse(req.params);
-
-    if (!result.success) {
-      return res.status(400).json({
-        error: 'VALIDATION_ERROR',
-        message: 'Invalid request parameters',
-        details: result.error.issues.map((issue) => ({
-          field: issue.path.join('.'),
-          message: issue.message,
-        })),
-      });
-    }
-
-    req.params = result.data as Request['params'];
-    return next();
-  };
-}
-
 // Helper function to check if an error is a ZodError.. if it is we can handle it in a centralized error handler
 export function isZodError(error: unknown): error is ZodError {
   return error instanceof ZodError;

--- a/apps/backend/src/routes/quiz.routes.ts
+++ b/apps/backend/src/routes/quiz.routes.ts
@@ -2,7 +2,8 @@ import { Router } from 'express';
 import { getQuiz, startAttempt, submitAttempt, getResult } from '../controllers/quiz.controller.js';
 import { requireAuth } from '../middleware/requireAuth.js';
 import { authRateLimit } from '../middleware/authRateLimit.js';
-import { validateBody, validateParams } from '../middleware/validateRequest.js';
+import { validateParams } from '../middleware/validateParams.js';
+import { validateBody } from '../middleware/validateRequest.js';
 import {
   getQuizRequestParamsSchema,
   startQuizAttemptRequestParamsSchema,

--- a/apps/backend/src/routes/trainee-campaign.routes.ts
+++ b/apps/backend/src/routes/trainee-campaign.routes.ts
@@ -5,7 +5,7 @@ import {
   listTraineeCampaigns,
 } from '../controllers/trainee-campaign.controller.js';
 import { requireAuth } from '../middleware/requireAuth.js';
-import { validateParams } from '../middleware/validateRequest.js';
+import { validateParams } from '../middleware/validateParams.js';
 
 export const traineeCampaignRouter = Router();
 

--- a/apps/backend/src/routes/trainee.routes.ts
+++ b/apps/backend/src/routes/trainee.routes.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import { SimulationController } from '../controllers/simulation.controller.js';
 import { requireAuth } from '../middleware/requireAuth.js';
-import { validateBody, validateParams } from '../middleware/validateRequest.js';
+import { validateBody } from '../middleware/validateRequest.js';
+import { validateParams } from '../middleware/validateParams.js';
 import { traineeCampaignRouter } from './trainee-campaign.routes.js';
 import {
   classifySimulatedEmailRequestSchema,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
-sonar.exclusions=**/apps/backend/prisma/migrations/**/*.sql,apps/backend/prisma/migrations/**/*.sql,**/dist/**,**/build/**,**/coverage/**,pnpm-lock.yaml
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/test-results*.xml,**/*.junit.xml,apps/backend/src/generated/**,apps/backend/prisma/migrations/**,pnpm-lock.yaml
+
 sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.test.js,**/tests/**,**/__tests__/**
 
 sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=*:S1590
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/apps/backend/prisma/migrations/**/*.sql

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,3 @@
 sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/test-results*.xml,**/*.junit.xml,apps/backend/src/generated/**,apps/backend/prisma/migrations/**,pnpm-lock.yaml
 
 sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.test.js,**/tests/**,**/__tests__/**
-
-sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/apps/backend/prisma/migrations/**/*.sql


### PR DESCRIPTION
## Summary

Improves SonarQube reporting configuration and signal quality by excluding generated and non-source outputs from analysis while keeping meaningful backend, frontend, shared package, and script findings visible.

Changes include:
* Refined `sonar-project.properties` exclusions for generated and non-source artifacts.
* Excluded generated Prisma client files, Prisma migrations, build outputs, coverage outputs, dependency folders, lockfiles, and test-result artifacts from Sonar analysis.
* Reviewed duplicate-code exclusions and kept them limited to test/spec files.
* Fixed the duplicated validateParams middleware implementation by consolidating it into a single source of truth.
* Verified that Swagger/OpenAPI configuration remains visible to Sonar rather than being broadly excluded.
* Confirmed that backend, frontend, shared package, and script source files remain visible to Sonar analysis.
* Reviewed SonarQube’s relationship to ESLint, TypeScript, testing, and Codecov reporting.

## Linked Issue

Closes #175

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Chore/Maintenance

## Testing

Verified:
* SonarQube configuration changes.
* Validation middleware import paths.
* Duplicate-code exclusion patterns still apply only to tests/specs.
* No backend, frontend, shared package, or script source directories were broadly excluded.
* Existing CI quality gates remain unchanged.

The following was ran and all passed:
```
pnpm lint
pnpm typecheck
pnpm test
pnpm build
```

## Review Notes

Nothing of note really... just check if the de-duplication of validateParams looks good. 

<!-- See who to request for review at the bottom of the PR template -->

## Checklist

- [x] I tested the change locally
- [x] No unrelated changes are included
- [ ] Relevant tests were added or updated if applicable (N/A)
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed

<!-- WHO TO REQUEST FOR REVIEW -->
<!-- * Frontend/UI/UX/Styling: Connor or Zoë -->
<!-- * Backend/API/System Logic: Adriano or Rudolph -->
<!-- * Database/Prisma/Models: Adriano or Johan -->
<!-- * Testing/Validation/QA: Zoë -->
<!-- * Repo/DevOps/CI/CD/Actions: Johan -->
<!-- * Documentation/Diagrams: Johan and -->
<!--                         : Connor for Design/Brand -->
<!--                         : Zoë for SRS -->
<!--                         : Rudolph for API/Architecture -->
<!--                         : Adriano for Domain Model -->
