### PR TITLE
Docs/migration strategy/adriano

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -199,7 +199,7 @@ Use this compact path when starting from a clean checkout for local Demo 1 rehea
 
 From the repo root:
 
-```bash
+````bash
 pnpm install
 cp apps/backend/.env.example apps/backend/.env
 cp apps/frontend/.env.example apps/frontend/.env
@@ -207,13 +207,13 @@ docker compose up -d
 pnpm --filter @insightful-phish/backend prisma:generate
 pnpm --filter @insightful-phish/backend prisma:migrate:deploy
 DEMO_SEED_PASSWORD="your-local-demo-password" pnpm --filter @insightful-phish/backend seed:demo1
-```
+pnpm --filter @insightful-phish/backend dev
 
 Then start the backend:
 
 ```bash
 pnpm --filter @insightful-phish/backend dev
-```
+````
 
 In another terminal, start the frontend:
 

--- a/apps/backend/DATABASE.md
+++ b/apps/backend/DATABASE.md
@@ -1,0 +1,27 @@
+# Backend database strategy
+
+this document will guide the prisma migration startegy before sprint 4 and onwards. This will handle real persistant organisation data
+
+## our current migraion sequence
+
+Committed migrations live in [prisma/migrations](prisma/migrations) and currently apply in this order:
+
+1. `20260426140517_init`
+2. `20260511143154_demo1_access_context`
+3. `20260511144409_demo1_campaign_training`
+4. `20260511151647_demo1_quiz_interactions`
+5. `20260511185349_demo1_final_review_cleanup`
+6. `20260511204248_demo1_review_adjustments`
+7. `20260512120000_user_first_last_name`
+8. `20260513205654_modular_campaign_domain_model`
+9. `20260515110000_rename_learner_to_trainee`
+
+Please do not squash, rename, delete, or rewrite any old commited migrations. Treat them as the version controlled database history.
+
+## creating the future schema changes:
+
+The future schema changes should start in [prisma/migrations](prisma/migrations), and then create a new migration with:
+
+(in powershell)
+
+pnpm --filter @insightful-phish/backend prisma:migrate --name <migration-name>

--- a/apps/backend/SEEDING.md
+++ b/apps/backend/SEEDING.md
@@ -17,6 +17,25 @@ The Demo 1 seed creates repeatable local data for:
 
 The seed is designed for local Demo 1 development only.
 
+## Seed Responsobilities
+
+Local dev seed data is for repeatable dev workflows only. It should make the app usable after migrations without pretending to be production data.
+
+The current seed command creates demo 1 data through [prisma/seed.ts](prisma/seed.ts) and [prisma/seed-data](prisma/seed-data). It only serves for demo purposes not in a real world context yet.
+
+The demo seed data should stay deterministic and obviously be safe to rerun. It should use stable demo id's and known demo emails so it can update demo owned records without duplicating records.
+
+Integration tests should prefer factories and test setup over demo seed assumptions. Dont require 'seed:demo1' before running the integration tests.
+
+Sprint 4+ organisation/admin seed data should be added. Organisation seeds should distinguish between:
+
+- demo orgs for a local walkthrough
+- local admin accounts needed for dev
+- test records created by factories
+- any future persistent org data
+
+Do not seed real customer, org, invitation, domain, assignment, or reporting data through the demo seed.
+
 ## Demo-Only Credentials
 
 These credentials are for local Demo 1 development only and must not be used in production.
@@ -173,12 +192,23 @@ DATABASE_URL="postgresql://insightful_phish:insightful_phish@localhost:5432/insi
 
 The seed script does not truncate tables, drop the database, or wipe all users. It targets stable demo identifiers and known demo emails so unrelated data is left alone.
 
