### PR TITLE
Chore/backend sonar cleanup/adriano

### DIFF
--- a/apps/backend/scripts/copy-training-content.mjs
+++ b/apps/backend/scripts/copy-training-content.mjs
@@ -9,7 +9,7 @@ async function ensureSourceExists() {
   try {
     await access(sourceDir, constants.R_OK);
   } catch (error) {
-    throw new Error(`Training content source directory not found: ${sourceDir}`);
+    throw new Error(`Training content source directory not found: ${sourceDir}`, { cause: error });
   }
 }
 

--- a/apps/backend/src/services/content-resolver.service.ts
+++ b/apps/backend/src/services/content-resolver.service.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'node:fs/promises';
 
 export class TrainingContentResolveError extends Error {
-  constructor(message = 'Training content could not be loaded') {
-    super(message);
+  constructor(message = 'Training content could not be loaded', options?: ErrorOptions) {
+    super(message, options);
     this.name = 'TrainingContentResolveError';
   }
 }
@@ -40,7 +40,7 @@ export async function resolveContent(
 
   try {
     return await readFile(contentUrl, 'utf8');
-  } catch (_error) {
-    throw new TrainingContentResolveError();
+  } catch (error) {
+    throw new TrainingContentResolveError(undefined, { cause: error });
   }
 }

--- a/apps/backend/src/services/simulation.service.ts
+++ b/apps/backend/src/services/simulation.service.ts
@@ -329,7 +329,7 @@ export class SimulationService {
     }
 
     // Validate red flags
-    if (input.selectedRedFlagIds && input.selectedRedFlagIds.length > 0) {
+    if (input.selectedRedFlagIds?.length) {
       const validRedFlagIds = new Set(email.redFlags.map((rf: any) => rf.id));
       const invalidFlags = input.selectedRedFlagIds.filter((id) => !validRedFlagIds.has(id));
       if (invalidFlags.length > 0) {

--- a/apps/backend/tests/helpers/auth.ts
+++ b/apps/backend/tests/helpers/auth.ts
@@ -1,0 +1,8 @@
+import request from 'supertest';
+import { createApp } from '../../src/app.js';
+
+export const testUserPassword = ['pass', 'word'].join('');
+
+export async function loginTestUser(email: string) {
+  return await request(createApp()).post('/auth/login').send({ email, password: testUserPassword });
+}

--- a/apps/backend/tests/integration/access-control.integration.test.ts
+++ b/apps/backend/tests/integration/access-control.integration.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { loginTestUser } from '../helpers/auth.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createApp } from '../../src/app.js';
 import { clearAuthRateLimitStore } from '../../src/middleware/authRateLimit.js';
@@ -111,20 +112,10 @@ describe('Access Control and Negative Integration Tests', () => {
     });
 
     // 8. Log in both trainees to retrieve JWT tokens
-    const loginA = await request(createApp())
-      .post('/auth/login')
-      .send({
-        email: traineeA.user.email,
-        password: ['pass', 'word'].join(''),
-      });
+    const loginA = await loginTestUser(traineeA.user.email);
     const tokenA = loginA.body.token;
 
-    const loginB = await request(createApp())
-      .post('/auth/login')
-      .send({
-        email: traineeB.user.email,
-        password: ['pass', 'word'].join(''),
-      });
+    const loginB = await loginTestUser(traineeB.user.email);
     const tokenB = loginB.body.token;
 
     return {

--- a/apps/backend/tests/integration/auth.integration.test.ts
+++ b/apps/backend/tests/integration/auth.integration.test.ts
@@ -2,10 +2,10 @@ import request from 'supertest';
 import { describe, expect, it } from 'vitest';
 import { createApp } from '../../src/app.js';
 import { prisma } from '../../src/lib/prisma.js';
-import { createTrainee } from '../helpers/factories.js';
 import { verifyPassword } from '../../src/services/password.service.js';
+import { loginTestUser, testUserPassword } from '../helpers/auth.js';
+import { createTrainee } from '../helpers/factories.js';
 
-const testUserPassword = ['pass', 'word'].join('');
 const secureRegisterPassword = ['Secure', 'Password', '123!'].join('');
 
 describe('Auth Integration Tests', () => {
@@ -90,10 +90,7 @@ describe('Auth Integration Tests', () => {
       },
     });
 
-    const loginResponse = await request(createApp()).post('/auth/login').send({
-      email,
-      password: testUserPassword,
-    });
+    const loginResponse = await loginTestUser(email);
 
     const token = loginResponse.body.token;
 

--- a/apps/backend/tests/integration/uc01-inbox.integration.test.ts
+++ b/apps/backend/tests/integration/uc01-inbox.integration.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { loginTestUser } from '../helpers/auth.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createApp } from '../../src/app.js';
 import { prisma } from '../../src/lib/prisma.js';
@@ -63,12 +64,7 @@ describe('UC-01 Simulated Inbox Integration Tests', () => {
     });
 
     // Login to get token
-    const loginResponse = await request(createApp())
-      .post('/auth/login')
-      .send({
-        email: user.email,
-        password: ['pass', 'word'].join(''),
-      });
+    const loginResponse = await loginTestUser(user.email);
 
     expect(loginResponse.status).toBe(200);
     expect(loginResponse.body.token).toBeDefined();
@@ -213,12 +209,7 @@ describe('UC-01 Simulated Inbox Integration Tests', () => {
       traineeProfileId: otherTraineeProfile.id,
     });
 
-    const otherLoginResponse = await request(createApp())
-      .post('/auth/login')
-      .send({
-        email: otherUser.email,
-        password: ['pass', 'word'].join(''),
-      });
+    const otherLoginResponse = await loginTestUser(otherUser.email);
 
     expect(otherLoginResponse.status).toBe(200);
     expect(otherLoginResponse.body.token).toBeDefined();

--- a/apps/backend/tests/integration/uc02-training.integration.test.ts
+++ b/apps/backend/tests/integration/uc02-training.integration.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { loginTestUser } from '../helpers/auth.js';
 import { readFile } from 'node:fs/promises';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createApp } from '../../src/app.js';
@@ -68,12 +69,7 @@ describe('UC-02 Training Document Integration Tests', () => {
       traineeProfileId: traineeProfile.id,
     });
 
-    const loginResponse = await request(createApp())
-      .post('/auth/login')
-      .send({
-        email: user.email,
-        password: ['pass', 'word'].join(''),
-      });
+    const loginResponse = await loginTestUser(user.email);
 
     token = loginResponse.body.token;
     campaignItemId = campaignItem.id;

--- a/apps/backend/tests/integration/uc03-quiz.integration.test.ts
+++ b/apps/backend/tests/integration/uc03-quiz.integration.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { loginTestUser } from '../helpers/auth.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { clearAuthRateLimitStore } from '../../src/middleware/authRateLimit.js';
 import { createApp } from '../../src/app.js';
@@ -74,12 +75,7 @@ describe('UC-03 Quiz Integration Tests', () => {
     });
 
     // Login to get token
-    const loginResponse = await request(createApp())
-      .post('/auth/login')
-      .send({
-        email: user.email,
-        password: ['pass', 'word'].join(''),
-      });
+    const loginResponse = await loginTestUser(user.email);
 
     const token = loginResponse.body.token;
 


### PR DESCRIPTION
## Summary

* fixed selected low-risk backend Sonar findings without changing service behaviour
* cleaned up shared package campaign code where safe
* made small backend service maintainability improvements such as optional chaining, unnecessary assertion cleanup, and readonly member updates
* improved explicit error handling in backend script code where needed
* kept the cleanup focused and avoided broad service rewrites or feature refactors

## Linked Issue

Closes #172 

## Type of change

* [ ] Feature
* [x] Bug Fix
* [ ] Documentation / Config / Chore
* [ ] Tests

## Testing

Ran or verified:

* `pnpm lint:backend`
* `pnpm lint:shared`
* `pnpm lint`
* `pnpm typecheck`
* `pnpm test`
* `pnpm format:check`

## Review Notes

This PR intentionally focuses only on selected low-risk Sonar findings in backend, shared, scripts, and backend test areas.

The changes are maintainability-focused and should not alter existing API behaviour, service flow, seed behaviour, or test setup behaviour.

The high-complexity `quiz.service` refactor is intentionally out of scope for this issue. No new auth/admin features or broad backend rewrites are included.

Exception-handling changes were kept explicit. Errors are either handled with clearer context or unnecessary catch blocks were avoided rather than silently swallowing failures.

## Checklist

* [x] I tested the change locally
* [x] No unrelated changes are included
* [x] Selected low-risk Sonar findings are resolved
* [x] No high-complexity feature refactor is included
* [x] Backend/shared behaviour remains stable
* [x] Existing tests remain stable
* [x] No new auth/admin functionality was added
* [x] No broad service rewrites were introduced
* [x] No secrets, credentials, or sensitive values were committed
