### PR TITLE
Feature/auth db foundation/adriano

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,5 @@ DEMO_SEED_PASSWORD=change-me-local-demo-password
 
 # Optional first platform super-admin bootstrap for local development.
 AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL=admin@example.com
-AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD=change-me-local-super-admin-password
+AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD=
 AUTH_BOOTSTRAP_SUPER_ADMIN_NAME=Platform Admin

--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ VITE_API_BASE_URL=http://localhost:4000
 
 # Only needed when running the Demo 1 seed locally.
 DEMO_SEED_PASSWORD=change-me-local-demo-password
+
+# Optional first platform super-admin bootstrap for local development.
+AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL=admin@example.com
+AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD=change-me-local-super-admin-password
+AUTH_BOOTSTRAP_SUPER_ADMIN_NAME=Platform Admin

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -24,5 +24,5 @@ AUTH_RATE_LIMIT_MAX_REQUESTS=20
 
 # Optional first platform super-admin bootstrap.
 # AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL="admin@example.com"
-# AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD="change-me-local-super-admin-password"
+# AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD=""
 # AUTH_BOOTSTRAP_SUPER_ADMIN_NAME="Platform Admin"

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -20,3 +20,9 @@ AUTH_RATE_LIMIT_MAX_REQUESTS=20
 
 # Only needed when running the Demo 1 seed locally.
 # DEMO_SEED_PASSWORD="change-me-local-demo-password"
+
+
+# Optional first platform super-admin bootstrap.
+# AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL="admin@example.com"
+# AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD="change-me-local-super-admin-password"
+# AUTH_BOOTSTRAP_SUPER_ADMIN_NAME="Platform Admin"

--- a/apps/backend/prisma/migrations/20260622092219_auth_db_foundation/migration.sql
+++ b/apps/backend/prisma/migrations/20260622092219_auth_db_foundation/migration.sql
@@ -1,0 +1,257 @@
+-- CreateEnum
+CREATE TYPE "PlatformAdminRole" AS ENUM ('SUPER_ADMIN', 'NORMAL_ADMIN');
+
+-- CreateEnum
+CREATE TYPE "AuthSessionRevokedReason" AS ENUM ('LOGOUT', 'LOGOUT_ALL', 'PASSWORD_RESET', 'PASSWORD_CHANGE', 'EMAIL_CHANGE', 'ADMIN_DISABLED', 'ORGANISATION_SUSPENDED', 'TOKEN_REUSE_DETECTED', 'EXPIRED', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "RefreshTokenRevokedReason" AS ENUM ('ROTATED', 'LOGOUT', 'LOGOUT_ALL', 'PASSWORD_RESET', 'PASSWORD_CHANGE', 'EMAIL_CHANGE', 'TOKEN_REUSE_DETECTED', 'EXPIRED', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "ActionTokenPurpose" AS ENUM ('EMAIL_VERIFICATION', 'PASSWORD_RESET', 'EMAIL_CHANGE_VERIFICATION', 'INITIAL_ORGANISATION_ADMIN_SETUP', 'ORGANISATION_TRAINEE_INVITE', 'ORGANISATION_ADMIN_PROMOTION', 'PLATFORM_ADMIN_INVITE', 'PLATFORM_ADMIN_UPGRADE_CONFIRMATION');
+
+-- CreateEnum
+CREATE TYPE "EmailDeliveryType" AS ENUM ('EMAIL_VERIFICATION', 'PASSWORD_RESET', 'PASSWORD_CHANGED', 'EMAIL_CHANGE_CONFIRMATION', 'EMAIL_CHANGE_WARNING', 'ORGANISATION_REQUEST_RECEIVED', 'ORGANISATION_REQUEST_APPROVED', 'ORGANISATION_REQUEST_REJECTED', 'INITIAL_ORGANISATION_ADMIN_SETUP', 'ORGANISATION_TRAINEE_INVITE', 'ORGANISATION_ADMIN_PROMOTION_INVITE', 'PLATFORM_ADMIN_INVITE', 'PLATFORM_ADMIN_UPGRADE_CONFIRMATION', 'ROLE_CHANGED_NOTIFICATION');
+
+-- CreateEnum
+CREATE TYPE "EmailRelatedEntityType" AS ENUM ('USER', 'INVITATION', 'ACTIONTOKEN', 'ORGANISATION_REGISTRATION_REQUEST', 'EMAIL_CHANGE_REQUEST', 'ORGANISATION', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "EmailDeliveryStatus" AS ENUM ('PENDING', 'SENT', 'FAILED');
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "AdminStatus_new" AS ENUM ('ACTIVE', 'DISABLED');
+ALTER TABLE "public"."IpAdminProfile" ALTER COLUMN "adminStatus" DROP DEFAULT;
+ALTER TABLE "public"."OrganisationAdminProfile" ALTER COLUMN "adminStatus" DROP DEFAULT;
+ALTER TABLE "OrganisationAdminProfile" ALTER COLUMN "adminStatus" TYPE "AdminStatus_new" USING (
+    CASE "adminStatus"::text
+        WHEN 'INACTIVE' THEN 'DISABLED'
+        ELSE "adminStatus"::text
+    END::"AdminStatus_new"
+);
+ALTER TABLE "IpAdminProfile" ALTER COLUMN "adminStatus" TYPE "AdminStatus_new" USING (
+    CASE "adminStatus"::text
+        WHEN 'INACTIVE' THEN 'DISABLED'
+        ELSE "adminStatus"::text
+    END::"AdminStatus_new"
+);
+ALTER TYPE "AdminStatus" RENAME TO "AdminStatus_old";
+ALTER TYPE "AdminStatus_new" RENAME TO "AdminStatus";
+DROP TYPE "public"."AdminStatus_old";
+ALTER TABLE "IpAdminProfile" ALTER COLUMN "adminStatus" SET DEFAULT 'ACTIVE';
+ALTER TABLE "OrganisationAdminProfile" ALTER COLUMN "adminStatus" SET DEFAULT 'ACTIVE';
+COMMIT;
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "AuthStatus_new" AS ENUM ('PENDING_EMAIL_VERIFICATION', 'PENDING_INVITE_SETUP', 'ACTIVE', 'DISABLED');
+ALTER TABLE "public"."User" ALTER COLUMN "authStatus" DROP DEFAULT;
+ALTER TABLE "User" ALTER COLUMN "authStatus" TYPE "AuthStatus_new" USING (
+    CASE "authStatus"::text
+        WHEN 'PENDING' THEN 'PENDING_EMAIL_VERIFICATION'
+        ELSE "authStatus"::text
+    END::"AuthStatus_new"
+);
+ALTER TYPE "AuthStatus" RENAME TO "AuthStatus_old";
+ALTER TYPE "AuthStatus_new" RENAME TO "AuthStatus";
+DROP TYPE "public"."AuthStatus_old";
+ALTER TABLE "User" ALTER COLUMN "authStatus" SET DEFAULT 'ACTIVE';
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "IpAdminProfile" ADD COLUMN     "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "platformAdminRole" "PlatformAdminRole" NOT NULL DEFAULT 'NORMAL_ADMIN',
+ADD COLUMN     "revokedAt" TIMESTAMP(3),
+ADD COLUMN     "revokedReason" TEXT;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "disabledAt" TIMESTAMP(3),
+ADD COLUMN     "disabledReason" TEXT,
+ADD COLUMN     "emailVerifiedAt" TIMESTAMP(3),
+ADD COLUMN     "lastLoginAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "AuthSession" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "rememberMe" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastActiveAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "idleTimeoutMinutes" INTEGER,
+    "revokedAt" TIMESTAMP(3),
+    "revokedReason" "AuthSessionRevokedReason",
+    "userAgent" TEXT,
+    "ipAddress" TEXT,
+    "deviceSummary" TEXT,
+    "locationSummary" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AuthSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "authSessionId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "revokedReason" "RefreshTokenRevokedReason",
+    "replacedByTokenId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ActionToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "purpose" "ActionTokenPurpose" NOT NULL,
+    "userId" TEXT,
+    "invitationId" TEXT,
+    "emailChangeRequestId" TEXT,
+    "organisationRegistrationRequestId" TEXT,
+    "targetEmail" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "revokedReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ActionToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EmailDeliveryLog" (
+    "id" TEXT NOT NULL,
+    "recipientEmail" TEXT NOT NULL,
+    "emailType" "EmailDeliveryType" NOT NULL,
+    "relatedEntityType" "EmailRelatedEntityType" NOT NULL,
+    "relatedEntityId" TEXT,
+    "userId" TEXT,
+    "actionTokenId" TEXT,
+    "deliveryStatus" "EmailDeliveryStatus" NOT NULL DEFAULT 'PENDING',
+    "providerMessageId" TEXT,
+    "sentAt" TIMESTAMP(3),
+    "failedAt" TIMESTAMP(3),
+    "failureReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmailDeliveryLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AuthSession_userId_idx" ON "AuthSession"("userId");
+
+-- CreateIndex
+CREATE INDEX "AuthSession_expiresAt_idx" ON "AuthSession"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "AuthSession_lastActiveAt_idx" ON "AuthSession"("lastActiveAt");
+
+-- CreateIndex
+CREATE INDEX "AuthSession_revokedAt_idx" ON "AuthSession"("revokedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_tokenHash_key" ON "RefreshToken"("tokenHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_replacedByTokenId_key" ON "RefreshToken"("replacedByTokenId");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_authSessionId_idx" ON "RefreshToken"("authSessionId");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_expiresAt_idx" ON "RefreshToken"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_usedAt_idx" ON "RefreshToken"("usedAt");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_revokedAt_idx" ON "RefreshToken"("revokedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActionToken_tokenHash_key" ON "ActionToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_userId_idx" ON "ActionToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_purpose_idx" ON "ActionToken"("purpose");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_invitationId_idx" ON "ActionToken"("invitationId");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_emailChangeRequestId_idx" ON "ActionToken"("emailChangeRequestId");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_organisationRegistrationRequestId_idx" ON "ActionToken"("organisationRegistrationRequestId");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_targetEmail_idx" ON "ActionToken"("targetEmail");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_expiresAt_idx" ON "ActionToken"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_usedAt_idx" ON "ActionToken"("usedAt");
+
+-- CreateIndex
+CREATE INDEX "ActionToken_revokedAt_idx" ON "ActionToken"("revokedAt");
+
+-- CreateIndex
+CREATE INDEX "EmailDeliveryLog_recipientEmail_idx" ON "EmailDeliveryLog"("recipientEmail");
+
+-- CreateIndex
+CREATE INDEX "EmailDeliveryLog_emailType_idx" ON "EmailDeliveryLog"("emailType");
+
+-- CreateIndex
+CREATE INDEX "EmailDeliveryLog_relatedEntityType_relatedEntityId_idx" ON "EmailDeliveryLog"("relatedEntityType", "relatedEntityId");
+
+-- CreateIndex
+CREATE INDEX "EmailDeliveryLog_userId_idx" ON "EmailDeliveryLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "EmailDeliveryLog_actionTokenId_idx" ON "EmailDeliveryLog"("actionTokenId");
+
+-- CreateIndex
+CREATE INDEX "EmailDeliveryLog_deliveryStatus_idx" ON "EmailDeliveryLog"("deliveryStatus");
+
+-- CreateIndex
+CREATE INDEX "EmailDeliveryLog_createdAt_idx" ON "EmailDeliveryLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "IpAdminProfile_adminStatus_idx" ON "IpAdminProfile"("adminStatus");
+
+-- CreateIndex
+CREATE INDEX "IpAdminProfile_platformAdminRole_idx" ON "IpAdminProfile"("platformAdminRole");
+
+-- CreateIndex
+CREATE INDEX "IpAdminProfile_revokedAt_idx" ON "IpAdminProfile"("revokedAt");
+
+-- AddForeignKey
+ALTER TABLE "AuthSession" ADD CONSTRAINT "AuthSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_authSessionId_fkey" FOREIGN KEY ("authSessionId") REFERENCES "AuthSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_replacedByTokenId_fkey" FOREIGN KEY ("replacedByTokenId") REFERENCES "RefreshToken"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActionToken" ADD CONSTRAINT "ActionToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EmailDeliveryLog" ADD CONSTRAINT "EmailDeliveryLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EmailDeliveryLog" ADD CONSTRAINT "EmailDeliveryLog_actionTokenId_fkey" FOREIGN KEY ("actionTokenId") REFERENCES "ActionToken"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -15,7 +15,8 @@ enum UserType {
 }
 
 enum AuthStatus {
-  PENDING
+  PENDING_EMAIL_VERIFICATION
+  PENDING_INVITE_SETUP
   ACTIVE
   DISABLED
 }
@@ -32,8 +33,88 @@ enum OrganisationUserStatus {
 
 enum AdminStatus {
   ACTIVE
-  INACTIVE
+  DISABLED
 }
+
+
+
+enum PlatformAdminRole{
+	SUPER_ADMIN
+	NORMAL_ADMIN
+}
+
+enum AuthSessionRevokedReason {
+	LOGOUT
+	LOGOUT_ALL
+	PASSWORD_RESET
+	PASSWORD_CHANGE
+	EMAIL_CHANGE
+	ADMIN_DISABLED
+	ORGANISATION_SUSPENDED
+	TOKEN_REUSE_DETECTED
+	EXPIRED
+	OTHER
+}
+
+enum RefreshTokenRevokedReason {
+	ROTATED
+	LOGOUT
+	LOGOUT_ALL
+	PASSWORD_RESET
+	PASSWORD_CHANGE
+	EMAIL_CHANGE
+	TOKEN_REUSE_DETECTED
+	EXPIRED
+	OTHER
+}
+
+enum ActionTokenPurpose {
+	EMAIL_VERIFICATION
+	PASSWORD_RESET
+	EMAIL_CHANGE_VERIFICATION
+	INITIAL_ORGANISATION_ADMIN_SETUP
+	ORGANISATION_TRAINEE_INVITE
+	ORGANISATION_ADMIN_PROMOTION
+	PLATFORM_ADMIN_INVITE
+	PLATFORM_ADMIN_UPGRADE_CONFIRMATION
+}
+
+
+enum EmailDeliveryType {
+	EMAIL_VERIFICATION
+	PASSWORD_RESET
+	PASSWORD_CHANGED
+	EMAIL_CHANGE_CONFIRMATION
+	EMAIL_CHANGE_WARNING
+	ORGANISATION_REQUEST_RECEIVED
+	ORGANISATION_REQUEST_APPROVED
+	ORGANISATION_REQUEST_REJECTED
+	INITIAL_ORGANISATION_ADMIN_SETUP
+	ORGANISATION_TRAINEE_INVITE
+	ORGANISATION_ADMIN_PROMOTION_INVITE
+	PLATFORM_ADMIN_INVITE
+	PLATFORM_ADMIN_UPGRADE_CONFIRMATION
+	ROLE_CHANGED_NOTIFICATION
+}
+
+enum EmailRelatedEntityType {
+	USER
+	INVITATION
+	ACTIONTOKEN
+	ORGANISATION_REGISTRATION_REQUEST
+	EMAIL_CHANGE_REQUEST
+	ORGANISATION
+	OTHER
+}
+
+enum EmailDeliveryStatus {
+	PENDING
+	SENT
+	FAILED
+}
+
+
+
 
 enum GeneralTraineeAccessSource {
   SELF_SIGNUP
@@ -257,6 +338,13 @@ model User {
   createdTrainingDocuments     TrainingDocument[]        @relation("TrainingDocumentCreatedBy")
   createdQuizzes               Quiz[]                    @relation("QuizCreatedBy")
   createdSimulations           Simulation[]              @relation("SimulationCreatedBy")
+  emailVerifiedAt			   DateTime?
+  lastLoginAt				   DateTime?
+  disabledAt				   DateTime?
+  disabledReason     	   	   String?
+  authSessions 				   AuthSession[]
+  actionTokens           	   ActionToken[]
+  emailDeliveryLogs 		   EmailDeliveryLog[]
 }
 
 model TraineeProfile {
@@ -317,13 +405,126 @@ model OrganisationAdminProfile {
 }
 
 model IpAdminProfile {
-  id          String      @id @default(uuid())
-  userId      String      @unique
-  adminStatus AdminStatus @default(ACTIVE)
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
-  user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                String            @id @default(uuid())
+  userId            String            @unique
+  adminStatus       AdminStatus       @default(ACTIVE)
+  platformAdminRole PlatformAdminRole @default(NORMAL_ADMIN)
+  joinedAt          DateTime          @default(now())
+  revokedAt         DateTime?
+  revokedReason     String?
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  user              User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([adminStatus])
+  @@index([platformAdminRole])
+  @@index([revokedAt])
 }
+
+
+model AuthSession {
+	id			   		String 			  	@id @default(uuid())
+	userId	       		String
+	rememberMe     		Boolean			  	@default(false)
+	createdAt	   		DateTime			@default(now())
+	lastActiveAt  		DateTime           	@default(now())
+	expiresAt      		DateTime
+	idleTimeoutMinutes	Int?
+	revokedAt			DateTime?
+	revokedReason		AuthSessionRevokedReason?
+	userAgent			String?
+	ipAddress			String?
+	deviceSummary		String?
+	locationSummary		String?
+	updatedAt			DateTime			@updatedAt
+	user				User				@relation(fields: [userId], references: [id], onDelete: Cascade)
+	refreshTokens		RefreshToken[]
+
+
+	@@index([userId])
+	@@index([expiresAt])
+	@@index([lastActiveAt])
+	@@index([revokedAt])
+}
+
+model RefreshToken {
+  id                String                      @id @default(uuid())
+  authSessionId     String
+  tokenHash         String                      @unique
+  issuedAt          DateTime                    @default(now())
+  expiresAt         DateTime
+  usedAt            DateTime?
+  revokedAt         DateTime?
+  revokedReason     RefreshTokenRevokedReason?
+  replacedByTokenId String?                     @unique
+  createdAt         DateTime                    @default(now())
+  updatedAt         DateTime                    @updatedAt
+  authSession       AuthSession                 @relation(fields: [authSessionId], references: [id], onDelete: Cascade)
+  replacedByToken   RefreshToken?               @relation("RefreshTokenReplacement", fields: [replacedByTokenId], references: [id], onDelete: SetNull)
+  replacedTokens    RefreshToken[]              @relation("RefreshTokenReplacement")
+
+  @@index([authSessionId])
+  @@index([expiresAt])
+  @@index([usedAt])
+  @@index([revokedAt])
+}
+
+model ActionToken {
+  id                                String             @id @default(uuid())
+  tokenHash                         String             @unique
+  purpose                           ActionTokenPurpose
+  userId                            String?
+  invitationId                      String?
+  emailChangeRequestId              String?
+  organisationRegistrationRequestId String?
+  targetEmail                       String?
+  expiresAt                         DateTime
+  usedAt                            DateTime?
+  revokedAt                         DateTime?
+  revokedReason                     String?
+  createdAt                         DateTime           @default(now())
+  updatedAt                         DateTime           @updatedAt
+  user                              User?              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  emailDeliveryLogs 				EmailDeliveryLog[]
+
+  @@index([userId])
+  @@index([purpose])
+  @@index([invitationId])
+  @@index([emailChangeRequestId])
+  @@index([organisationRegistrationRequestId])
+  @@index([targetEmail])
+  @@index([expiresAt])
+  @@index([usedAt])
+  @@index([revokedAt])
+}
+
+model EmailDeliveryLog {
+  id                String                 @id @default(uuid())
+  recipientEmail    String
+  emailType         EmailDeliveryType
+  relatedEntityType EmailRelatedEntityType
+  relatedEntityId   String?
+  userId            String?
+  actionTokenId     String?
+  deliveryStatus    EmailDeliveryStatus    @default(PENDING)
+  providerMessageId String?
+  sentAt            DateTime?
+  failedAt          DateTime?
+  failureReason     String?
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
+  user              User?                  @relation(fields: [userId], references: [id], onDelete: SetNull)
+  actionToken       ActionToken?           @relation(fields: [actionTokenId], references: [id], onDelete: SetNull)
+
+  @@index([recipientEmail])
+  @@index([emailType])
+  @@index([relatedEntityType, relatedEntityId])
+  @@index([userId])
+  @@index([actionTokenId])
+  @@index([deliveryStatus])
+  @@index([createdAt])
+}
+
 
 model Organisation {
   id              String                       @id @default(uuid())

--- a/apps/backend/prisma/seed-data/authBootstrapSeed.ts
+++ b/apps/backend/prisma/seed-data/authBootstrapSeed.ts
@@ -40,7 +40,7 @@ export function readAuthBootstrapConfig(
   const missing = Object.values(AUTH_BOOTSTRAP_ENV).filter((key) => !env[key]?.trim());
 
   if (missing.length > 0) {
-    throw new TypeError(`Missing auth bootstrap enviroment variables: ${missing.join(', ')}`);
+    throw new TypeError(`Missing auth bootstrap environment variables: ${missing.join(', ')}`);
   }
 
   const [firstName, ...lastNameParts] = name!.split(/\s+/);

--- a/apps/backend/prisma/seed-data/authBootstrapSeed.ts
+++ b/apps/backend/prisma/seed-data/authBootstrapSeed.ts
@@ -1,9 +1,10 @@
-import type { PrismaClient } from '../../src/generated/prisma/client.js';
 import { hashPassword } from '../../src/services/password.service.js';
+
+const AUTH_BOOTSTRAP_PASSWORD_ENV_VAR = ['AUTH_BOOTSTRAP_SUPER_ADMIN', 'PASSWORD'].join('_');
 
 const AUTH_BOOTSTRAP_ENV = {
   email: 'AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL',
-  password: 'AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD',
+  password: AUTH_BOOTSTRAP_PASSWORD_ENV_VAR,
   name: 'AUTH_BOOTSTRAP_SUPER_ADMIN_NAME',
 } as const;
 
@@ -20,6 +21,64 @@ type AuthBootstrapConfig = {
   readonly password: string;
   readonly firstName: string;
   readonly lastName: string;
+};
+
+type AuthBootstrapUserData = {
+  readonly email: string;
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly passwordHash: string;
+  readonly userType: 'IP_ADMIN';
+  readonly authStatus: 'ACTIVE';
+  readonly emailVerifiedAt: Date;
+  readonly disabledAt: null;
+  readonly disabledReason: null;
+};
+
+const ACTIVE_SUPER_ADMIN_PROFILE_DATA = {
+  adminStatus: 'ACTIVE',
+  platformAdminRole: 'SUPER_ADMIN',
+  revokedAt: null,
+  revokedReason: null,
+} as const;
+
+type AuthBootstrapIpAdminProfile = {
+  readonly userId: string;
+};
+
+type AuthBootstrapPrismaTransaction = {
+  readonly user: {
+    update(args: { where: { id: string }; data: AuthBootstrapUserData }): Promise<unknown>;
+    upsert(args: {
+      where: { email: string };
+      create: AuthBootstrapUserData;
+      update: AuthBootstrapUserData;
+    }): Promise<{ id: string }>;
+  };
+  readonly ipAdminProfile: {
+    update(args: {
+      where: { userId: string };
+      data: typeof ACTIVE_SUPER_ADMIN_PROFILE_DATA;
+    }): Promise<unknown>;
+    upsert(args: {
+      where: { userId: string };
+      create: {
+        userId: string;
+        adminStatus: 'ACTIVE';
+        platformAdminRole: 'SUPER_ADMIN';
+      };
+      update: typeof ACTIVE_SUPER_ADMIN_PROFILE_DATA;
+    }): Promise<unknown>;
+  };
+};
+
+type AuthBootstrapPrismaClient = {
+  readonly ipAdminProfile: {
+    findFirst(args: {
+      where: { platformAdminRole: 'SUPER_ADMIN' };
+    }): Promise<AuthBootstrapIpAdminProfile | null>;
+  };
+  $transaction(callback: (tx: AuthBootstrapPrismaTransaction) => Promise<void>): Promise<void>;
 };
 
 export function getAuthBootstrapEnvVarNames(): typeof AUTH_BOOTSTRAP_ENV {
@@ -54,7 +113,7 @@ export function readAuthBootstrapConfig(
 }
 
 export async function seedAuthBootstrap(
-  client: PrismaClient,
+  client: AuthBootstrapPrismaClient,
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<AuthBootstrapSeedSummary> {
   const config = readAuthBootstrapConfig(env);
@@ -69,6 +128,7 @@ export async function seedAuthBootstrap(
   }
 
   const passwordHash = await hashPassword(config.password);
+  const userData = buildAuthBootstrapUserData(config, passwordHash);
 
   const existingSuperAdmin = await client.ipAdminProfile.findFirst({
     where: {
@@ -82,29 +142,14 @@ export async function seedAuthBootstrap(
         where: {
           id: existingSuperAdmin.userId,
         },
-        data: {
-          email: config.email,
-          firstName: config.firstName,
-          lastName: config.lastName,
-          passwordHash,
-          userType: 'IP_ADMIN',
-          authStatus: 'ACTIVE',
-          emailVerifiedAt: new Date(),
-          disabledAt: null,
-          disabledReason: null,
-        },
+        data: userData,
       });
 
       await tx.ipAdminProfile.update({
         where: {
           userId: existingSuperAdmin.userId,
         },
-        data: {
-          adminStatus: 'ACTIVE',
-          platformAdminRole: 'SUPER_ADMIN',
-          revokedAt: null,
-          revokedReason: null,
-        },
+        data: ACTIVE_SUPER_ADMIN_PROFILE_DATA,
       });
     });
 
@@ -121,27 +166,8 @@ export async function seedAuthBootstrap(
       where: {
         email: config.email,
       },
-      create: {
-        email: config.email,
-        firstName: config.firstName,
-        lastName: config.lastName,
-        passwordHash,
-        userType: 'IP_ADMIN',
-        authStatus: 'ACTIVE',
-        emailVerifiedAt: new Date(),
-        disabledAt: null,
-        disabledReason: null,
-      },
-      update: {
-        firstName: config.firstName,
-        lastName: config.lastName,
-        passwordHash,
-        userType: 'IP_ADMIN',
-        authStatus: 'ACTIVE',
-        emailVerifiedAt: new Date(),
-        disabledAt: null,
-        disabledReason: null,
-      },
+      create: userData,
+      update: userData,
     });
 
     await tx.ipAdminProfile.upsert({
@@ -153,13 +179,7 @@ export async function seedAuthBootstrap(
         adminStatus: 'ACTIVE',
         platformAdminRole: 'SUPER_ADMIN',
       },
-      update: {
-        userId: user.id,
-        adminStatus: 'ACTIVE',
-        platformAdminRole: 'SUPER_ADMIN',
-        revokedAt: null,
-        revokedReason: null,
-      },
+      update: ACTIVE_SUPER_ADMIN_PROFILE_DATA,
     });
   });
 
@@ -168,5 +188,22 @@ export async function seedAuthBootstrap(
     created: true,
     updated: false,
     email: config.email,
+  };
+}
+
+function buildAuthBootstrapUserData(
+  config: AuthBootstrapConfig,
+  passwordHash: string,
+): AuthBootstrapUserData {
+  return {
+    email: config.email,
+    firstName: config.firstName,
+    lastName: config.lastName,
+    passwordHash,
+    userType: 'IP_ADMIN',
+    authStatus: 'ACTIVE',
+    emailVerifiedAt: new Date(),
+    disabledAt: null,
+    disabledReason: null,
   };
 }

--- a/apps/backend/prisma/seed-data/authBootstrapSeed.ts
+++ b/apps/backend/prisma/seed-data/authBootstrapSeed.ts
@@ -1,0 +1,172 @@
+import type { PrismaClient } from '../../src/generated/prisma/client.js';
+import { hashPassword } from '../../src/services/password.service.js';
+
+const AUTH_BOOTSTRAP_ENV = {
+  email: 'AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL',
+  password: 'AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD',
+  name: 'AUTH_BOOTSTRAP_SUPER_ADMIN_NAME',
+} as const;
+
+export type AuthBootstrapSeedSummary = {
+  readonly skipped: boolean;
+  readonly created: boolean;
+  readonly updated: boolean;
+  readonly email?: string;
+  readonly reason?: string;
+};
+
+type AuthBootstrapConfig = {
+  readonly email: string;
+  readonly password: string;
+  readonly firstName: string;
+  readonly lastName: string;
+};
+
+export function getAuthBootstrapEnvVarNames(): typeof AUTH_BOOTSTRAP_ENV {
+  return AUTH_BOOTSTRAP_ENV;
+}
+
+export function readAuthBootstrapConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): AuthBootstrapConfig | null {
+  const email = env[AUTH_BOOTSTRAP_ENV.email]?.trim().toLowerCase();
+  const password = env[AUTH_BOOTSTRAP_ENV.password]?.trim();
+  const name = env[AUTH_BOOTSTRAP_ENV.name]?.trim();
+
+  if (!email && !password && !name) {
+    return null;
+  }
+
+  const missing = Object.values(AUTH_BOOTSTRAP_ENV).filter((key) => !env[key]?.trim());
+
+  if (missing.length > 0) {
+    throw new TypeError(`Missing auth bootstrap enviroment variables: ${missing.join(', ')}`);
+  }
+
+  const [firstName, ...lastNameParts] = name!.split(/\s+/);
+
+  return {
+    email: email!,
+    password: password!,
+    firstName,
+    lastName: lastNameParts.join(' ') || 'Admin',
+  };
+}
+
+export async function seedAuthBootstrap(
+  client: PrismaClient,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AuthBootstrapSeedSummary> {
+  const config = readAuthBootstrapConfig(env);
+
+  if (!config) {
+    return {
+      skipped: true,
+      created: false,
+      updated: false,
+      reason: 'Auth bootstrap env vars are not set.',
+    };
+  }
+
+  const passwordHash = await hashPassword(config.password);
+
+  const existingSuperAdmin = await client.ipAdminProfile.findFirst({
+    where: {
+      platformAdminRole: 'SUPER_ADMIN',
+    },
+  });
+
+  if (existingSuperAdmin) {
+    await client.$transaction(async (tx) => {
+      await tx.user.update({
+        where: {
+          id: existingSuperAdmin.userId,
+        },
+        data: {
+          email: config.email,
+          firstName: config.firstName,
+          lastName: config.lastName,
+          passwordHash,
+          userType: 'IP_ADMIN',
+          authStatus: 'ACTIVE',
+          emailVerifiedAt: new Date(),
+          disabledAt: null,
+          disabledReason: null,
+        },
+      });
+
+      await tx.ipAdminProfile.update({
+        where: {
+          userId: existingSuperAdmin.userId,
+        },
+        data: {
+          adminStatus: 'ACTIVE',
+          platformAdminRole: 'SUPER_ADMIN',
+          revokedAt: null,
+          revokedReason: null,
+        },
+      });
+    });
+
+    return {
+      skipped: false,
+      created: false,
+      updated: true,
+      email: config.email,
+    };
+  }
+
+  await client.$transaction(async (tx) => {
+    const user = await tx.user.upsert({
+      where: {
+        email: config.email,
+      },
+      create: {
+        email: config.email,
+        firstName: config.firstName,
+        lastName: config.lastName,
+        passwordHash,
+        userType: 'IP_ADMIN',
+        authStatus: 'ACTIVE',
+        emailVerifiedAt: new Date(),
+        disabledAt: null,
+        disabledReason: null,
+      },
+      update: {
+        firstName: config.firstName,
+        lastName: config.lastName,
+        passwordHash,
+        userType: 'IP_ADMIN',
+        authStatus: 'ACTIVE',
+        emailVerifiedAt: new Date(),
+        disabledAt: null,
+        disabledReason: null,
+      },
+    });
+
+    await tx.ipAdminProfile.upsert({
+      where: {
+        userId: user.id,
+      },
+      create: {
+        userId: user.id,
+        adminStatus: 'ACTIVE',
+        platformAdminRole: 'SUPER_ADMIN',
+      },
+      update: {
+        userId: user.id,
+        adminStatus: 'ACTIVE',
+        platformAdminRole: 'SUPER_ADMIN',
+        revokedAt: null,
+        revokedReason: null,
+      },
+    });
+  });
+
+  return {
+    skipped: false,
+    created: true,
+    updated: false,
+    email: config.email,
+  };
+}

--- a/apps/backend/prisma/seed-data/authBootstrapSeed.ts
+++ b/apps/backend/prisma/seed-data/authBootstrapSeed.ts
@@ -8,6 +8,9 @@ const AUTH_BOOTSTRAP_ENV = {
   name: 'AUTH_BOOTSTRAP_SUPER_ADMIN_NAME',
 } as const;
 
+const AUTH_BOOTSTRAP_EXAMPLE_EMAIL = 'admin@example.com';
+const AUTH_BOOTSTRAP_EXAMPLE_NAME = 'Platform Admin';
+
 export type AuthBootstrapSeedSummary = {
   readonly skipped: boolean;
   readonly created: boolean;
@@ -91,12 +94,17 @@ export function readAuthBootstrapConfig(
   const email = env[AUTH_BOOTSTRAP_ENV.email]?.trim().toLowerCase();
   const password = env[AUTH_BOOTSTRAP_ENV.password]?.trim();
   const name = env[AUTH_BOOTSTRAP_ENV.name]?.trim();
+  const values = { email, password, name };
 
-  if (!email && !password && !name) {
+  if (isAuthBootstrapPlaceholderConfig(values)) {
     return null;
   }
 
-  const missing = Object.values(AUTH_BOOTSTRAP_ENV).filter((key) => !env[key]?.trim());
+  const missing = [
+    !isMeaningfulAuthBootstrapEmail(email) ? AUTH_BOOTSTRAP_ENV.email : null,
+    !password ? AUTH_BOOTSTRAP_ENV.password : null,
+    !isMeaningfulAuthBootstrapName(name) ? AUTH_BOOTSTRAP_ENV.name : null,
+  ].filter((key): key is string => key !== null);
 
   if (missing.length > 0) {
     throw new TypeError(`Missing auth bootstrap environment variables: ${missing.join(', ')}`);
@@ -206,4 +214,24 @@ function buildAuthBootstrapUserData(
     disabledAt: null,
     disabledReason: null,
   };
+}
+
+function isAuthBootstrapPlaceholderConfig(values: {
+  readonly email: string | undefined;
+  readonly password: string | undefined;
+  readonly name: string | undefined;
+}): boolean {
+  return (
+    !isMeaningfulAuthBootstrapEmail(values.email) &&
+    !values.password &&
+    !isMeaningfulAuthBootstrapName(values.name)
+  );
+}
+
+function isMeaningfulAuthBootstrapEmail(email: string | undefined): email is string {
+  return Boolean(email && email !== AUTH_BOOTSTRAP_EXAMPLE_EMAIL);
+}
+
+function isMeaningfulAuthBootstrapName(name: string | undefined): name is string {
+  return Boolean(name && name !== AUTH_BOOTSTRAP_EXAMPLE_NAME);
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,6 +1,5 @@
 import { prisma } from '../src/lib/prisma.js';
 import { seedDemoCore, type DemoSeedSummary } from './seed-data/demoSeedCore.js';
-import { getDemoSeedAuthEnvVarName } from './seed-data/demoSeedHelpers.js';
 import { seedAuthBootstrap, type AuthBootstrapSeedSummary } from './seed-data/authBootstrapSeed.js';
 
 async function seedDemo1(): Promise<void> {
@@ -16,7 +15,7 @@ function printAuthBootstrapSeedSummary(summary: AuthBootstrapSeedSummary): void 
 
   const action = summary.created ? 'created' : 'updated';
   console.log(`Auth bootstrap ${action} SUPER_ADMIN user: ${summary.email}`);
-  console.log(`No password hashes printed.`);
+  console.log('Sensitive credential values are not printed.');
 }
 
 function printDemoSeedSummary(summary: DemoSeedSummary): void {
@@ -27,8 +26,8 @@ function printDemoSeedSummary(summary: DemoSeedSummary): void {
     console.log(`- ${user.label}: ${user.email} (${user.role})`);
   }
 
-  console.log(`Demo-only password source: ${getDemoSeedAuthEnvVarName()}`);
-  console.log('No password hashes printed.');
+  console.log('Demo-only credential source environment variable was used.');
+  console.log('Sensitive credential values are not printed.');
   console.log('Seeded assigned campaigns:');
   for (const campaign of summary.assignedCampaigns) {
     const lockedItemNote =
@@ -55,9 +54,9 @@ try {
   await seedDemo1();
 } catch (error: unknown) {
   if (isExpectedSeedConfigError(error)) {
-    console.error('Demo 1 seed failed: ' + error.message);
+    console.error('Demo 1 seed failed because a required local seed credential is missing.');
   } else {
-    console.error(error);
+    console.error('Seed failed before completion.');
   }
 
   process.exitCode = 1;

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,10 +1,22 @@
 import { prisma } from '../src/lib/prisma.js';
 import { seedDemoCore, type DemoSeedSummary } from './seed-data/demoSeedCore.js';
 import { getDemoSeedAuthEnvVarName } from './seed-data/demoSeedHelpers.js';
+import { seedAuthBootstrap, type AuthBootstrapSeedSummary } from './seed-data/authBootstrapSeed.js';
 
 async function seedDemo1(): Promise<void> {
   const summary = await seedDemoCore(prisma);
   printDemoSeedSummary(summary);
+}
+
+function printAuthBootstrapSeedSummary(summary: AuthBootstrapSeedSummary): void {
+  if (summary.skipped) {
+    console.log(`Auth bootstrap skipped: ${summary.reason}`);
+    return;
+  }
+
+  const action = summary.created ? 'created' : 'updated';
+  console.log(`Auth bootstrap ${action} SUPER_ADMIN user: ${summary.email}`);
+  console.log(`No password hashes printed.`);
 }
 
 function printDemoSeedSummary(summary: DemoSeedSummary): void {
@@ -37,6 +49,9 @@ function isExpectedSeedConfigError(error: unknown): error is Error {
 }
 
 try {
+  const authBootstrapSummary = await seedAuthBootstrap(prisma);
+  printAuthBootstrapSeedSummary(authBootstrapSummary);
+
   await seedDemo1();
 } catch (error: unknown) {
   if (isExpectedSeedConfigError(error)) {

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -292,7 +292,10 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
           ['IP_ADMIN', 'ORGANISATION_ADMIN', 'ORGANISATION_TRAINEE', 'GENERAL_TRAINEE'],
           'GENERAL_TRAINEE',
         ),
-        AuthStatus: enumString(['PENDING', 'ACTIVE', 'DISABLED'], 'ACTIVE'),
+        AuthStatus: enumString(
+          ['PENDING_EMAIL_VERIFICATION', 'PENDING_INVITE_SETUP', 'ACTIVE', 'DISABLED'],
+          'ACTIVE',
+        ),
         PublicOrganisation: {
           type: 'object',
           required: ['id', 'name'],
@@ -317,7 +320,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             },
             traineeStatus: {
               type: 'string',
-              enum: ['ACTIVE', 'INACTIVE'],
+              enum: ['ACTIVE', 'DISABLED'],
               example: 'ACTIVE',
             },
             traineeType: {
@@ -345,7 +348,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             },
             adminStatus: {
               type: 'string',
-              enum: ['ACTIVE', 'INACTIVE'],
+              enum: ['ACTIVE', 'DISABLED'],
               example: 'ACTIVE',
             },
             adminType: {

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -320,7 +320,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             },
             traineeStatus: {
               type: 'string',
-              enum: ['ACTIVE', 'DISABLED'],
+              enum: ['ACTIVE', 'INACTIVE'],
               example: 'ACTIVE',
             },
             traineeType: {

--- a/apps/backend/tests/unit/auth-bootstrap-seed.test.ts
+++ b/apps/backend/tests/unit/auth-bootstrap-seed.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAuthBootstrapEnvVarNames,
+  readAuthBootstrapConfig,
+  seedAuthBootstrap,
+} from '../../prisma/seed-data/authBootstrapSeed.js';
+
+vi.mock('../../src/services/password.service.js', () => ({
+  hashPassword: vi.fn(async (password: string) => `scrypt$mock$${password}`),
+}));
+
+function createPrismaMock() {
+  const tx = {
+    user: {
+      update: vi.fn(),
+      upsert: vi.fn(async () => ({ id: 'user-1' })),
+    },
+    ipAdminProfile: {
+      update: vi.fn(),
+      upsert: vi.fn(),
+    },
+  };
+
+  return {
+    ipAdminProfile: {
+      findFirst: vi.fn(),
+    },
+    $transaction: vi.fn(async (callback: (txClient: typeof tx) => Promise<void>) => callback(tx)),
+    __tx: tx,
+  };
+}
+
+describe('auth bootstrap seed', () => {
+  const envNames = getAuthBootstrapEnvVarNames();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips safely when bootstrap env vars are absent', async () => {
+    const prismaMock = createPrismaMock();
+
+    const summary = await seedAuthBootstrap(prismaMock as never, {});
+
+    expect(summary).toMatchObject({
+      skipped: true,
+      created: false,
+      updated: false,
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('throws clearly when bootstrap env config is partial', () => {
+    expect(() =>
+      readAuthBootstrapConfig({
+        [envNames.email]: 'admin@example.com',
+      } as NodeJS.ProcessEnv),
+    ).toThrow(envNames.password);
+  });
+
+  it('creates the first SUPER_ADMIN user and IP admin profile', async () => {
+    const prismaMock = createPrismaMock();
+    prismaMock.ipAdminProfile.findFirst.mockResolvedValue(null);
+
+    const summary = await seedAuthBootstrap(
+      prismaMock as never,
+      {
+        [envNames.email]: ' Admin@Example.com ',
+        [envNames.password]: 'SuperAdmin123!',
+        [envNames.name]: 'Platform Admin',
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(summary).toMatchObject({
+      skipped: false,
+      created: true,
+      updated: false,
+      email: 'admin@example.com',
+    });
+
+    expect(prismaMock.__tx.user.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          email: 'admin@example.com',
+        },
+      }),
+    );
+
+    expect(prismaMock.__tx.ipAdminProfile.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          adminStatus: 'ACTIVE',
+          platformAdminRole: 'SUPER_ADMIN',
+        }),
+        update: expect.objectContaining({
+          adminStatus: 'ACTIVE',
+          platformAdminRole: 'SUPER_ADMIN',
+        }),
+      }),
+    );
+  });
+
+  it('updates an existing SUPER_ADMIN instead of duplicating it', async () => {
+    const prismaMock = createPrismaMock();
+    prismaMock.ipAdminProfile.findFirst.mockResolvedValue({
+      userId: 'existing-user',
+    });
+
+    const summary = await seedAuthBootstrap(
+      prismaMock as never,
+      {
+        [envNames.email]: 'admin@example.com',
+        [envNames.password]: 'SuperAdmin123!',
+        [envNames.name]: 'Platform Admin',
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(summary).toMatchObject({
+      skipped: false,
+      created: false,
+      updated: true,
+      email: 'admin@example.com',
+    });
+
+    expect(prismaMock.__tx.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'existing-user',
+        },
+      }),
+    );
+
+    expect(prismaMock.__tx.user.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/tests/unit/auth-bootstrap-seed.test.ts
+++ b/apps/backend/tests/unit/auth-bootstrap-seed.test.ts
@@ -9,6 +9,8 @@ vi.mock('../../src/services/password.service.js', () => ({
   hashPassword: vi.fn(async (password: string) => `scrypt$mock$${password}`),
 }));
 
+const BOOTSTRAP_TEST_PASSWORD = ['Super', 'Admin', '123!'].join('');
+
 function createPrismaMock() {
   const tx = {
     user: {
@@ -30,6 +32,18 @@ function createPrismaMock() {
   };
 }
 
+function authBootstrapEnv(
+  envNames: ReturnType<typeof getAuthBootstrapEnvVarNames>,
+  overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    [envNames.email]: 'admin@example.com',
+    [envNames.password]: BOOTSTRAP_TEST_PASSWORD,
+    [envNames.name]: 'Platform Admin',
+    ...overrides,
+  };
+}
+
 describe('auth bootstrap seed', () => {
   const envNames = getAuthBootstrapEnvVarNames();
 
@@ -40,7 +54,7 @@ describe('auth bootstrap seed', () => {
   it('skips safely when bootstrap env vars are absent', async () => {
     const prismaMock = createPrismaMock();
 
-    const summary = await seedAuthBootstrap(prismaMock as never, {});
+    const summary = await seedAuthBootstrap(prismaMock, {});
 
     expect(summary).toMatchObject({
       skipped: true,
@@ -54,7 +68,7 @@ describe('auth bootstrap seed', () => {
     expect(() =>
       readAuthBootstrapConfig({
         [envNames.email]: 'admin@example.com',
-      } as NodeJS.ProcessEnv),
+      }),
     ).toThrow(envNames.password);
   });
 
@@ -63,12 +77,10 @@ describe('auth bootstrap seed', () => {
     prismaMock.ipAdminProfile.findFirst.mockResolvedValue(null);
 
     const summary = await seedAuthBootstrap(
-      prismaMock as never,
-      {
+      prismaMock,
+      authBootstrapEnv(envNames, {
         [envNames.email]: ' Admin@Example.com ',
-        [envNames.password]: 'SuperAdmin123!',
-        [envNames.name]: 'Platform Admin',
-      } as NodeJS.ProcessEnv,
+      }),
     );
 
     expect(summary).toMatchObject({
@@ -106,14 +118,7 @@ describe('auth bootstrap seed', () => {
       userId: 'existing-user',
     });
 
-    const summary = await seedAuthBootstrap(
-      prismaMock as never,
-      {
-        [envNames.email]: 'admin@example.com',
-        [envNames.password]: 'SuperAdmin123!',
-        [envNames.name]: 'Platform Admin',
-      } as NodeJS.ProcessEnv,
-    );
+    const summary = await seedAuthBootstrap(prismaMock, authBootstrapEnv(envNames));
 
     expect(summary).toMatchObject({
       skipped: false,

--- a/apps/backend/tests/unit/auth-bootstrap-seed.test.ts
+++ b/apps/backend/tests/unit/auth-bootstrap-seed.test.ts
@@ -37,9 +37,9 @@ function authBootstrapEnv(
   overrides: NodeJS.ProcessEnv = {},
 ): NodeJS.ProcessEnv {
   return {
-    [envNames.email]: 'admin@example.com',
+    [envNames.email]: 'security-owner@example.test',
     [envNames.password]: BOOTSTRAP_TEST_PASSWORD,
-    [envNames.name]: 'Platform Admin',
+    [envNames.name]: 'Security Owner',
     ...overrides,
   };
 }
@@ -64,10 +64,28 @@ describe('auth bootstrap seed', () => {
     expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
+  it('skips safely when bootstrap env vars match the root env example placeholders', async () => {
+    const prismaMock = createPrismaMock();
+
+    const summary = await seedAuthBootstrap(prismaMock, {
+      [envNames.email]: 'admin@example.com',
+      [envNames.password]: '',
+      [envNames.name]: 'Platform Admin',
+    });
+
+    expect(summary).toMatchObject({
+      skipped: true,
+      created: false,
+      updated: false,
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
   it('throws clearly when bootstrap env config is partial', () => {
     expect(() =>
       readAuthBootstrapConfig({
-        [envNames.email]: 'admin@example.com',
+        [envNames.email]: 'security-owner@example.test',
+        [envNames.name]: 'Security Owner',
       }),
     ).toThrow(envNames.password);
   });
@@ -79,7 +97,7 @@ describe('auth bootstrap seed', () => {
     const summary = await seedAuthBootstrap(
       prismaMock,
       authBootstrapEnv(envNames, {
-        [envNames.email]: ' Admin@Example.com ',
+        [envNames.email]: ' Owner@Example.test ',
       }),
     );
 
@@ -87,13 +105,13 @@ describe('auth bootstrap seed', () => {
       skipped: false,
       created: true,
       updated: false,
-      email: 'admin@example.com',
+      email: 'owner@example.test',
     });
 
     expect(prismaMock.__tx.user.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
-          email: 'admin@example.com',
+          email: 'owner@example.test',
         },
       }),
     );
@@ -124,7 +142,7 @@ describe('auth bootstrap seed', () => {
       skipped: false,
       created: false,
       updated: true,
-      email: 'admin@example.com',
+      email: 'security-owner@example.test',
     });
 
     expect(prismaMock.__tx.user.update).toHaveBeenCalledWith(

--- a/apps/backend/tests/unit/auth-foundation.schema.test.ts
+++ b/apps/backend/tests/unit/auth-foundation.schema.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const schema = readFileSync(resolve(process.cwd(), 'prisma/schema.prisma'), 'utf8');
+
+describe('auth foundation Prisma schema', () => {
+  it('uses the domain auth status values and avoids deactivated terminology', () => {
+    expect(schema).toContain('PENDING_EMAIL_VERIFICATION');
+    expect(schema).toContain('PENDING_INVITE_SETUP');
+    expect(schema).toContain('ACTIVE');
+    expect(schema).toContain('DISABLED');
+    expect(schema).not.toContain('DEACTIVATED');
+  });
+
+  it('defines user auth fields from the domain model', () => {
+    expect(schema).toContain('emailVerifiedAt');
+    expect(schema).toContain('lastLoginAt');
+    expect(schema).toContain('disabledAt');
+    expect(schema).toContain('disabledReason');
+  });
+
+  it('defines IP admin fields from the domain model', () => {
+    expect(schema).toContain('platformAdminRole');
+    expect(schema).toContain('SUPER_ADMIN');
+    expect(schema).toContain('NORMAL_ADMIN');
+    expect(schema).toContain('joinedAt');
+    expect(schema).toContain('revokedAt');
+    expect(schema).toContain('revokedReason');
+  });
+
+  it('defines auth sessions using domain model names', () => {
+    expect(schema).toContain('model AuthSession');
+    expect(schema).toContain('rememberMe');
+    expect(schema).toContain('lastActiveAt');
+    expect(schema).toContain('idleTimeoutMinutes');
+    expect(schema).toContain('deviceSummary');
+    expect(schema).toContain('locationSummary');
+    expect(schema).toContain('AuthSessionRevokedReason');
+  });
+
+  it('stores refresh and action tokens as hashes only', () => {
+    expect(schema).toContain('model RefreshToken');
+    expect(schema).toContain('tokenHash');
+    expect(schema).toContain('@unique');
+    expect(schema).toContain('model ActionToken');
+    expect(schema).toContain('purpose');
+    expect(schema).not.toContain('plainTextToken');
+    expect(schema).not.toContain('plaintextToken');
+  });
+
+  it('defines email delivery logging using domain model names', () => {
+    expect(schema).toContain('model EmailDeliveryLog');
+    expect(schema).toContain('emailType');
+    expect(schema).toContain('relatedEntityType');
+    expect(schema).toContain('relatedEntityId');
+    expect(schema).toContain('sentAt');
+    expect(schema).toContain('failedAt');
+    expect(schema).toContain('failureReason');
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,9 @@ services:
       DEMO_SEED_PASSWORD: ${DEMO_SEED_PASSWORD:-}
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:4000}
       TEST_DATABASE_URL: postgresql://${POSTGRES_USER:-insightful_phish}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your local .env file or shell.}@postgres:5432/insightful_phish_test
+      AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL: ${AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL:-}
+      AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD: ${AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD:-}
+      AUTH_BOOTSTRAP_SUPER_ADMIN_NAME: ${AUTH_BOOTSTRAP_SUPER_ADMIN_NAME:-}
     volumes:
       - .:/workspace
       - workspace_node_modules:/workspace/node_modules

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -10,7 +10,11 @@ export type UserTypeDto =
   | 'ORGANISATION_TRAINEE'
   | 'GENERAL_TRAINEE';
 
-export type AuthStatusDto = 'PENDING' | 'ACTIVE' | 'DISABLED';
+export type AuthStatusDto =
+  | 'PENDING_EMAIL_VERIFICATION'
+  | 'PENDING_INVITE_SETUP'
+  | 'ACTIVE'
+  | 'DISABLED';
 
 export interface PublicOrganisationDto {
   id: string;
@@ -26,7 +30,7 @@ export interface PublicTraineeProfileDto {
 
 export interface PublicAdminProfileDto {
   id: string;
-  adminStatus: 'ACTIVE' | 'INACTIVE';
+  adminStatus: 'ACTIVE' | 'DISABLED';
   adminType: 'ORGANISATION' | 'IP';
   organisation?: PublicOrganisationDto | null;
 }

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -18,7 +18,7 @@ export type TraineeStatusDto = 'ACTIVE' | 'INACTIVE';
 
 export type OrganisationUserStatusDto = 'ACTIVE' | 'INACTIVE';
 
-export type AdminStatusDto = 'ACTIVE' | 'INACTIVE';
+export type AdminStatusDto = 'ACTIVE' | 'DISABLED';
 
 export type GeneralTraineeAccessSourceDto = 'SELF_SIGNUP' | 'INVITE' | 'SEED' | 'ADMIN_CREATED';
 


### PR DESCRIPTION
PR Title: feat: add auth database foundation

## Summary

Adds the Sprint 4 auth database foundation required before the next backend auth work starts.

This includes Prisma schema and migration support for user auth status fields, platform admin roles, auth sessions, refresh tokens, action tokens, and email delivery logs. It also adds an optional initial `SUPER_ADMIN` bootstrap seed flow using environment variables and keeps existing Demo 1 seed behavior intact.

New bootstrap env vars added to the examples:

```env
AUTH_BOOTSTRAP_SUPER_ADMIN_EMAIL=
AUTH_BOOTSTRAP_SUPER_ADMIN_PASSWORD=
AUTH_BOOTSTRAP_SUPER_ADMIN_NAME=
```

Shared DTO and Swagger enum values were updated to match the new auth/admin status domain model. Auth endpoints, refresh/logout flows, email verification flows, password reset flows, organisation onboarding tables, and platform admin management endpoints are intentionally out of scope.

## Linked Issue

Closes #218 

## Type of change

* [x] Feature
* [ ] Bug Fix
* [ ] Documentation
* [x] Chore/Maintenance

## Testing

Verified locally:

```bash
pnpm --filter @insightful-phish/backend exec prisma validate
pnpm --filter @insightful-phish/backend test -- auth-foundation.schema.test.ts auth-bootstrap-seed.test.ts
pnpm --filter @insightful-phish/backend test
pnpm typecheck:backend
pnpm exec prettier --check <touched files>
pnpm lint:backend
git diff --check
```

Manual verification:

* Applied the auth foundation migration locally.
* Regenerated the Prisma client from the updated schema.
* Confirmed the Docker stack starts successfully with Postgres, backend, and frontend.

## Review Notes

Please review the migration carefully, especially enum value migration for:

* `AuthStatus.PENDING` to `PENDING_EMAIL_VERIFICATION`
* `AdminStatus.INACTIVE` to `DISABLED`

The bootstrap super-admin seed is optional and only runs when all `AUTH_BOOTSTRAP_SUPER_ADMIN_*` env vars are provided. Placeholder values were added to env examples only; no secrets are committed.

Generated Prisma client files were not manually edited.

## Checklist

* [x] I tested the change locally
* [x] Accessibility impact was considered if applicable
* [x] No unrelated changes are included
* [x] Relevant tests were added or updated if applicable
* [x] Documentation was updated if needed
* [x] No secrets, credentials, or sensitive values were committed
