### PR TITLE
Chore/production auth secret/johan

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -6,6 +6,7 @@ TEST_DATABASE_URL="postgresql://insightful_phish:insightful_phish@localhost:5432
 
 FRONTEND_ORIGIN="http://localhost:5173"
 
+# Do not use this secret token in production. Change it to a secure random string before deploying to production.
 AUTH_TOKEN_SECRET="this-is-a-demo-auth-secret-token-change-before-production"
 AUTH_TOKEN_EXPIRES_IN_SECONDS=28800
 

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -3,15 +3,32 @@ import { z } from 'zod';
 
 dotenv.config();
 
+const DEMO_AUTH_TOKEN_SECRET = 'this-is-a-demo-auth-secret-token-change-before-production';
+
 const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().default(4000),
   DATABASE_URL: z.string().min(1),
   FRONTEND_ORIGIN: z.string().default('http://localhost:5173'),
-  AUTH_TOKEN_SECRET: z.string().min(32).default('this-is-a-demo-auth-secret-token-change-before-production'),
+  AUTH_TOKEN_SECRET: z.string().default(DEMO_AUTH_TOKEN_SECRET),
   AUTH_TOKEN_EXPIRES_IN_SECONDS: z.coerce.number().default(60 * 60 * 8),
   AUTH_RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60 * 1000),
   AUTH_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().default(5),
+}).superRefine((value, context) => {
+  if (value.NODE_ENV !== 'production') { //If we are not in production, we can use the demo auth token secret
+    return;
+  }
+
+if (value.AUTH_TOKEN_SECRET === DEMO_AUTH_TOKEN_SECRET) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'AUTH_TOKEN_SECRET must be changed before deploying to production',
+    });
+  }
 });
+
+export function parseEnv(input: NodeJS.ProcessEnv) {
+  return EnvSchema.parse(input);
+}
 
 export const env = EnvSchema.parse(process.env);

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -10,7 +10,7 @@ const EnvSchema = z.object({
   PORT: z.coerce.number().default(4000),
   DATABASE_URL: z.string().min(1),
   FRONTEND_ORIGIN: z.string().default('http://localhost:5173'),
-  AUTH_TOKEN_SECRET: z.string().default(DEMO_AUTH_TOKEN_SECRET),
+  AUTH_TOKEN_SECRET: z.string().min(32).default(DEMO_AUTH_TOKEN_SECRET),
   AUTH_TOKEN_EXPIRES_IN_SECONDS: z.coerce.number().default(60 * 60 * 8),
   AUTH_RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60 * 1000),
   AUTH_RATE_LIMIT_MAX_REQUESTS: z.coerce.number().default(5),
@@ -19,7 +19,7 @@ const EnvSchema = z.object({
     return;
   }
 
-if (value.AUTH_TOKEN_SECRET === DEMO_AUTH_TOKEN_SECRET) {
+  if (value.AUTH_TOKEN_SECRET === DEMO_AUTH_TOKEN_SECRET) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
       message: 'AUTH_TOKEN_SECRET must be changed before deploying to production',
@@ -31,4 +31,4 @@ export function parseEnv(input: NodeJS.ProcessEnv) {
   return EnvSchema.parse(input);
 }
 
-export const env = EnvSchema.parse(process.env);
+export const env = parseEnv(process.env);

--- a/apps/backend/tests/unit/config-env.test.ts
+++ b/apps/backend/tests/unit/config-env.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnv } from '../../src/config/env.js';
+
+const baseEnv = {
+  DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/insightful_phish_test',
+};
+
+describe('parseEnv', () => {
+  it('allows demo auth token in development', () => {
+    const env = parseEnv({ ...baseEnv, NODE_ENV: 'development' });
+    expect(env.AUTH_TOKEN_SECRET).toBe('this-is-a-demo-auth-secret-token-change-before-production');
+  });
+
+  it('rejects demo auth token in production', () => {
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        NODE_ENV: 'production',
+        AUTH_TOKEN_SECRET: 'this-is-a-demo-auth-secret-token-change-before-production',
+      }),
+    ).toThrowError('AUTH_TOKEN_SECRET must be changed before deploying to production');
+  });
+
+  it('accepts a non-demo auth token in production', () => {
+    const env = parseEnv({
+      ...baseEnv,
+      NODE_ENV: 'production',
+      AUTH_TOKEN_SECRET: 'this-is-a-non-demo-auth-secret-token',
+    });
+    expect(env.AUTH_TOKEN_SECRET).toBe('this-is-a-non-demo-auth-secret-token');
+  });
+});

--- a/apps/backend/tests/unit/config-env.test.ts
+++ b/apps/backend/tests/unit/config-env.test.ts
@@ -29,4 +29,57 @@ describe('parseEnv', () => {
     });
     expect(env.AUTH_TOKEN_SECRET).toBe('this-is-a-non-demo-auth-secret-token');
   });
+
+  it('allows demo secret token in test environment', () => {
+    const env = parseEnv({ ...baseEnv, NODE_ENV: 'test' });
+    expect(env.AUTH_TOKEN_SECRET).toBe('this-is-a-demo-auth-secret-token-change-before-production');
+  });
+
+  it('defaults to development if no NODE_ENV is set', () => {
+    const env = parseEnv(baseEnv);
+    expect(env.NODE_ENV).toBe('development');
+  });
+
+  it('rejects missing AUTH_TOKEN_SECRET in production', () => {
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        NODE_ENV: 'production',
+      }),
+    ).toThrowError('AUTH_TOKEN_SECRET must be changed before deploying to production');
+  });
+
+  it('rejects too short auth token secret in all environment', () => {
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        NODE_ENV: 'production',
+        AUTH_TOKEN_SECRET: 'short',
+      }),
+    ).toThrowError('String must contain at least 32 character(s)');
+
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        NODE_ENV: 'development',
+        AUTH_TOKEN_SECRET: 'short',
+      }),
+    ).toThrowError('String must contain at least 32 character(s)');
+
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        NODE_ENV: 'test',
+        AUTH_TOKEN_SECRET: 'short',
+      }),
+    ).toThrowError('String must contain at least 32 character(s)');
+  });
+
+  it('requires DATABASE_URL', () => {
+    expect(() =>
+      parseEnv({
+        NODE_ENV: 'development',
+      }),
+    ).toThrow(/DATABASE_URL/);
+  });
 });


### PR DESCRIPTION
## Summary

Hardened backend environment validation so `NODE_ENV=production` cannot silently use the demo auth token secret.

The backend still keeps the demo auth token secret as a convenient local/test default, but production now requires an explicit non-demo secret with the existing minimum length validation.

## Linked Issue

Closes #169 

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Chore/Maintenance

## Testing

All tests bass locally

## Review Notes

Behaviour after this change:
- `NODE_ENV=development`: may use the demo auth token secret by default.
- `NODE_ENV=test`: may use the demo auth token secret by default.
- missing `NODE_ENV`: defaults to development and may use the demo auth token secret.
- `NODE_ENV=production`: rejects a missing/default demo auth token secret and requires an explicit non-demo value.
- Explicit auth token secrets still need at least 32 characters.

The `.env.example` file keeps the demo value for local onboarding, but now warns that it must not be used in production.

## Checklist

- [x] I tested the change locally
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed