### PR TITLE
Feat/org membership db/adriano

### DIFF
--- a/apps/backend/prisma/migrations/20260629120000_org_membership_invite_foundation/migration.sql
+++ b/apps/backend/prisma/migrations/20260629120000_org_membership_invite_foundation/migration.sql
@@ -1,0 +1,42 @@
+-- Extend invitation lifecycle support for organisation trainee invites.
+ALTER TYPE "InvitationPurpose" ADD VALUE 'ORGANISATION_TRAINEE_INVITE';
+
+ALTER TYPE "InvitationStatus" ADD VALUE 'SENT';
+ALTER TYPE "InvitationStatus" ADD VALUE 'FAILED_TO_SEND';
+ALTER TYPE "InvitationStatus" ADD VALUE 'COMPLETED';
+ALTER TYPE "InvitationStatus" ADD VALUE 'REJECTED';
+
+-- Preserve existing organisation trainee membership state while adopting membership naming.
+ALTER TABLE "OrganisationTraineeProfile"
+  RENAME COLUMN "organisationUserStatus" TO "membershipStatus";
+
+ALTER INDEX "OrganisationTraineeProfile_organisationUserStatus_idx"
+  RENAME TO "OrganisationTraineeProfile_membershipStatus_idx";
+
+-- Nullable fields preserve existing rows and allow later invite acceptance flows to link records.
+ALTER TABLE "OrganisationTraineeProfile"
+  ADD COLUMN "createdFromInvitationId" TEXT,
+  ADD COLUMN "disabledAt" TIMESTAMP(3),
+  ADD COLUMN "disabledReason" TEXT;
+
+ALTER TABLE "Invitation"
+  ADD COLUMN "targetUserId" TEXT;
+
+CREATE UNIQUE INDEX "OrganisationTraineeProfile_createdFromInvitationId_key"
+  ON "OrganisationTraineeProfile"("createdFromInvitationId");
+
+CREATE INDEX "OrganisationTraineeProfile_disabledAt_idx"
+  ON "OrganisationTraineeProfile"("disabledAt");
+
+CREATE INDEX "Invitation_targetUserId_idx"
+  ON "Invitation"("targetUserId");
+
+ALTER TABLE "OrganisationTraineeProfile"
+  ADD CONSTRAINT "OrganisationTraineeProfile_createdFromInvitationId_fkey"
+  FOREIGN KEY ("createdFromInvitationId") REFERENCES "Invitation"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "Invitation"
+  ADD CONSTRAINT "Invitation_targetUserId_fkey"
+  FOREIGN KEY ("targetUserId") REFERENCES "User"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/backend/prisma/migrations/20260629120000_org_membership_invite_foundation/migration.sql
+++ b/apps/backend/prisma/migrations/20260629120000_org_membership_invite_foundation/migration.sql
@@ -22,8 +22,11 @@ ALTER TABLE "OrganisationTraineeProfile"
 ALTER TABLE "Invitation"
   ADD COLUMN "targetUserId" TEXT;
 
-CREATE UNIQUE INDEX "OrganisationTraineeProfile_createdFromInvitationId_key"
-  ON "OrganisationTraineeProfile"("createdFromInvitationId");
+CREATE UNIQUE INDEX "OrganisationTraineeProfile_createdFromInvitationId_organisationId_key"
+  ON "OrganisationTraineeProfile"("createdFromInvitationId", "organisationId");
+
+CREATE UNIQUE INDEX "Invitation_id_organisationId_key"
+  ON "Invitation"("id", "organisationId");
 
 CREATE INDEX "OrganisationTraineeProfile_disabledAt_idx"
   ON "OrganisationTraineeProfile"("disabledAt");
@@ -33,8 +36,8 @@ CREATE INDEX "Invitation_targetUserId_idx"
 
 ALTER TABLE "OrganisationTraineeProfile"
   ADD CONSTRAINT "OrganisationTraineeProfile_createdFromInvitationId_fkey"
-  FOREIGN KEY ("createdFromInvitationId") REFERENCES "Invitation"("id")
-  ON DELETE SET NULL ON UPDATE CASCADE;
+  FOREIGN KEY ("createdFromInvitationId", "organisationId") REFERENCES "Invitation"("id", "organisationId")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
 
 ALTER TABLE "Invitation"
   ADD CONSTRAINT "Invitation_targetUserId_fkey"

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -444,19 +444,22 @@ model GeneralTraineeProfile {
 }
 
 model OrganisationTraineeProfile {
-  id                     String                 @id @default(uuid())
-  traineeProfileId       String                 @unique
-  organisationId         String
-  employeeLabel          String?
-  joinedAt               DateTime               @default(now())
-  organisationUserStatus OrganisationUserStatus @default(ACTIVE)
-  createdAt              DateTime               @default(now())
-  updatedAt              DateTime               @updatedAt
-  traineeProfile         TraineeProfile         @relation(fields: [traineeProfileId], references: [id], onDelete: Cascade)
-  organisation           Organisation           @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  id               String                 @id @default(uuid())
+  traineeProfileId String                 @unique
+  organisationId   String
+  employeeLabel    String?
+  joinedAt         DateTime               @default(now())
+  membershipStatus OrganisationUserStatus @default(ACTIVE)
+  disabledAt       DateTime?
+  disabledReason   String?
+  createdAt        DateTime               @default(now())
+  updatedAt        DateTime               @updatedAt
+  traineeProfile   TraineeProfile         @relation(fields: [traineeProfileId], references: [id], onDelete: Cascade)
+  organisation     Organisation           @relation(fields: [organisationId], references: [id], onDelete: Cascade)
 
   @@index([organisationId])
-  @@index([organisationUserStatus])
+  @@index([membershipStatus])
+  @@index([disabledAt])
 }
 
 model OrganisationAdminProfile {

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -136,13 +136,18 @@ enum OrganisationRegistrationRequestStatus {
 
 enum InvitationPurpose {
   INITIAL_ORGANISATION_ADMIN_SETUP
+  ORGANISATION_TRAINEE_INVITE
 }
 
 enum InvitationStatus {
   PENDING
+  SENT
+  FAILED_TO_SEND
   ACCEPTED
+  COMPLETED
   EXPIRED
   REVOKED
+  REJECTED
 }
 
 enum OrganisationContextType {
@@ -414,6 +419,7 @@ model User {
   authSessions                 AuthSession[]
   actionTokens                 ActionToken[]
   emailDeliveryLogs            EmailDeliveryLog[]
+  targetedInvitations          Invitation[]               @relation("InvitationTargetUser")
   auditLogEntries              AuditLogEntry[]           @relation("AuditLogEntryActor")
 }
 
@@ -444,18 +450,20 @@ model GeneralTraineeProfile {
 }
 
 model OrganisationTraineeProfile {
-  id               String                 @id @default(uuid())
-  traineeProfileId String                 @unique
-  organisationId   String
-  employeeLabel    String?
-  joinedAt         DateTime               @default(now())
-  membershipStatus OrganisationUserStatus @default(ACTIVE)
-  disabledAt       DateTime?
-  disabledReason   String?
-  createdAt        DateTime               @default(now())
-  updatedAt        DateTime               @updatedAt
-  traineeProfile   TraineeProfile         @relation(fields: [traineeProfileId], references: [id], onDelete: Cascade)
-  organisation     Organisation           @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  id                      String                 @id @default(uuid())
+  traineeProfileId        String                 @unique
+  organisationId          String
+  employeeLabel           String?
+  joinedAt                DateTime               @default(now())
+  membershipStatus        OrganisationUserStatus @default(ACTIVE)
+  createdFromInvitationId String?                @unique
+  disabledAt              DateTime?
+  disabledReason          String?
+  createdAt               DateTime               @default(now())
+  updatedAt               DateTime               @updatedAt
+  traineeProfile          TraineeProfile         @relation(fields: [traineeProfileId], references: [id], onDelete: Cascade)
+  organisation            Organisation           @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  createdFromInvitation   Invitation?            @relation("InvitationAcceptedOrganisationTrainee", fields: [createdFromInvitationId], references: [id], onDelete: SetNull)
 
   @@index([organisationId])
   @@index([membershipStatus])
@@ -673,6 +681,7 @@ model Invitation {
   id                                String                           @id @default(uuid())
   organisationId                    String
   organisationRegistrationRequestId String?
+  targetUserId                      String?
   recipientEmail                    String
   recipientFirstName                String?
   recipientLastName                 String?
@@ -686,11 +695,14 @@ model Invitation {
   updatedAt                         DateTime                         @updatedAt
   organisation                      Organisation                     @relation(fields: [organisationId], references: [id], onDelete: Cascade)
   organisationRegistrationRequest   OrganisationRegistrationRequest? @relation(fields: [organisationRegistrationRequestId], references: [id], onDelete: SetNull)
+  targetUser                        User?                            @relation("InvitationTargetUser", fields: [targetUserId], references: [id], onDelete: SetNull)
+  acceptedOrganisationTraineeProfile OrganisationTraineeProfile?      @relation("InvitationAcceptedOrganisationTrainee")
   actionTokens                      ActionToken[]
   emailDeliveryLogs                 EmailDeliveryLog[]
 
   @@index([organisationId])
   @@index([organisationRegistrationRequestId])
+  @@index([targetUserId])
   @@index([recipientEmail])
   @@index([status])
   @@index([purpose])

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -567,8 +567,8 @@ model ActionToken {
   createdAt                         DateTime                         @default(now())
   updatedAt                         DateTime                         @updatedAt
   user                              User?                            @relation(fields: [userId], references: [id], onDelete: Cascade)
-  emailDeliveryLogs                 EmailDeliveryLog[]
-  invitation                        Invitation?                      @relation(fields: [invitationId], references: [id], onDelete: SetNull)
+  emailDeliveryLogs                 EmailDeliveryLog[]               @relation("ActionTokenEmailDeliveryLogs")
+  invitation                        Invitation?                      @relation("InvitationActionTokens", fields: [invitationId], references: [id], onDelete: SetNull)
   organisationRegistrationRequest   OrganisationRegistrationRequest? @relation(fields: [organisationRegistrationRequestId], references: [id], onDelete: SetNull)
 
   @@index([userId])
@@ -603,10 +603,10 @@ model EmailDeliveryLog {
   createdAt                         DateTime                         @default(now())
   updatedAt                         DateTime                         @updatedAt
   user                              User?                            @relation(fields: [userId], references: [id], onDelete: SetNull)
-  actionToken                       ActionToken?                     @relation(fields: [actionTokenId], references: [id], onDelete: SetNull)
+  actionToken                       ActionToken?                     @relation("ActionTokenEmailDeliveryLogs", fields: [actionTokenId], references: [id], onDelete: SetNull)
   organisation                      Organisation?                    @relation(fields: [organisationId], references: [id], onDelete: SetNull)
   organisationRegistrationRequest   OrganisationRegistrationRequest? @relation(fields: [organisationRegistrationRequestId], references: [id], onDelete: SetNull)
-  invitation                        Invitation?                      @relation(fields: [invitationId], references: [id], onDelete: SetNull)
+  invitation                        Invitation?                      @relation("InvitationEmailDeliveryLogs", fields: [invitationId], references: [id], onDelete: SetNull)
 
   @@index([recipientEmail])
   @@index([emailType])
@@ -696,9 +696,9 @@ model Invitation {
   organisation                      Organisation                     @relation(fields: [organisationId], references: [id], onDelete: Cascade)
   organisationRegistrationRequest   OrganisationRegistrationRequest? @relation(fields: [organisationRegistrationRequestId], references: [id], onDelete: SetNull)
   targetUser                        User?                            @relation("InvitationTargetUser", fields: [targetUserId], references: [id], onDelete: SetNull)
-  acceptedOrganisationTraineeProfile OrganisationTraineeProfile?      @relation("InvitationAcceptedOrganisationTrainee")
-  actionTokens                      ActionToken[]
-  emailDeliveryLogs                 EmailDeliveryLog[]
+  acceptedOrganisationTraineeProfile OrganisationTraineeProfile?     @relation("InvitationAcceptedOrganisationTrainee")
+  actionTokens                      ActionToken[]                    @relation("InvitationActionTokens")
+  emailDeliveryLogs                 EmailDeliveryLog[]               @relation("InvitationEmailDeliveryLogs")
 
   @@index([organisationId])
   @@index([organisationRegistrationRequestId])

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -419,7 +419,7 @@ model User {
   authSessions                 AuthSession[]
   actionTokens                 ActionToken[]
   emailDeliveryLogs            EmailDeliveryLog[]
-  targetedInvitations          Invitation[]               @relation("InvitationTargetUser")
+  targetedInvitations          Invitation[]              @relation("InvitationTargetUser")
   auditLogEntries              AuditLogEntry[]           @relation("AuditLogEntryActor")
 }
 
@@ -456,15 +456,16 @@ model OrganisationTraineeProfile {
   employeeLabel           String?
   joinedAt                DateTime               @default(now())
   membershipStatus        OrganisationUserStatus @default(ACTIVE)
-  createdFromInvitationId String?                @unique
+  createdFromInvitationId String?
   disabledAt              DateTime?
   disabledReason          String?
   createdAt               DateTime               @default(now())
   updatedAt               DateTime               @updatedAt
   traineeProfile          TraineeProfile         @relation(fields: [traineeProfileId], references: [id], onDelete: Cascade)
   organisation            Organisation           @relation(fields: [organisationId], references: [id], onDelete: Cascade)
-  createdFromInvitation   Invitation?            @relation("InvitationAcceptedOrganisationTrainee", fields: [createdFromInvitationId], references: [id], onDelete: SetNull)
+  createdFromInvitation   Invitation?            @relation("InvitationAcceptedOrganisationTrainee", fields: [createdFromInvitationId, organisationId], references: [id, organisationId], onDelete: Restrict)
 
+  @@unique([createdFromInvitationId, organisationId])
   @@index([organisationId])
   @@index([membershipStatus])
   @@index([disabledAt])
@@ -637,34 +638,34 @@ model Organisation {
 }
 
 model OrganisationRegistrationRequest {
-  id                        String                                @id @default(uuid())
-  submittedOrganisationName String
-  submittedWebsite          String?
+  id                               String                                @id @default(uuid())
+  submittedOrganisationName        String
+  submittedWebsite                 String?
   submittedOrganisationDescription String?
   submittedOrganisationSize        Int?
-  submittedPrimaryDomain    String?
-  representativeFirstName   String
-  representativeLastName    String
-  representativeEmail       String
-  representativePhone       String?
-  status                    OrganisationRegistrationRequestStatus @default(PENDING_REVIEW)
-  contactedByIpAdminId      String?
-  approvedByIpAdminId       String?
-  rejectedByIpAdminId       String?
-  approvedOrganisationId    String?
-  contactedAt               DateTime?
-  approvedAt                DateTime?
-  rejectedAt                DateTime?
-  rejectionReason           String?
-  createdAt                 DateTime                              @default(now())
-  updatedAt                 DateTime                              @updatedAt
-  contactedBy               IpAdminProfile?                       @relation("OrganisationRegistrationRequestContactedBy", fields: [contactedByIpAdminId], references: [id], onDelete: SetNull)
-  approvedBy                IpAdminProfile?                       @relation("OrganisationRegistrationRequestApprovedBy", fields: [approvedByIpAdminId], references: [id], onDelete: SetNull)
-  rejectedBy                IpAdminProfile?                       @relation("OrganisationRegistrationRequestRejectedBy", fields: [rejectedByIpAdminId], references: [id], onDelete: SetNull)
-  approvedOrganisation      Organisation?                         @relation(fields: [approvedOrganisationId], references: [id], onDelete: SetNull)
-  initialAdminInvitations   Invitation[]
-  actionTokens              ActionToken[]
-  emailDeliveryLogs         EmailDeliveryLog[]
+  submittedPrimaryDomain           String?
+  representativeFirstName          String
+  representativeLastName           String
+  representativeEmail              String
+  representativePhone              String?
+  status                           OrganisationRegistrationRequestStatus @default(PENDING_REVIEW)
+  contactedByIpAdminId             String?
+  approvedByIpAdminId              String?
+  rejectedByIpAdminId              String?
+  approvedOrganisationId           String?
+  contactedAt                      DateTime?
+  approvedAt                       DateTime?
+  rejectedAt                       DateTime?
+  rejectionReason                  String?
+  createdAt                        DateTime                              @default(now())
+  updatedAt                        DateTime                              @updatedAt
+  contactedBy                      IpAdminProfile?                       @relation("OrganisationRegistrationRequestContactedBy", fields: [contactedByIpAdminId], references: [id], onDelete: SetNull)
+  approvedBy                       IpAdminProfile?                       @relation("OrganisationRegistrationRequestApprovedBy", fields: [approvedByIpAdminId], references: [id], onDelete: SetNull)
+  rejectedBy                       IpAdminProfile?                       @relation("OrganisationRegistrationRequestRejectedBy", fields: [rejectedByIpAdminId], references: [id], onDelete: SetNull)
+  approvedOrganisation             Organisation?                         @relation(fields: [approvedOrganisationId], references: [id], onDelete: SetNull)
+  initialAdminInvitations          Invitation[]
+  actionTokens                     ActionToken[]
+  emailDeliveryLogs                EmailDeliveryLog[]
 
   @@index([status])
   @@index([contactedByIpAdminId])
@@ -678,28 +679,29 @@ model OrganisationRegistrationRequest {
 }
 
 model Invitation {
-  id                                String                           @id @default(uuid())
-  organisationId                    String
-  organisationRegistrationRequestId String?
-  targetUserId                      String?
-  recipientEmail                    String
-  recipientFirstName                String?
-  recipientLastName                 String?
-  purpose                           InvitationPurpose                @default(INITIAL_ORGANISATION_ADMIN_SETUP)
-  status                            InvitationStatus                 @default(PENDING)
-  expiresAt                         DateTime
-  acceptedAt                        DateTime?
-  revokedAt                         DateTime?
-  revokedReason                     String?
-  createdAt                         DateTime                         @default(now())
-  updatedAt                         DateTime                         @updatedAt
-  organisation                      Organisation                     @relation(fields: [organisationId], references: [id], onDelete: Cascade)
-  organisationRegistrationRequest   OrganisationRegistrationRequest? @relation(fields: [organisationRegistrationRequestId], references: [id], onDelete: SetNull)
-  targetUser                        User?                            @relation("InvitationTargetUser", fields: [targetUserId], references: [id], onDelete: SetNull)
-  acceptedOrganisationTraineeProfile OrganisationTraineeProfile?     @relation("InvitationAcceptedOrganisationTrainee")
-  actionTokens                      ActionToken[]                    @relation("InvitationActionTokens")
-  emailDeliveryLogs                 EmailDeliveryLog[]               @relation("InvitationEmailDeliveryLogs")
+  id                                 String                           @id @default(uuid())
+  organisationId                     String
+  organisationRegistrationRequestId  String?
+  targetUserId                       String?
+  recipientEmail                     String
+  recipientFirstName                 String?
+  recipientLastName                  String?
+  purpose                            InvitationPurpose                @default(INITIAL_ORGANISATION_ADMIN_SETUP)
+  status                             InvitationStatus                 @default(PENDING)
+  expiresAt                          DateTime
+  acceptedAt                         DateTime?
+  revokedAt                          DateTime?
+  revokedReason                      String?
+  createdAt                          DateTime                         @default(now())
+  updatedAt                          DateTime                         @updatedAt
+  organisation                       Organisation                     @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  organisationRegistrationRequest    OrganisationRegistrationRequest? @relation(fields: [organisationRegistrationRequestId], references: [id], onDelete: SetNull)
+  targetUser                         User?                            @relation("InvitationTargetUser", fields: [targetUserId], references: [id], onDelete: SetNull)
+  acceptedOrganisationTraineeProfile OrganisationTraineeProfile?      @relation("InvitationAcceptedOrganisationTrainee")
+  actionTokens                       ActionToken[]                    @relation("InvitationActionTokens")
+  emailDeliveryLogs                  EmailDeliveryLog[]               @relation("InvitationEmailDeliveryLogs")
 
+  @@unique([id, organisationId])
   @@index([organisationId])
   @@index([organisationRegistrationRequestId])
   @@index([targetUserId])

--- a/apps/backend/src/repositories/setup.repository.ts
+++ b/apps/backend/src/repositories/setup.repository.ts
@@ -100,7 +100,7 @@ export function createOrganisationTraineeUser(
           organisationTraineeProfile: {
             create: {
               organisationId: input.organisationId,
-              organisationUserStatus: 'ACTIVE',
+              membershipStatus: 'ACTIVE',
             },
           },
         },
@@ -212,11 +212,11 @@ export async function activateOrganisationTraineeUser(
     create: {
       traineeProfileId: traineeProfile.id,
       organisationId: input.organisationId,
-      organisationUserStatus: 'ACTIVE',
+      membershipStatus: 'ACTIVE',
     },
     update: {
       organisationId: input.organisationId,
-      organisationUserStatus: 'ACTIVE',
+      membershipStatus: 'ACTIVE',
     },
   });
 

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -99,8 +99,7 @@ export function toGuardAuthSubject(user: UserWithAuthSubject | null): GuardAuthS
       : null,
     organisationTraineeProfile: user.traineeProfile?.organisationTraineeProfile
       ? {
-          organisationUserStatus:
-            user.traineeProfile.organisationTraineeProfile.organisationUserStatus,
+          membershipStatus: user.traineeProfile.organisationTraineeProfile.membershipStatus,
           organisation: {
             id: user.traineeProfile.organisationTraineeProfile.organisation.id,
             status: user.traineeProfile.organisationTraineeProfile.organisation.status,

--- a/apps/backend/src/services/auth-status-guard.service.ts
+++ b/apps/backend/src/services/auth-status-guard.service.ts
@@ -39,7 +39,7 @@ export type GuardOrganisation = {
 export type GuardTraineeProfile = { traineeStatus: 'ACTIVE' | 'INACTIVE' };
 
 export type GuardOrganisationTraineeProfile = {
-  organisationUserStatus: 'ACTIVE' | 'INACTIVE';
+  membershipStatus: 'ACTIVE' | 'INACTIVE';
   organisation?: GuardOrganisation | null;
 };
 
@@ -90,7 +90,7 @@ export function ensureActiveTraineeProfile(
 export function ensureActiveOrganisationUser(
   organisationProfile: GuardOrganisationTraineeProfile | null | undefined,
 ): AuthGuardResult {
-  if (organisationProfile?.organisationUserStatus !== 'ACTIVE') {
+  if (organisationProfile?.membershipStatus !== 'ACTIVE') {
     return failure('ORGANISATION_USER_INACTIVE');
   }
   return { allowed: true };

--- a/apps/backend/tests/helpers/factories.ts
+++ b/apps/backend/tests/helpers/factories.ts
@@ -11,9 +11,6 @@ import {
   DifficultyLevel,
   CampaignStatus,
   CampaignItemType,
-  CampaignComponentType,
-  CampaignGroupType,
-  CompletionRule,
   CampaignItemAvailabilityStatus,
   AssignmentStatus,
   CampaignAccessType,
@@ -27,6 +24,11 @@ import {
   EmailRedFlagType,
   RedFlagSeverity,
   QuestionType,
+} from '../../src/generated/prisma/enums.js';
+import type {
+  CampaignComponentType,
+  CampaignGroupType,
+  CompletionRule,
 } from '../../src/generated/prisma/enums.js';
 
 // Pre-hashed scrypt password hash for speed (corresponds to "password")
@@ -83,7 +85,7 @@ export async function createTrainee(
       organisationId: string;
       employeeLabel?: string;
       joinedAt?: Date;
-      organisationUserStatus?: OrganisationUserStatus;
+      membershipStatus?: OrganisationUserStatus;
     };
   } = {},
 ) {
@@ -122,8 +124,8 @@ export async function createTrainee(
         organisationId: overrides.organisationProfile.organisationId,
         employeeLabel: overrides.organisationProfile.employeeLabel ?? null,
         joinedAt: overrides.organisationProfile.joinedAt ?? new Date(),
-        organisationUserStatus:
-          overrides.organisationProfile.organisationUserStatus ?? OrganisationUserStatus.ACTIVE,
+        membershipStatus:
+          overrides.organisationProfile.membershipStatus ?? OrganisationUserStatus.ACTIVE,
       },
     });
 

--- a/apps/backend/tests/integration/organisation-membership-relations.integration.test.ts
+++ b/apps/backend/tests/integration/organisation-membership-relations.integration.test.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { prisma } from '../../src/lib/prisma.js';
+
+const TEST_HASHED_CREDENTIAL = ['scrypt', 'membership', 'fixture'].join('$');
+const EXPIRES_AT = new Date('2026-07-29T08:00:00.000Z');
+
+function testId(prefix: string) {
+  return `${prefix}-${randomUUID()}`;
+}
+
+function testEmail(prefix: string) {
+  return `${prefix}-${randomUUID()}@example.test`;
+}
+
+async function createOrganisation(namePrefix: string) {
+  return prisma.organisation.create({
+    data: {
+      id: testId('org'),
+      name: `${namePrefix} ${randomUUID()}`,
+      status: 'ACTIVE',
+    },
+  });
+}
+
+async function createUser(emailPrefix: string) {
+  return prisma.user.create({
+    data: {
+      id: testId('user'),
+      firstName: 'Test',
+      lastName: 'Member',
+      email: testEmail(emailPrefix),
+      passwordHash: TEST_HASHED_CREDENTIAL,
+      userType: 'ORGANISATION_TRAINEE',
+      authStatus: 'ACTIVE',
+    },
+  });
+}
+
+async function createTraineeProfile(userId: string) {
+  return prisma.traineeProfile.create({
+    data: {
+      id: testId('trainee-profile'),
+      userId,
+      traineeStatus: 'ACTIVE',
+    },
+  });
+}
+
+async function createInvitation(input: {
+  organisationId: string;
+  targetUserId: string;
+  emailPrefix: string;
+}) {
+  return prisma.invitation.create({
+    data: {
+      id: testId('invitation'),
+      organisationId: input.organisationId,
+      targetUserId: input.targetUserId,
+      recipientEmail: testEmail(input.emailPrefix),
+      recipientFirstName: 'Invited',
+      recipientLastName: 'Member',
+      purpose: 'ORGANISATION_TRAINEE_INVITE',
+      status: 'SENT',
+      expiresAt: EXPIRES_AT,
+    },
+  });
+}
+
+describe('organisation membership Prisma relations', () => {
+  it('resolves invitation action-token and email-log relations', async () => {
+    const organisation = await createOrganisation('Membership Relations');
+    const targetUser = await createUser('member-target');
+    const invitation = await createInvitation({
+      organisationId: organisation.id,
+      targetUserId: targetUser.id,
+      emailPrefix: 'member-invite',
+    });
+
+    const actionToken = await prisma.actionToken.create({
+      data: {
+        id: testId('action-token'),
+        tokenHash: `sha256:${randomUUID()}`,
+        purpose: 'ORGANISATION_TRAINEE_INVITE',
+        invitationId: invitation.id,
+        targetEmail: invitation.recipientEmail,
+        expiresAt: EXPIRES_AT,
+      },
+    });
+
+    const emailDeliveryLog = await prisma.emailDeliveryLog.create({
+      data: {
+        id: testId('email-log'),
+        recipientEmail: invitation.recipientEmail,
+        emailType: 'ORGANISATION_TRAINEE_INVITE',
+        actionTokenId: actionToken.id,
+        organisationId: organisation.id,
+        invitationId: invitation.id,
+        deliveryStatus: 'PENDING',
+      },
+    });
+
+    const storedInvitation = await prisma.invitation.findUniqueOrThrow({
+      where: { id: invitation.id },
+      include: {
+        actionTokens: true,
+        emailDeliveryLogs: true,
+      },
+    });
+
+    expect(storedInvitation.actionTokens).toMatchObject([{ id: actionToken.id }]);
+    expect(storedInvitation.emailDeliveryLogs).toMatchObject([{ id: emailDeliveryLog.id }]);
+  });
+
+  it('links accepted invitations to organisation-scoped trainee memberships', async () => {
+    const organisation = await createOrganisation('Accepted Membership');
+    const targetUser = await createUser('accepted-member');
+    const traineeProfile = await createTraineeProfile(targetUser.id);
+    const invitation = await createInvitation({
+      organisationId: organisation.id,
+      targetUserId: targetUser.id,
+      emailPrefix: 'accepted-invite',
+    });
+
+    await prisma.invitation.update({
+      where: { id: invitation.id },
+      data: {
+        status: 'COMPLETED',
+        acceptedAt: new Date('2026-07-01T08:00:00.000Z'),
+      },
+    });
+
+    const membership = await prisma.organisationTraineeProfile.create({
+      data: {
+        id: testId('membership'),
+        traineeProfileId: traineeProfile.id,
+        organisationId: organisation.id,
+        membershipStatus: 'ACTIVE',
+        createdFromInvitationId: invitation.id,
+      },
+    });
+
+    const storedInvitation = await prisma.invitation.findUniqueOrThrow({
+      where: { id: invitation.id },
+      include: {
+        acceptedOrganisationTraineeProfile: true,
+      },
+    });
+
+    expect(storedInvitation.status).toBe('COMPLETED');
+    expect(storedInvitation.acceptedOrganisationTraineeProfile).toMatchObject({
+      id: membership.id,
+      organisationId: organisation.id,
+      createdFromInvitationId: invitation.id,
+      membershipStatus: 'ACTIVE',
+    });
+  });
+
+  it.each([
+    'PENDING',
+    'SENT',
+    'FAILED_TO_SEND',
+    'ACCEPTED',
+    'COMPLETED',
+    'EXPIRED',
+    'REVOKED',
+    'REJECTED',
+  ] as const)('can represent invitation status %s', async (status) => {
+    const organisation = await createOrganisation(`Status ${status}`);
+    const targetUser = await createUser(`status-${status.toLowerCase()}`);
+
+    const invitation = await prisma.invitation.create({
+      data: {
+        id: testId('invitation-status'),
+        organisationId: organisation.id,
+        targetUserId: targetUser.id,
+        recipientEmail: testEmail(`status-${status.toLowerCase()}`),
+        purpose: 'ORGANISATION_TRAINEE_INVITE',
+        status,
+        expiresAt: EXPIRES_AT,
+      },
+    });
+
+    expect(invitation.status).toBe(status);
+    expect(invitation.purpose).toBe('ORGANISATION_TRAINEE_INVITE');
+  });
+
+  it('rejects linking a membership to an invitation from another organisation', async () => {
+    const invitationOrganisation = await createOrganisation('Invitation Organisation');
+    const membershipOrganisation = await createOrganisation('Membership Organisation');
+    const targetUser = await createUser('cross-org-member');
+    const traineeProfile = await createTraineeProfile(targetUser.id);
+    const invitation = await createInvitation({
+      organisationId: invitationOrganisation.id,
+      targetUserId: targetUser.id,
+      emailPrefix: 'cross-org-invite',
+    });
+
+    await expect(
+      prisma.organisationTraineeProfile.create({
+        data: {
+          id: testId('cross-org-membership'),
+          traineeProfileId: traineeProfile.id,
+          organisationId: membershipOrganisation.id,
+          membershipStatus: 'ACTIVE',
+          createdFromInvitationId: invitation.id,
+        },
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/backend/tests/unit/auth-status-guard.service.test.ts
+++ b/apps/backend/tests/unit/auth-status-guard.service.test.ts
@@ -47,7 +47,7 @@ describe('auth-status guard service', () => {
       ensureUserCanAuthenticate({
         user: { ...user, userType: 'ORGANISATION_TRAINEE' },
         traineeProfile: { traineeStatus: 'ACTIVE' },
-        organisationTraineeProfile: { organisationUserStatus: 'ACTIVE', organisation: defaultOrg },
+        organisationTraineeProfile: { membershipStatus: 'ACTIVE', organisation: defaultOrg },
       }),
     ).toEqual({ allowed: true });
 
@@ -84,7 +84,7 @@ describe('auth-status guard service', () => {
     expect(
       ensureOrganisationMember({
         user: { ...user, userType: 'ORGANISATION_TRAINEE' },
-        organisationTraineeProfile: { organisationUserStatus: 'ACTIVE', organisation: defaultOrg },
+        organisationTraineeProfile: { membershipStatus: 'ACTIVE', organisation: defaultOrg },
       }),
     ).toEqual({ allowed: true });
 
@@ -117,7 +117,7 @@ describe('auth-status guard service', () => {
         user: { ...user, userType: 'ORGANISATION_TRAINEE' },
         traineeProfile: { traineeStatus: 'ACTIVE' },
         organisationTraineeProfile: {
-          organisationUserStatus: 'INACTIVE',
+          membershipStatus: 'INACTIVE',
           organisation: defaultOrg,
         },
       },

--- a/apps/backend/tests/unit/org-membership.schema.test.ts
+++ b/apps/backend/tests/unit/org-membership.schema.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const schema = readFileSync(resolve(process.cwd(), 'prisma/schema.prisma'), 'utf8');
+
+function schemaBlock(kind: 'enum' | 'model', name: string): string {
+  const match = schema.match(new RegExp(`${kind} ${name}\\s*\\{([\\s\\S]*?)\\n\\}`));
+
+  if (!match?.[1]) {
+    throw new Error(`${kind} ${name} was not found in Prisma schema.`);
+  }
+
+  return match[1];
+}
+
+function expectValues(block: string, values: readonly string[]): void {
+  for (const value of values) {
+    expect(block).toContain(value);
+  }
+}
+
+describe('organisation membership Prisma schema', () => {
+  it('adds membership lifecycle fields to organisation trainee profiles', () => {
+    const profile = schemaBlock('model', 'OrganisationTraineeProfile');
+
+    expectValues(profile, [
+      'membershipStatus',
+      'joinedAt',
+      'createdFromInvitationId',
+      'disabledAt',
+      'disabledReason',
+      'createdFromInvitation',
+      '@@index([membershipStatus])',
+      '@@index([disabledAt])',
+    ]);
+    expect(profile).not.toContain('organisationUserStatus');
+  });
+
+  it('supports organisation trainee invitation lifecycle values', () => {
+    expectValues(schemaBlock('enum', 'InvitationPurpose'), [
+      'INITIAL_ORGANISATION_ADMIN_SETUP',
+      'ORGANISATION_TRAINEE_INVITE',
+    ]);
+    expectValues(schemaBlock('enum', 'InvitationStatus'), [
+      'PENDING',
+      'SENT',
+      'FAILED_TO_SEND',
+      'ACCEPTED',
+      'COMPLETED',
+      'EXPIRED',
+      'REVOKED',
+      'REJECTED',
+    ]);
+  });
+
+  it('links invitations to target users and accepted memberships', () => {
+    const invitation = schemaBlock('model', 'Invitation');
+    const user = schemaBlock('model', 'User');
+
+    expectValues(invitation, [
+      'targetUserId',
+      'targetUser',
+      'acceptedOrganisationTraineeProfile',
+      '@@index([targetUserId])',
+    ]);
+    expect(user).toContain('targetedInvitations');
+  });
+
+  it('keeps invite token and email-log relations typed', () => {
+    expectValues(schemaBlock('model', 'ActionToken'), [
+      'invitationId',
+      'invitation',
+      'InvitationActionTokens',
+      'ActionTokenEmailDeliveryLogs',
+    ]);
+    expectValues(schemaBlock('model', 'EmailDeliveryLog'), [
+      'actionTokenId',
+      'invitationId',
+      'actionToken',
+      'invitation',
+      'ActionTokenEmailDeliveryLogs',
+      'InvitationEmailDeliveryLogs',
+    ]);
+  });
+});

--- a/apps/backend/tests/unit/org-membership.schema.test.ts
+++ b/apps/backend/tests/unit/org-membership.schema.test.ts
@@ -31,6 +31,9 @@ describe('organisation membership Prisma schema', () => {
       'disabledAt',
       'disabledReason',
       'createdFromInvitation',
+      'fields: [createdFromInvitationId, organisationId]',
+      'references: [id, organisationId]',
+      '@@unique([createdFromInvitationId, organisationId])',
       '@@index([membershipStatus])',
       '@@index([disabledAt])',
     ]);
@@ -63,6 +66,7 @@ describe('organisation membership Prisma schema', () => {
       'targetUser',
       'acceptedOrganisationTraineeProfile',
       '@@index([targetUserId])',
+      '@@unique([id, organisationId])',
     ]);
     expect(user).toContain('targetedInvitations');
   });

--- a/apps/backend/tests/unit/user.repository.auth-subject.test.ts
+++ b/apps/backend/tests/unit/user.repository.auth-subject.test.ts
@@ -71,7 +71,7 @@ describe('user repository auth subject helpers', () => {
       traineeProfile: {
         traineeStatus: 'ACTIVE',
         organisationTraineeProfile: {
-          organisationUserStatus: 'ACTIVE',
+          membershipStatus: 'ACTIVE',
           organisation: {
             id: 'org01',
             status: 'ACTIVE',
@@ -88,7 +88,7 @@ describe('user repository auth subject helpers', () => {
       },
       traineeProfile: { traineeStatus: 'ACTIVE' },
       organisationTraineeProfile: {
-        organisationUserStatus: 'ACTIVE',
+        membershipStatus: 'ACTIVE',
         organisation: {
           id: 'org01',
           status: 'ACTIVE',

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -16,7 +16,9 @@ import type {
 
 export type TraineeStatusDto = 'ACTIVE' | 'INACTIVE';
 
-export type OrganisationUserStatusDto = 'ACTIVE' | 'INACTIVE';
+export type OrganisationTraineeMembershipStatusDto = 'ACTIVE' | 'INACTIVE';
+
+export type OrganisationUserStatusDto = OrganisationTraineeMembershipStatusDto;
 
 export type AdminStatusDto = 'ACTIVE' | 'DISABLED';
 
@@ -121,7 +123,10 @@ export interface OrganisationTraineeProfileDto {
   organisationId: string;
   employeeLabel?: string | null;
   joinedAt: string;
-  organisationUserStatus: OrganisationUserStatusDto;
+  membershipStatus: OrganisationTraineeMembershipStatusDto;
+  createdFromInvitationId?: string | null;
+  disabledAt?: string | null;
+  disabledReason?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -18,8 +18,6 @@ export type TraineeStatusDto = 'ACTIVE' | 'INACTIVE';
 
 export type OrganisationTraineeMembershipStatusDto = 'ACTIVE' | 'INACTIVE';
 
-export type OrganisationUserStatusDto = OrganisationTraineeMembershipStatusDto;
-
 export type AdminStatusDto = 'ACTIVE' | 'DISABLED';
 
 export type GeneralTraineeAccessSourceDto = 'SELF_SIGNUP' | 'INVITE' | 'SEED' | 'ADMIN_CREATED';


### PR DESCRIPTION
PR Title: feat: add organisation membership invite database foundation

## Summary

Adds the Sprint 4 database foundation for organisation membership and organisation employee invite flows.

This updates the Prisma foundation for `ORGANISATIONTRAINEE` membership status tracking, employee invitation lifecycle support, invite setup/acceptance token relations, and employee invite email-log relations. The changes are intended to unlock later organisation employee invite, accept invite, resend, revoke, and employee list backend work.

The migration preserves existing organisation/user data and keeps this issue focused on database foundations only. No employee invite/list endpoints, frontend changes, organisation admin promotion permissions, organisation security settings, or direct SMTP/email sending logic are included.

## Linked Issue

Closes #262 

## Type of change

* [x] Feature
* [ ] Bug Fix
* [ ] Documentation
* [x] Chore/Maintenance

## Testing

Ran:

```bash
pnpm --filter @insightful-phish/backend exec prisma validate
pnpm --filter @insightful-phish/backend exec prisma generate
pnpm build:shared
pnpm --filter @insightful-phish/backend test -- organisation-membership
pnpm --filter @insightful-phish/backend test
pnpm typecheck:backend
pnpm lint:backend
git diff --check
```

Verified:

* Prisma schema validates successfully.
* Prisma client generation completes successfully.
* Shared package build passes.
* Backend unit tests pass for the organisation membership/invite foundation.
* Backend typecheck and lint pass.
* Git diff whitespace check passes.

## Review Notes

Reviewers should focus on the Prisma schema and migration, especially:

* `OrganisationTrainee` membership lifecycle fields
* invitation status/type support for organisation employee invites
* invitation-to-action-token relations
* invitation/email-log relations
* accepted invitation to resulting organisation trainee membership relation
* data preservation for existing organisation/user records

This PR intentionally does not implement employee invite/list/accept/resend/revoke endpoints. Those are unlocked by this database foundation and will be handled in later issues.

No frontend changes, new environment variables, production email provider setup, direct SMTP calls, or generated Prisma client edits are included.

## Checklist

* [x] I tested the change locally
* [x] Accessibility impact was considered if applicable
* [x] No unrelated changes are included
* [x] Relevant tests were added or updated if applicable
* [x] Documentation was updated if needed
* [x] No secrets, credentials, or sensitive values were committed