+## Safe Reset, Migrate, and Seed Commands
+
+For a normal local dev db, apply committed migrations and run the demo seed only when the demo data is needed:
+
+````powershell
+docker compose up -d
+pnpm --filter @insightful-phish/backend prisma:generate
+pnpm --filter @insightful-phish/backend prisma:migrate:deploy
+$env:DEMO_SEED_PASSWORD = "your-local-demo-password"
+pnpm --filter @insightful-phish/backend seed:demo1
+
 ## Viewing Seeded Data
 
 Use Prisma Studio to browse the local database in a web UI:
 
 ```bash
 pnpm --filter @insightful-phish/backend prisma:studio
-```
+````
 
 If the browser does not open automatically, use the local URL printed by the command.

--- a/apps/backend/TESTING.md
+++ b/apps/backend/TESTING.md
@@ -6,6 +6,14 @@ Database-backed Vitest and Supertest tests use a dedicated PostgreSQL test datab
 
 Unit tests remain separate from integration tests. Integration tests are the only tests wired to the database cleanup setup.
 
+## Test Data Strategy
+
+Integration tests use a dedicated PostgreSQL test database. They should create the records that they need through the test setup and factories.
+
+Do not make the integration tests depend on Demo 1 seed data. Demo seed data is only for local demo walkthroughs, while integration tests need isolated records that are the reset between the tests.
+
+Unit tests may import demo seed constants or helpers only when testing the seef config and summary behaviour. This does not mean that the integration db should be preloaded with demo data.
+
 ## Required Environment Variables
 
 Normal backend development uses `DATABASE_URL` and should point to the development database:
@@ -135,3 +143,17 @@ The truncate helper:
 - Uses `CASCADE` so related rows are cleaned without maintaining a fragile delete order
 
 After all integration tests finish, `disconnectTestPrisma()` calls `prisma.$disconnect()`.
+
+## Safe Test Database Commands
+
+Please use a dedicated test db whose name contains 'test':
+
+```powershell
+docker compose up -d
+docker compose exec postgres createdb -U insightful_phish insightful_phish_test
+$env:TEST_DATABASE_URL = "postgresql://insightful_phish:insightful_phish@localhost:5432/insightful_phish_test"
+$env:DATABASE_URL = $env:TEST_DATABASE_URL
+pnpm --filter @insightful-phish/backend prisma:generate
+pnpm --filter @insightful-phish/backend exec prisma migrate deploy
+pnpm --filter @insightful-phish/backend test:integration
+```


### PR DESCRIPTION
## Summary

* documented the backend migration strategy and future schema review expectations
* documented local, development, demo, and test database seeding responsibilities
* clarified that integration tests should rely on factories/test setup instead of Demo 1 seed assumptions
* documented safe reset, migrate, generate, and seed command expectations
* clarified that `apps/backend/src/generated/prisma` is generated Prisma output and must not be hand-edited
* updated setup guidance with the expected database setup order for local development

## Linked Issue

Closes #185 

## Type of change

* [ ] Feature
* [ ] Bug Fix
* [x] Documentation / Config / Chore
* [ ] Tests

## Testing

Verified documentation-only changes with:

* `git diff --stat`
* `git diff --check`
* `git status --short`

## Review Notes

This PR is documentation-only. It reviews and documents the current migration, test database, and seeding strategy before Sprint 4+ introduces more persistent organisation/admin data.

No Prisma schema changes, migration changes, seed implementation changes, test implementation changes, or production database operations are included.

The documentation calls out the risk of destructive resets once real persistent organisation data exists, and keeps destructive reset guidance limited to local, development, and test databases.

It also clarifies that future schema work touching organisation, invitation, domain, assignment, or reporting models should receive careful migration review before merging.

## Checklist

* [x] I tested the change locally
* [x] Documentation-only change
* [x] Migration strategy is documented
* [x] Test database strategy is documented
* [x] Seed strategy is documented
* [x] Real persistent data risks are noted
* [x] Generated Prisma client expectations are documented
* [x] No schema changes are included
* [x] No migration files were changed
* [x] No seed code was changed
* [x] No test implementation was changed
* [x] No production database operations are included
* [x] No secrets, credentials, or sensitive values were committed
