### PR TITLE
feat(auth): implement forgot password, reset password, and token cont…

### DIFF
--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -656,6 +656,97 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             },
           },
         },
+        AuthForgotPasswordRequest: {
+          type: 'object',
+          required: ['email'],
+          additionalProperties: false,
+          properties: {
+            email: {
+              type: 'string',
+              format: 'email',
+              example: 'johan@example.com',
+            },
+          },
+        },
+        AuthForgotPasswordResponse: {
+          type: 'object',
+          required: ['message'],
+          properties: {
+            message: {
+              type: 'string',
+              example: 'If the email is registered, a password reset link has been sent.',
+            },
+          },
+        },
+        AuthResetPasswordRequest: {
+          type: 'object',
+          required: ['token', 'newPassword', 'confirmNewPassword'],
+          additionalProperties: false,
+          properties: {
+            token: {
+              type: 'string',
+              example: 'exampleResetTokenValueWithAtLeast32Chars',
+            },
+            newPassword: {
+              type: 'string',
+              format: 'password',
+              minLength: 12,
+              example: 'ExampleLocalPassword1!',
+            },
+            confirmNewPassword: {
+              type: 'string',
+              example: 'ExampleLocalPassword1!',
+            },
+          },
+        },
+        AuthResetPasswordResponse: {
+          type: 'object',
+          required: ['success'],
+          properties: {
+            success: {
+              type: 'boolean',
+              example: true,
+            },
+          },
+        },
+        TokenContextResponse: {
+          type: 'object',
+          required: ['tokenState', 'canResend', 'resendCooldownSeconds', 'messageCode', 'flow'],
+          properties: {
+            tokenState: {
+              type: 'string',
+              enum: ['VALID', 'INVALID', 'EXPIRED', 'USED', 'REVOKED'],
+              example: 'VALID',
+            },
+            canResend: {
+              type: 'boolean',
+              example: true,
+            },
+            resendCooldownSeconds: {
+              type: 'integer',
+              example: 0,
+            },
+            messageCode: {
+              type: 'string',
+              example: 'TOKEN_VALID',
+            },
+            flow: {
+              type: 'string',
+              enum: [
+                'EMAIL_VERIFICATION',
+                'PASSWORD_RESET',
+                'EMAIL_CHANGE_VERIFICATION',
+                'INITIAL_ORGANISATION_ADMIN_SETUP',
+                'ORGANISATION_TRAINEE_INVITE',
+                'ORGANISATION_ADMIN_PROMOTION',
+                'PLATFORM_ADMIN_INVITE',
+                'PLATFORM_ADMIN_UPGRADE_CONFIRMATION',
+                'UNKNOWN',
+              ],
+              example: 'PASSWORD_RESET',
+            },
+          },
+        },
         SetupTokenState: enumString(['VALID', 'INVALID', 'EXPIRED', 'USED', 'REVOKED'], 'VALID'),
         SetupTokenContextResponse: {
           type: 'object',
@@ -1967,6 +2058,14 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         AuthLogin: {
           required: true,
           ...jsonContent(schemaRef('AuthLoginRequest')),
+        },
+        AuthForgotPassword: {
+          required: true,
+          ...jsonContent(schemaRef('AuthForgotPasswordRequest')),
+        },
+        AuthResetPassword: {
+          required: true,
+          ...jsonContent(schemaRef('AuthResetPasswordRequest')),
         },
         EmptyJson: {
           required: false,

--- a/apps/backend/src/controllers/auth.controller.ts
+++ b/apps/backend/src/controllers/auth.controller.ts
@@ -5,13 +5,21 @@ import {
   AuthStatusGuardError,
   AuthRefreshTokenReuseError,
   AuthRefreshTokenInvalidError,
+  AuthResetPasswordError,
   loginUser,
   registerUser,
   getCurrentUser,
   refreshUserToken,
   logoutUser,
   resendVerificationEmail,
+  requestPasswordReset,
+  resetUserPassword,
 } from '../services/auth.service.js';
+import {
+  getTokenContext,
+  resendActionToken,
+  TokenResendError,
+} from '../services/action-token.service.js';
 
 function getCookie(req: Request, name: string): string | null {
   const cookieHeader = req.headers.cookie;
@@ -193,4 +201,58 @@ export async function resendVerification(req: Request, res: Response) {
   return res.status(200).json({
     message: 'If the email is registered and unverified, a verification link has been sent.',
   });
+}
+
+export async function forgotPassword(req: Request, res: Response) {
+  await requestPasswordReset(req.body.email);
+  return res.status(200).json({
+    message: 'If the email is registered, a password reset link has been sent.',
+  });
+}
+
+export async function resetPassword(req: Request, res: Response) {
+  try {
+    await resetUserPassword(
+      req.body.token,
+      req.body.newPassword,
+      req.ip,
+      req.headers['user-agent'],
+    );
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    if (error instanceof AuthResetPasswordError) {
+      return res.status(error.statusCode).json({
+        error: error.code,
+        message: error.message,
+      });
+    }
+    throw error;
+  }
+}
+
+export async function validateTokenContext(req: Request, res: Response) {
+  const result = await getTokenContext(req.params.token as string);
+  return res.status(200).json(result);
+}
+
+export async function resendTokenLink(req: Request, res: Response) {
+  try {
+    await resendActionToken(req.params.token as string);
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    if (error instanceof TokenResendError) {
+      if (error.statusCode === 429) {
+        return res.status(429).json({
+          error: error.code,
+          message: error.message,
+          cooldownSeconds: error.cooldownSeconds,
+        });
+      }
+      return res.status(error.statusCode).json({
+        error: error.code,
+        message: error.message,
+      });
+    }
+    throw error;
+  }
 }

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -2,6 +2,9 @@ import {
   authLoginRequestSchema,
   authRegisterRequestSchema,
   authResendVerificationRequestSchema,
+  authForgotPasswordRequestSchema,
+  authResetPasswordRequestSchema,
+  tokenParamsSchema,
 } from '@insightful-phish/shared';
 import { Router } from 'express';
 import {
@@ -11,10 +14,14 @@ import {
   logout,
   refresh,
   resendVerification,
+  forgotPassword,
+  resetPassword,
+  validateTokenContext,
+  resendTokenLink,
 } from '../controllers/auth.controller.js';
 import { authRateLimit } from '../middleware/authRateLimit.js';
 import { requireAuth } from '../middleware/requireAuth.js';
-import { validateBody } from '../middleware/validateRequest.js';
+import { validateBody, validateParams } from '../middleware/validateRequest.js';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 
 export const authRouter = Router();
@@ -217,4 +224,188 @@ authRouter.post(
   authRateLimit,
   validateBody(authResendVerificationRequestSchema),
   asyncHandler(resendVerification),
+);
+
+/**
+ * @openapi
+ * /auth/forgot-password:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Request a password reset link
+ *     description: Initiates a password reset flow. Sends an email containing a secure password reset token when eligible. Always returns a generic success message to prevent account enumeration.
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AuthForgotPasswordRequest'
+ *     responses:
+ *       200:
+ *         description: Safe generic accepted response.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthForgotPasswordResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       429:
+ *         $ref: '#/components/responses/AuthRateLimited'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+authRouter.post(
+  '/auth/forgot-password',
+  authRateLimit,
+  validateBody(authForgotPasswordRequestSchema),
+  asyncHandler(forgotPassword),
+);
+
+/**
+ * @openapi
+ * /auth/reset-password:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Reset password with a token
+ *     description: Resets user password using a valid action token, revoking all existing sessions and refresh tokens on success.
+ *     security: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AuthResetPasswordRequest'
+ *     responses:
+ *       200:
+ *         description: Password reset successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthResetPasswordResponse'
+ *       400:
+ *         description: Bad Request. Token is invalid format.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       401:
+ *         description: Unauthorized. Token is invalid.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       403:
+ *         description: Forbidden. User account is disabled.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       409:
+ *         description: Conflict. Token has already been used.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       422:
+ *         $ref: '#/components/responses/UnprocessableEntity'
+ *       429:
+ *         $ref: '#/components/responses/AuthRateLimited'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+authRouter.post(
+  '/auth/reset-password',
+  authRateLimit,
+  validateBody(authResetPasswordRequestSchema, { statusCode: 422 }),
+  asyncHandler(resetPassword),
+);
+
+/**
+ * @openapi
+ * /auth/tokens/{token}/context:
+ *   get:
+ *     tags: [Auth]
+ *     summary: Retrieve action token context
+ *     description: Returns the validation state, resend eligibility, and cooldown status of a token without consuming it.
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: token
+ *         required: true
+ *         schema:
+ *           type: string
+ *           minLength: 32
+ *           maxLength: 512
+ *           pattern: '^[A-Za-z0-9_-]+$'
+ *         description: The raw token value to fetch context for.
+ *     responses:
+ *       200:
+ *         description: Token context retrieved successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TokenContextResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       429:
+ *         $ref: '#/components/responses/AuthRateLimited'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+authRouter.get(
+  '/auth/tokens/:token/context',
+  authRateLimit,
+  validateParams(tokenParamsSchema),
+  asyncHandler(validateTokenContext),
+);
+
+/**
+ * @openapi
+ * /auth/tokens/{token}/resend:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Request a replacement token
+ *     description: Revokes the original token and triggers email resend for the associated flow, subject to cooldown.
+ *     security: []
+ *     parameters:
+ *       - in: path
+ *         name: token
+ *         required: true
+ *         schema:
+ *           type: string
+ *           minLength: 32
+ *           maxLength: 512
+ *           pattern: '^[A-Za-z0-9_-]+$'
+ *         description: The raw token to resend.
+ *     responses:
+ *       200:
+ *         description: Resend process completed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *       400:
+ *         description: Bad Request. Resend is ineligible.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       429:
+ *         description: Too Many Requests. Cooldown active.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+authRouter.post(
+  '/auth/tokens/:token/resend',
+  authRateLimit,
+  validateParams(tokenParamsSchema),
+  asyncHandler(resendTokenLink),
 );

--- a/apps/backend/src/services/action-token.service.ts
+++ b/apps/backend/src/services/action-token.service.ts
@@ -1,4 +1,6 @@
-import type { ActionTokenPurpose } from '../generated/prisma/enums.js';
+import type { ActionTokenPurpose, EmailDeliveryType } from '../generated/prisma/enums.js';
+import { prisma } from '../lib/prisma.js';
+import { requestAuthEmailSend } from './auth-email-hook.service.js';
 import type { ActionTokenModel } from '../generated/prisma/models/ActionToken.js';
 import {
   createActionToken,
@@ -108,4 +110,246 @@ export function runWithConsumedActionToken<T>(
   action: (tx: Prisma.TransactionClient) => Promise<T>,
 ) {
   return withClaimedActionToken(input, action);
+}
+
+export type TokenContextResponse = {
+  tokenState: ActionTokenState;
+  canResend: boolean;
+  resendCooldownSeconds: number;
+  messageCode: string;
+  flow: ActionTokenPurpose | 'UNKNOWN';
+};
+
+function mapPurposeToEmailType(purpose: ActionTokenPurpose): EmailDeliveryType | null {
+  switch (purpose) {
+    case 'EMAIL_VERIFICATION':
+      return 'EMAIL_VERIFICATION';
+    case 'PASSWORD_RESET':
+      return 'PASSWORD_RESET';
+    case 'EMAIL_CHANGE_VERIFICATION':
+      return 'EMAIL_CHANGE_CONFIRMATION';
+    case 'INITIAL_ORGANISATION_ADMIN_SETUP':
+      return 'INITIAL_ORGANISATION_ADMIN_SETUP';
+    case 'ORGANISATION_TRAINEE_INVITE':
+      return 'ORGANISATION_TRAINEE_INVITE';
+    case 'ORGANISATION_ADMIN_PROMOTION':
+      return 'ORGANISATION_ADMIN_PROMOTION_INVITE';
+    case 'PLATFORM_ADMIN_INVITE':
+      return 'PLATFORM_ADMIN_INVITE';
+    case 'PLATFORM_ADMIN_UPGRADE_CONFIRMATION':
+      return 'PLATFORM_ADMIN_UPGRADE_CONFIRMATION';
+    default:
+      return null;
+  }
+}
+
+function determineTokenState(token: ActionTokenModel, now = new Date()): ActionTokenState {
+  if (token.revokedAt) return 'REVOKED';
+  if (token.usedAt) return 'USED';
+  if (token.expiresAt.getTime() <= now.getTime()) return 'EXPIRED';
+  return 'VALID';
+}
+
+export async function getTokenContext(rawToken: string): Promise<TokenContextResponse> {
+  const tokenHash = hashOpaqueToken(rawToken);
+  const token = await prisma.actionToken.findUnique({
+    where: { tokenHash },
+    include: {
+      user: true,
+      emailChangeRequest: true,
+      invitation: {
+        include: {
+          organisation: true,
+        },
+      },
+    },
+  });
+
+  if (!token) {
+    return {
+      tokenState: 'INVALID',
+      canResend: false,
+      resendCooldownSeconds: 0,
+      messageCode: 'TOKEN_INVALID',
+      flow: 'UNKNOWN',
+    };
+  }
+
+  const now = new Date();
+  const state = determineTokenState(token, now);
+
+  // Determine resend eligibility
+  let canResend = false;
+  const flow = token.purpose;
+
+  if (flow === 'PASSWORD_RESET') {
+    canResend = token.user ? token.user.authStatus !== 'DISABLED' : false;
+  } else if (flow === 'EMAIL_VERIFICATION') {
+    canResend = token.user ? token.user.authStatus === 'PENDING_EMAIL_VERIFICATION' : false;
+  } else if (flow === 'EMAIL_CHANGE_VERIFICATION') {
+    canResend = token.emailChangeRequest ? token.emailChangeRequest.status === 'PENDING' : false;
+  } else if (
+    flow === 'INITIAL_ORGANISATION_ADMIN_SETUP' ||
+    flow === 'ORGANISATION_TRAINEE_INVITE' ||
+    flow === 'ORGANISATION_ADMIN_PROMOTION' ||
+    flow === 'PLATFORM_ADMIN_INVITE' ||
+    flow === 'PLATFORM_ADMIN_UPGRADE_CONFIRMATION'
+  ) {
+    canResend = token.invitation
+      ? token.invitation.status !== 'ACCEPTED' &&
+        token.invitation.status !== 'REVOKED' &&
+        token.invitation.status !== 'COMPLETED'
+      : false;
+  }
+
+  // Compute cooldown
+  let resendCooldownSeconds = 0;
+  const recipientEmail =
+    token.targetEmail ??
+    token.user?.email ??
+    token.invitation?.recipientEmail ??
+    token.emailChangeRequest?.RequestedEmail ??
+    null;
+
+  const emailType = mapPurposeToEmailType(flow);
+
+  if (recipientEmail && emailType) {
+    const lastLog = await prisma.emailDeliveryLog.findFirst({
+      where: {
+        recipientEmail,
+        emailType,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    if (lastLog) {
+      const cooldownMs = 60000;
+      const elapsed = now.getTime() - lastLog.createdAt.getTime();
+      resendCooldownSeconds =
+        elapsed < cooldownMs ? Math.max(0, Math.ceil((cooldownMs - elapsed) / 1000)) : 0;
+    }
+  }
+
+  return {
+    tokenState: state,
+    canResend,
+    resendCooldownSeconds,
+    messageCode: `TOKEN_${state}`,
+    flow,
+  };
+}
+
+export class TokenResendError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+    public readonly cooldownSeconds?: number,
+  ) {
+    super(message);
+    this.name = 'TokenResendError';
+  }
+}
+
+export async function resendActionToken(rawToken: string): Promise<void> {
+  const context = await getTokenContext(rawToken);
+
+  if (!context.canResend || context.flow === 'UNKNOWN') {
+    throw new TokenResendError(400, 'TOKEN_RESEND_INELIGIBLE', 'Token cannot be resent safely');
+  }
+
+  if (context.resendCooldownSeconds > 0) {
+    throw new TokenResendError(
+      429,
+      'RESEND_COOLDOWN_ACTIVE',
+      'Resend cooldown active. Please try again later.',
+      context.resendCooldownSeconds,
+    );
+  }
+
+  const tokenHash = hashOpaqueToken(rawToken);
+  const originalToken = await prisma.actionToken.findUnique({
+    where: { tokenHash },
+    include: {
+      user: true,
+      emailChangeRequest: true,
+      invitation: {
+        include: {
+          organisation: true,
+        },
+      },
+    },
+  });
+
+  if (!originalToken) {
+    throw new TokenResendError(400, 'TOKEN_RESEND_INELIGIBLE', 'Token cannot be resent safely');
+  }
+
+  const recipientEmail =
+    originalToken.targetEmail ??
+    originalToken.user?.email ??
+    originalToken.invitation?.recipientEmail ??
+    originalToken.emailChangeRequest?.RequestedEmail ??
+    null;
+
+  const emailType = mapPurposeToEmailType(originalToken.purpose);
+
+  if (!recipientEmail || !emailType) {
+    throw new TokenResendError(400, 'TOKEN_RESEND_INELIGIBLE', 'Token cannot be resent safely');
+  }
+
+  const newToken = await prisma.$transaction(async (tx) => {
+    await tx.actionToken.updateMany({
+      where: {
+        purpose: originalToken.purpose,
+        userId: originalToken.userId ?? null,
+        invitationId: originalToken.invitationId ?? null,
+        emailChangeRequestId: originalToken.emailChangeRequestId ?? null,
+        targetEmail: originalToken.targetEmail ?? null,
+        revokedAt: null,
+        usedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+        revokedReason: 'REPLACED',
+      },
+    });
+
+    const issued = await issueActionToken(
+      {
+        purpose: originalToken.purpose,
+        userId: originalToken.userId,
+        invitationId: originalToken.invitationId,
+        emailChangeRequestId: originalToken.emailChangeRequestId,
+        targetEmail: originalToken.targetEmail,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+      tx,
+    );
+
+    return issued;
+  });
+
+  await requestAuthEmailSend({
+    emailType,
+    recipientEmail,
+    userId: originalToken.userId,
+    actionTokenId: newToken.token.id,
+    invitationId: originalToken.invitationId,
+    relatedEntityType: originalToken.emailChangeRequestId ? 'EMAIL_CHANGE_REQUEST' : undefined,
+    relatedEntityId: originalToken.emailChangeRequestId,
+    templateData: {
+      actionToken: newToken.rawToken,
+      firstName:
+        originalToken.user?.firstName ??
+        originalToken.invitation?.recipientFirstName ??
+        'Trainee',
+      actionTokenExpiresAt: newToken.token.expiresAt,
+      oldEmail: originalToken.emailChangeRequest?.currentEmail,
+      newEmail: originalToken.emailChangeRequest?.RequestedEmail,
+      organisationName: originalToken.invitation?.organisation.name,
+    },
+  });
 }

--- a/apps/backend/src/services/action-token.service.ts
+++ b/apps/backend/src/services/action-token.service.ts
@@ -143,11 +143,97 @@ function mapPurposeToEmailType(purpose: ActionTokenPurpose): EmailDeliveryType |
   }
 }
 
-function determineTokenState(token: ActionTokenModel, now = new Date()): ActionTokenState {
+type ActionTokenWithRelations = Prisma.ActionTokenGetPayload<{
+  include: {
+    user: true;
+    emailChangeRequest: true;
+    invitation: {
+      include: {
+        organisation: true;
+      };
+    };
+  };
+}>;
+
+function determineTokenState(
+  token: ActionTokenModel | ActionTokenWithRelations,
+  now = new Date(),
+): ActionTokenState {
   if (token.revokedAt) return 'REVOKED';
   if (token.usedAt) return 'USED';
   if (token.expiresAt.getTime() <= now.getTime()) return 'EXPIRED';
   return 'VALID';
+}
+
+function checkResendEligibility(token: ActionTokenWithRelations, state: ActionTokenState): boolean {
+  if (state !== 'VALID' && state !== 'EXPIRED') {
+    return false;
+  }
+
+  const flow = token.purpose;
+
+  if (flow === 'PASSWORD_RESET') {
+    return token.user ? token.user.authStatus !== 'DISABLED' : false;
+  }
+  if (flow === 'EMAIL_VERIFICATION') {
+    return token.user ? token.user.authStatus === 'PENDING_EMAIL_VERIFICATION' : false;
+  }
+  if (flow === 'EMAIL_CHANGE_VERIFICATION') {
+    return token.emailChangeRequest ? token.emailChangeRequest.status === 'PENDING' : false;
+  }
+  if (
+    flow === 'INITIAL_ORGANISATION_ADMIN_SETUP' ||
+    flow === 'ORGANISATION_TRAINEE_INVITE' ||
+    flow === 'ORGANISATION_ADMIN_PROMOTION' ||
+    flow === 'PLATFORM_ADMIN_INVITE' ||
+    flow === 'PLATFORM_ADMIN_UPGRADE_CONFIRMATION'
+  ) {
+    return token.invitation
+      ? token.invitation.status !== 'ACCEPTED' &&
+          token.invitation.status !== 'REVOKED' &&
+          token.invitation.status !== 'COMPLETED'
+      : false;
+  }
+
+  return false;
+}
+
+function getRecipientEmail(token: ActionTokenWithRelations): string | null {
+  return (
+    token.targetEmail ??
+    token.user?.email ??
+    token.invitation?.recipientEmail ??
+    token.emailChangeRequest?.RequestedEmail ??
+    null
+  );
+}
+
+async function computeResendCooldown(
+  recipientEmail: string | null,
+  emailType: EmailDeliveryType | null,
+  now: Date,
+): Promise<number> {
+  if (!recipientEmail || !emailType) {
+    return 0;
+  }
+
+  const lastLog = await prisma.emailDeliveryLog.findFirst({
+    where: {
+      recipientEmail,
+      emailType,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+
+  if (!lastLog) {
+    return 0;
+  }
+
+  const cooldownMs = 60000;
+  const elapsed = now.getTime() - lastLog.createdAt.getTime();
+  return elapsed < cooldownMs ? Math.max(0, Math.ceil((cooldownMs - elapsed) / 1000)) : 0;
 }
 
 export async function getTokenContext(rawToken: string): Promise<TokenContextResponse> {
@@ -177,67 +263,17 @@ export async function getTokenContext(rawToken: string): Promise<TokenContextRes
 
   const now = new Date();
   const state = determineTokenState(token, now);
-
-  // Determine resend eligibility
-  let canResend = false;
-  const flow = token.purpose;
-
-  if (flow === 'PASSWORD_RESET') {
-    canResend = token.user ? token.user.authStatus !== 'DISABLED' : false;
-  } else if (flow === 'EMAIL_VERIFICATION') {
-    canResend = token.user ? token.user.authStatus === 'PENDING_EMAIL_VERIFICATION' : false;
-  } else if (flow === 'EMAIL_CHANGE_VERIFICATION') {
-    canResend = token.emailChangeRequest ? token.emailChangeRequest.status === 'PENDING' : false;
-  } else if (
-    flow === 'INITIAL_ORGANISATION_ADMIN_SETUP' ||
-    flow === 'ORGANISATION_TRAINEE_INVITE' ||
-    flow === 'ORGANISATION_ADMIN_PROMOTION' ||
-    flow === 'PLATFORM_ADMIN_INVITE' ||
-    flow === 'PLATFORM_ADMIN_UPGRADE_CONFIRMATION'
-  ) {
-    canResend = token.invitation
-      ? token.invitation.status !== 'ACCEPTED' &&
-        token.invitation.status !== 'REVOKED' &&
-        token.invitation.status !== 'COMPLETED'
-      : false;
-  }
-
-  // Compute cooldown
-  let resendCooldownSeconds = 0;
-  const recipientEmail =
-    token.targetEmail ??
-    token.user?.email ??
-    token.invitation?.recipientEmail ??
-    token.emailChangeRequest?.RequestedEmail ??
-    null;
-
-  const emailType = mapPurposeToEmailType(flow);
-
-  if (recipientEmail && emailType) {
-    const lastLog = await prisma.emailDeliveryLog.findFirst({
-      where: {
-        recipientEmail,
-        emailType,
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    });
-
-    if (lastLog) {
-      const cooldownMs = 60000;
-      const elapsed = now.getTime() - lastLog.createdAt.getTime();
-      resendCooldownSeconds =
-        elapsed < cooldownMs ? Math.max(0, Math.ceil((cooldownMs - elapsed) / 1000)) : 0;
-    }
-  }
+  const canResend = checkResendEligibility(token, state);
+  const recipientEmail = getRecipientEmail(token);
+  const emailType = mapPurposeToEmailType(token.purpose);
+  const resendCooldownSeconds = await computeResendCooldown(recipientEmail, emailType, now);
 
   return {
     tokenState: state,
     canResend,
     resendCooldownSeconds,
     messageCode: `TOKEN_${state}`,
-    flow,
+    flow: token.purpose,
   };
 }
 
@@ -300,7 +336,24 @@ export async function resendActionToken(rawToken: string): Promise<void> {
     throw new TokenResendError(400, 'TOKEN_RESEND_INELIGIBLE', 'Token cannot be resent safely');
   }
 
+  // Re-check token state immediately before the transaction
+  const preTxState = determineTokenState(originalToken);
+  if (preTxState !== 'VALID' && preTxState !== 'EXPIRED') {
+    throw new TokenResendError(400, 'TOKEN_RESEND_INELIGIBLE', 'Token cannot be resent safely');
+  }
+
   const newToken = await prisma.$transaction(async (tx) => {
+    const currentToken = await tx.actionToken.findUnique({
+      where: { id: originalToken.id },
+    });
+    if (!currentToken) {
+      throw new TokenResendError(400, 'TOKEN_RESEND_INELIGIBLE', 'Token cannot be resent safely');
+    }
+    const txState = determineTokenState(currentToken);
+    if (txState !== 'VALID' && txState !== 'EXPIRED') {
+      throw new TokenResendError(400, 'TOKEN_RESEND_INELIGIBLE', 'Token cannot be resent safely');
+    }
+
     await tx.actionToken.updateMany({
       where: {
         purpose: originalToken.purpose,

--- a/apps/backend/src/services/action-token.service.ts
+++ b/apps/backend/src/services/action-token.service.ts
@@ -343,9 +343,7 @@ export async function resendActionToken(rawToken: string): Promise<void> {
     templateData: {
       actionToken: newToken.rawToken,
       firstName:
-        originalToken.user?.firstName ??
-        originalToken.invitation?.recipientFirstName ??
-        'Trainee',
+        originalToken.user?.firstName ?? originalToken.invitation?.recipientFirstName ?? 'Trainee',
       actionTokenExpiresAt: newToken.token.expiresAt,
       oldEmail: originalToken.emailChangeRequest?.currentEmail,
       newEmail: originalToken.emailChangeRequest?.RequestedEmail,

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -10,7 +10,8 @@ import type { AuthSessionRevokedReason } from '../generated/prisma/enums.js';
 import { prisma } from '../lib/prisma.js';
 import { toPublicUserDto } from '../mappers/user.mapper.js';
 import * as UserRepository from '../repositories/user.repository.js';
-import { issueActionToken } from './action-token.service.js';
+import { issueActionToken, validateActionToken } from './action-token.service.js';
+import { recordAuditLog } from './audit-log.service.js';
 import { requestAuthEmailSend } from './auth-email-hook.service.js';
 import { generateAuthToken } from './auth-token.service.js';
 import * as PasswordService from './password.service.js';
@@ -32,6 +33,17 @@ export class AuthConflictError extends Error {
   constructor(message = 'A user with the provided email already exists') {
     super(message);
     this.name = 'AuthConflictError';
+  }
+}
+
+export class AuthResetPasswordError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AuthResetPasswordError';
   }
 }
 
@@ -362,6 +374,150 @@ export async function resendVerificationEmail(email: string): Promise<void> {
     actionTokenId: verification.token.id,
     templateData: {
       actionToken: verification.rawToken,
+    },
+  });
+}
+
+export async function requestPasswordReset(email: string): Promise<void> {
+  const normalizedEmail = email.trim().toLowerCase();
+  const user = await UserRepository.findUserByEmail(normalizedEmail);
+
+  if (!user || user.authStatus === 'DISABLED' || user.authStatus === 'PENDING_INVITE_SETUP') {
+    return;
+  }
+
+  const { verification } = await prisma.$transaction(async (tx) => {
+    await tx.actionToken.updateMany({
+      where: {
+        userId: user.id,
+        purpose: 'PASSWORD_RESET',
+        revokedAt: null,
+        usedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+        revokedReason: 'REPLACED',
+      },
+    });
+
+    const resetToken = await issueActionToken(
+      {
+        purpose: 'PASSWORD_RESET',
+        userId: user.id,
+        targetEmail: user.email,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+      tx,
+    );
+
+    return { verification: resetToken };
+  });
+
+  await requestAuthEmailSend({
+    emailType: 'PASSWORD_RESET',
+    recipientEmail: user.email,
+    userId: user.id,
+    actionTokenId: verification.token.id,
+    templateData: {
+      actionToken: verification.rawToken,
+      firstName: user.firstName,
+      actionTokenExpiresAt: verification.token.expiresAt,
+    },
+  });
+}
+
+export async function resetUserPassword(
+  rawToken: string,
+  passwordInput: string,
+  ipAddress?: string | null,
+  userAgent?: string | null,
+): Promise<void> {
+  const validationResult = await validateActionToken({
+    rawToken,
+    expectedPurpose: 'PASSWORD_RESET',
+  });
+
+  if (validationResult.state !== 'VALID' || !validationResult.token) {
+    const state = validationResult.state;
+    if (state === 'INVALID') {
+      throw new AuthResetPasswordError(401, 'RESET_TOKEN_INVALID', 'Reset token is invalid');
+    }
+    if (state === 'EXPIRED') {
+      throw new AuthResetPasswordError(401, 'RESET_TOKEN_EXPIRED', 'Reset token has expired');
+    }
+    if (state === 'USED') {
+      throw new AuthResetPasswordError(409, 'RESET_TOKEN_USED', 'Reset token has already been used');
+    }
+    if (state === 'REVOKED') {
+      throw new AuthResetPasswordError(401, 'RESET_TOKEN_REVOKED', 'Reset token has been revoked');
+    }
+    throw new AuthResetPasswordError(401, 'RESET_TOKEN_INVALID', 'Reset token is invalid');
+  }
+
+  const token = validationResult.token;
+  if (!token.userId) {
+    throw new AuthResetPasswordError(401, 'RESET_TOKEN_INVALID', 'Reset token is invalid');
+  }
+
+  const user = await UserRepository.findUserById(token.userId);
+  if (!user || user.authStatus === 'DISABLED') {
+    throw new AuthResetPasswordError(403, 'USER_DISABLED', 'User account is disabled');
+  }
+
+  const passwordHash = await PasswordService.hashPassword(passwordInput);
+
+  await prisma.$transaction(async (tx) => {
+    const claim = await tx.actionToken.updateMany({
+      where: { id: token.id, usedAt: null, revokedAt: null },
+      data: { usedAt: new Date() },
+    });
+
+    if (claim.count !== 1) {
+      throw new AuthResetPasswordError(409, 'RESET_TOKEN_USED', 'Reset token has already been used');
+    }
+
+    await tx.user.update({
+      where: { id: user.id },
+      data: { passwordHash },
+    });
+
+    await tx.authSession.updateMany({
+      where: { userId: user.id, revokedAt: null },
+      data: { revokedAt: new Date(), revokedReason: 'PASSWORD_RESET' },
+    });
+
+    await tx.refreshToken.updateMany({
+      where: {
+        authSession: {
+          userId: user.id,
+        },
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+        revokedReason: 'PASSWORD_RESET',
+      },
+    });
+  });
+
+  await recordAuditLog({
+    actorUserId: user.id,
+    actorType: user.userType,
+    targetType: 'USER',
+    targetId: user.id,
+    actionType: 'UPDATED',
+    outcome: 'SUCCESS',
+    metadata: { reason: 'PASSWORD_RESET' },
+    ipAddress,
+    userAgent,
+  });
+
+  await requestAuthEmailSend({
+    emailType: 'PASSWORD_CHANGED',
+    recipientEmail: user.email,
+    userId: user.id,
+    templateData: {
+      firstName: user.firstName,
     },
   });
 }

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -446,7 +446,11 @@ export async function resetUserPassword(
       throw new AuthResetPasswordError(401, 'RESET_TOKEN_EXPIRED', 'Reset token has expired');
     }
     if (state === 'USED') {
-      throw new AuthResetPasswordError(409, 'RESET_TOKEN_USED', 'Reset token has already been used');
+      throw new AuthResetPasswordError(
+        409,
+        'RESET_TOKEN_USED',
+        'Reset token has already been used',
+      );
     }
     if (state === 'REVOKED') {
       throw new AuthResetPasswordError(401, 'RESET_TOKEN_REVOKED', 'Reset token has been revoked');
@@ -473,7 +477,11 @@ export async function resetUserPassword(
     });
 
     if (claim.count !== 1) {
-      throw new AuthResetPasswordError(409, 'RESET_TOKEN_USED', 'Reset token has already been used');
+      throw new AuthResetPasswordError(
+        409,
+        'RESET_TOKEN_USED',
+        'Reset token has already been used',
+      );
     }
 
     await tx.user.update({

--- a/apps/backend/tests/unit/action-token.service.test.ts
+++ b/apps/backend/tests/unit/action-token.service.test.ts
@@ -344,5 +344,121 @@ describe('action-token service', () => {
         'Resend cooldown active. Please try again later.',
       );
     });
+
+    it('returns canResend: false for USED password reset tokens', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: new Date(),
+        revokedAt: null,
+        user: { authStatus: 'ACTIVE', email: 'test@example.com' },
+      });
+
+      const res = await getTokenContext('some-token');
+      expect(res.tokenState).toBe('USED');
+      expect(res.canResend).toBe(false);
+    });
+
+    it('returns canResend: false for REVOKED password reset tokens', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: null,
+        revokedAt: new Date(),
+        user: { authStatus: 'ACTIVE', email: 'test@example.com' },
+      });
+
+      const res = await getTokenContext('some-token');
+      expect(res.tokenState).toBe('REVOKED');
+      expect(res.canResend).toBe(false);
+    });
+
+    it('throws TokenResendError and does not resend if token is USED', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: new Date(),
+        revokedAt: null,
+        user: { authStatus: 'ACTIVE', email: 'test@example.com' },
+      });
+
+      await expect(resendActionToken('some-token')).rejects.toThrowError(
+        'Token cannot be resent safely',
+      );
+
+      expect(prismaMock.actionToken.updateMany).not.toHaveBeenCalled();
+      expect(repositoryMock.createActionToken).not.toHaveBeenCalled();
+      expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
+    });
+
+    it('throws TokenResendError and does not resend if token is REVOKED', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: null,
+        revokedAt: new Date(),
+        user: { authStatus: 'ACTIVE', email: 'test@example.com' },
+      });
+
+      await expect(resendActionToken('some-token')).rejects.toThrowError(
+        'Token cannot be resent safely',
+      );
+
+      expect(prismaMock.actionToken.updateMany).not.toHaveBeenCalled();
+      expect(repositoryMock.createActionToken).not.toHaveBeenCalled();
+      expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
+    });
+
+    it('throws TokenResendError if the token becomes invalid inside the transaction (stale check)', async () => {
+      prismaMock.actionToken.findUnique
+        .mockResolvedValueOnce({
+          id: 'token-123',
+          purpose: 'PASSWORD_RESET',
+          expiresAt: new Date(Date.now() + 3600000),
+          usedAt: null,
+          revokedAt: null,
+          user: {
+            id: 'user-123',
+            authStatus: 'ACTIVE',
+            email: 'test@example.com',
+            firstName: 'John',
+          },
+        })
+        .mockResolvedValueOnce({
+          id: 'token-123',
+          purpose: 'PASSWORD_RESET',
+          expiresAt: new Date(Date.now() + 3600000),
+          usedAt: null,
+          revokedAt: null,
+          user: {
+            id: 'user-123',
+            authStatus: 'ACTIVE',
+            email: 'test@example.com',
+            firstName: 'John',
+          },
+        });
+
+      prismaMock.actionToken.findUnique.mockResolvedValueOnce({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: new Date(),
+        revokedAt: null,
+      });
+
+      prismaMock.emailDeliveryLog.findFirst.mockResolvedValue(null);
+
+      await expect(resendActionToken('some-token')).rejects.toThrowError(
+        'Token cannot be resent safely',
+      );
+
+      expect(prismaMock.actionToken.updateMany).not.toHaveBeenCalled();
+      expect(repositoryMock.createActionToken).not.toHaveBeenCalled();
+      expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
+    });
   });
 }); //describe

--- a/apps/backend/tests/unit/action-token.service.test.ts
+++ b/apps/backend/tests/unit/action-token.service.test.ts
@@ -4,6 +4,8 @@ import {
   issueActionToken,
   revokeActionTokenById,
   validateActionToken,
+  getTokenContext,
+  resendActionToken,
 } from '../../src/services/action-token.service.js';
 
 const repositoryMock = vi.hoisted(() => ({
@@ -19,10 +21,29 @@ const tokenHashServiceMock = vi.hoisted(() => ({
   hashOpaqueToken: vi.fn(),
 }));
 
+const authEmailHookServiceMock = vi.hoisted(() => ({
+  requestAuthEmailSend: vi.fn(),
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
+  actionToken: {
+    findUnique: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  emailDeliveryLog: {
+    findFirst: vi.fn(),
+  },
+}));
+
 import type { Prisma } from '../../src/generated/prisma/client.js';
 
 vi.mock('../../src/repositories/action-token.repository.js', () => repositoryMock);
 vi.mock('../../src/services/token-hash.service.js', () => tokenHashServiceMock);
+vi.mock('../../src/services/auth-email-hook.service.js', () => authEmailHookServiceMock);
+vi.mock('../../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
 
 describe('action-token service', () => {
   beforeEach(() => {
@@ -225,5 +246,98 @@ describe('action-token service', () => {
       { tokenId: 'actiontoken01' },
       action,
     );
+  });
+
+  describe('getTokenContext and resendActionToken', () => {
+    beforeEach(() => {
+      prismaMock.$transaction.mockImplementation((action) => action(prismaMock));
+    });
+
+    it('returns INVALID for missing token', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue(null);
+      const res = await getTokenContext('some-missing-token');
+      expect(res.tokenState).toBe('INVALID');
+      expect(res.canResend).toBe(false);
+    });
+
+    it('returns VALID context and computes resend capability for active password reset token', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: null,
+        revokedAt: null,
+        user: { authStatus: 'ACTIVE', email: 'test@example.com' },
+      });
+      prismaMock.emailDeliveryLog.findFirst.mockResolvedValue(null);
+
+      const res = await getTokenContext('some-token');
+      expect(res.tokenState).toBe('VALID');
+      expect(res.canResend).toBe(true);
+      expect(res.resendCooldownSeconds).toBe(0);
+    });
+
+    it('computes cooldown remaining if email was recently sent', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() + 3600000),
+        usedAt: null,
+        revokedAt: null,
+        user: { authStatus: 'ACTIVE', email: 'test@example.com' },
+      });
+      prismaMock.emailDeliveryLog.findFirst.mockResolvedValue({
+        createdAt: new Date(Date.now() - 20000), // 20s ago
+      });
+
+      const res = await getTokenContext('some-token');
+      expect(res.resendCooldownSeconds).toBeGreaterThan(30);
+      expect(res.resendCooldownSeconds).toBeLessThanOrEqual(40);
+    });
+
+    it('resends token successfully if eligible and not on cooldown', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() - 3600000), // expired
+        usedAt: null,
+        revokedAt: null,
+        user: { id: 'user-123', authStatus: 'ACTIVE', email: 'test@example.com', firstName: 'John' },
+      });
+      prismaMock.emailDeliveryLog.findFirst.mockResolvedValue(null);
+      repositoryMock.createActionToken.mockResolvedValue({
+        id: 'token-456',
+        expiresAt: new Date(Date.now() + 3600000),
+      });
+
+      await resendActionToken('some-token');
+
+      expect(prismaMock.actionToken.updateMany).toHaveBeenCalled();
+      expect(repositoryMock.createActionToken).toHaveBeenCalled();
+      expect(authEmailHookServiceMock.requestAuthEmailSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailType: 'PASSWORD_RESET',
+          recipientEmail: 'test@example.com',
+        }),
+      );
+    });
+
+    it('throws TokenResendError if resend cooldown is active', async () => {
+      prismaMock.actionToken.findUnique.mockResolvedValue({
+        id: 'token-123',
+        purpose: 'PASSWORD_RESET',
+        expiresAt: new Date(Date.now() - 3600000),
+        usedAt: null,
+        revokedAt: null,
+        user: { authStatus: 'ACTIVE', email: 'test@example.com' },
+      });
+      prismaMock.emailDeliveryLog.findFirst.mockResolvedValue({
+        createdAt: new Date(Date.now() - 20000),
+      });
+
+      await expect(resendActionToken('some-token')).rejects.toThrowError(
+        'Resend cooldown active. Please try again later.',
+      );
+    });
   });
 }); //describe

--- a/apps/backend/tests/unit/action-token.service.test.ts
+++ b/apps/backend/tests/unit/action-token.service.test.ts
@@ -302,7 +302,12 @@ describe('action-token service', () => {
         expiresAt: new Date(Date.now() - 3600000), // expired
         usedAt: null,
         revokedAt: null,
-        user: { id: 'user-123', authStatus: 'ACTIVE', email: 'test@example.com', firstName: 'John' },
+        user: {
+          id: 'user-123',
+          authStatus: 'ACTIVE',
+          email: 'test@example.com',
+          firstName: 'John',
+        },
       });
       prismaMock.emailDeliveryLog.findFirst.mockResolvedValue(null);
       repositoryMock.createActionToken.mockResolvedValue({

--- a/apps/backend/tests/unit/auth-reset-password.test.ts
+++ b/apps/backend/tests/unit/auth-reset-password.test.ts
@@ -1,0 +1,374 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../../src/app.js';
+import { clearAuthRateLimitStore } from '../../src/middleware/authRateLimit.js';
+
+const userRepositoryMock = vi.hoisted(() => ({
+  findUserByEmail: vi.fn(),
+  findUserById: vi.fn(),
+}));
+
+const actionTokenServiceMock = vi.hoisted(() => {
+  class MockTokenResendError extends Error {
+    constructor(
+      public readonly statusCode: number,
+      public readonly code: string,
+      message: string,
+      public readonly cooldownSeconds?: number,
+    ) {
+      super(message);
+      this.name = 'TokenResendError';
+    }
+  }
+
+  return {
+    issueActionToken: vi.fn(),
+    validateActionToken: vi.fn(),
+    getTokenContext: vi.fn(),
+    resendActionToken: vi.fn(),
+    TokenResendError: MockTokenResendError,
+  };
+});
+
+const authEmailHookServiceMock = vi.hoisted(() => ({
+  requestAuthEmailSend: vi.fn(),
+}));
+
+const passwordServiceMock = vi.hoisted(() => ({
+  hashPassword: vi.fn(),
+  verifyPassword: vi.fn(),
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
+  actionToken: {
+    updateMany: vi.fn(),
+  },
+  user: {
+    update: vi.fn(),
+  },
+  authSession: {
+    updateMany: vi.fn(),
+  },
+  refreshToken: {
+    updateMany: vi.fn(),
+  },
+  auditLogEntry: {
+    create: vi.fn().mockResolvedValue({ id: 'audit-123' }),
+  },
+}));
+
+vi.mock('../../src/repositories/user.repository.js', () => userRepositoryMock);
+vi.mock('../../src/services/action-token.service.js', () => actionTokenServiceMock);
+vi.mock('../../src/services/auth-email-hook.service.js', () => authEmailHookServiceMock);
+vi.mock('../../src/services/password.service.js', () => passwordServiceMock);
+vi.mock('../../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
+
+describe('Forgot Password and Reset Password API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearAuthRateLimitStore();
+    prismaMock.$transaction.mockImplementation((action) => action(prismaMock));
+  });
+
+  describe('POST /auth/forgot-password', () => {
+    it('returns 200 and sends reset email for active, eligible users', async () => {
+      userRepositoryMock.findUserByEmail.mockResolvedValue({
+        id: 'user-123',
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        authStatus: 'ACTIVE',
+        userType: 'GENERAL_TRAINEE',
+      });
+
+      prismaMock.actionToken.updateMany.mockResolvedValue({ count: 1 });
+      actionTokenServiceMock.issueActionToken.mockResolvedValue({
+        rawToken: 'raw-token-12345678901234567890123456789012',
+        token: {
+          id: 'token-123',
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        },
+      });
+
+      authEmailHookServiceMock.requestAuthEmailSend.mockResolvedValue({
+        queued: true,
+        deliveryLogId: 'log-123',
+      });
+
+      const response = await request(createApp())
+        .post('/auth/forgot-password')
+        .send({ email: 'test@example.com' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty(
+        'message',
+        'If the email is registered, a password reset link has been sent.',
+      );
+      expect(userRepositoryMock.findUserByEmail).toHaveBeenCalledWith('test@example.com');
+      expect(actionTokenServiceMock.issueActionToken).toHaveBeenCalled();
+      expect(authEmailHookServiceMock.requestAuthEmailSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailType: 'PASSWORD_RESET',
+          recipientEmail: 'test@example.com',
+          userId: 'user-123',
+        }),
+      );
+    });
+
+    it('returns 200 and does NOT send reset email if user does not exist (enumeration safe)', async () => {
+      userRepositoryMock.findUserByEmail.mockResolvedValue(null);
+
+      const response = await request(createApp())
+        .post('/auth/forgot-password')
+        .send({ email: 'missing@example.com' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty(
+        'message',
+        'If the email is registered, a password reset link has been sent.',
+      );
+      expect(actionTokenServiceMock.issueActionToken).not.toHaveBeenCalled();
+      expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 and does NOT send reset email if user is disabled (enumeration safe)', async () => {
+      userRepositoryMock.findUserByEmail.mockResolvedValue({
+        id: 'user-disabled',
+        email: 'disabled@example.com',
+        authStatus: 'DISABLED',
+        userType: 'GENERAL_TRAINEE',
+      });
+
+      const response = await request(createApp())
+        .post('/auth/forgot-password')
+        .send({ email: 'disabled@example.com' });
+
+      expect(response.status).toBe(200);
+      expect(actionTokenServiceMock.issueActionToken).not.toHaveBeenCalled();
+      expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for invalid email input', async () => {
+      const response = await request(createApp())
+        .post('/auth/forgot-password')
+        .send({ email: 'not-an-email' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    });
+  });
+
+  describe('POST /auth/reset-password', () => {
+    const validPayload = {
+      token: 'raw-token-12345678901234567890123456789012',
+      newPassword: 'NewSecurePassword1!',
+      confirmNewPassword: 'NewSecurePassword1!',
+    };
+
+    it('successfully resets password when token is valid', async () => {
+      actionTokenServiceMock.validateActionToken.mockResolvedValue({
+        state: 'VALID',
+        token: {
+          id: 'token-123',
+          userId: 'user-123',
+          purpose: 'PASSWORD_RESET',
+        },
+      });
+
+      userRepositoryMock.findUserById.mockResolvedValue({
+        id: 'user-123',
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        authStatus: 'ACTIVE',
+        userType: 'GENERAL_TRAINEE',
+      });
+
+      passwordServiceMock.hashPassword.mockResolvedValue('scrypt$newhash');
+      prismaMock.actionToken.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.user.update.mockResolvedValue({});
+      prismaMock.authSession.updateMany.mockResolvedValue({ count: 1 });
+      prismaMock.refreshToken.updateMany.mockResolvedValue({ count: 1 });
+
+      const response = await request(createApp())
+        .post('/auth/reset-password')
+        .send(validPayload);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ success: true });
+
+      expect(passwordServiceMock.hashPassword).toHaveBeenCalledWith(validPayload.newPassword);
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-123' },
+        data: { passwordHash: 'scrypt$newhash' },
+      });
+      expect(prismaMock.authSession.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-123', revokedAt: null },
+        data: { revokedAt: expect.any(Date), revokedReason: 'PASSWORD_RESET' },
+      });
+      expect(prismaMock.refreshToken.updateMany).toHaveBeenCalledWith({
+        where: { authSession: { userId: 'user-123' }, revokedAt: null },
+        data: { revokedAt: expect.any(Date), revokedReason: 'PASSWORD_RESET' },
+      });
+      expect(authEmailHookServiceMock.requestAuthEmailSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          emailType: 'PASSWORD_CHANGED',
+          recipientEmail: 'test@example.com',
+        }),
+      );
+    });
+
+    it('returns 401 for an expired token', async () => {
+      actionTokenServiceMock.validateActionToken.mockResolvedValue({
+        state: 'EXPIRED',
+        token: { id: 'token-123' },
+      });
+
+      const response = await request(createApp())
+        .post('/auth/reset-password')
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toHaveProperty('error', 'RESET_TOKEN_EXPIRED');
+    });
+
+    it('returns 409 for an already used token', async () => {
+      actionTokenServiceMock.validateActionToken.mockResolvedValue({
+        state: 'USED',
+        token: { id: 'token-123' },
+      });
+
+      const response = await request(createApp())
+        .post('/auth/reset-password')
+        .send(validPayload);
+
+      expect(response.status).toBe(409);
+      expect(response.body).toHaveProperty('error', 'RESET_TOKEN_USED');
+    });
+
+    it('returns 403 if the user is disabled', async () => {
+      actionTokenServiceMock.validateActionToken.mockResolvedValue({
+        state: 'VALID',
+        token: {
+          id: 'token-123',
+          userId: 'user-123',
+        },
+      });
+
+      userRepositoryMock.findUserById.mockResolvedValue({
+        id: 'user-123',
+        authStatus: 'DISABLED',
+      });
+
+      const response = await request(createApp())
+        .post('/auth/reset-password')
+        .send(validPayload);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty('error', 'USER_DISABLED');
+    });
+
+    it('returns 422 for password confirmation mismatch', async () => {
+      const response = await request(createApp())
+        .post('/auth/reset-password')
+        .send({
+          ...validPayload,
+          confirmNewPassword: 'mismatchPassword!',
+        });
+
+      expect(response.status).toBe(422);
+      expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    });
+  });
+
+  describe('GET /auth/tokens/:token/context', () => {
+    it('returns token context', async () => {
+      actionTokenServiceMock.getTokenContext.mockResolvedValue({
+        tokenState: 'VALID',
+        canResend: true,
+        resendCooldownSeconds: 0,
+        messageCode: 'TOKEN_VALID',
+        flow: 'PASSWORD_RESET',
+      });
+
+      const response = await request(createApp())
+        .get('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/context');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        tokenState: 'VALID',
+        canResend: true,
+        resendCooldownSeconds: 0,
+        messageCode: 'TOKEN_VALID',
+        flow: 'PASSWORD_RESET',
+      });
+      expect(actionTokenServiceMock.getTokenContext).toHaveBeenCalledWith(
+        'exampleResetTokenValueWithAtLeast32Chars',
+      );
+    });
+
+    it('returns 400 for invalid token format', async () => {
+      const response = await request(createApp()).get('/auth/tokens/too-short/context');
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    });
+  });
+
+  describe('POST /auth/tokens/:token/resend', () => {
+    it('resends token successfully', async () => {
+      actionTokenServiceMock.resendActionToken.mockResolvedValue(undefined);
+
+      const response = await request(createApp())
+        .post('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ success: true });
+      expect(actionTokenServiceMock.resendActionToken).toHaveBeenCalledWith(
+        'exampleResetTokenValueWithAtLeast32Chars',
+      );
+    });
+
+    it('returns 429 when cooldown is active', async () => {
+      actionTokenServiceMock.resendActionToken.mockRejectedValue(
+        new actionTokenServiceMock.TokenResendError(
+          429,
+          'RESEND_COOLDOWN_ACTIVE',
+          'Resend cooldown active. Please try again later.',
+          40,
+        ),
+      );
+
+      const response = await request(createApp())
+        .post('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend');
+
+      expect(response.status).toBe(429);
+      expect(response.body).toEqual({
+        error: 'RESEND_COOLDOWN_ACTIVE',
+        message: 'Resend cooldown active. Please try again later.',
+        cooldownSeconds: 40,
+      });
+    });
+
+    it('returns 400 when resend is ineligible', async () => {
+      actionTokenServiceMock.resendActionToken.mockRejectedValue(
+        new actionTokenServiceMock.TokenResendError(
+          400,
+          'TOKEN_RESEND_INELIGIBLE',
+          'Token cannot be resent safely',
+        ),
+      );
+
+      const response = await request(createApp())
+        .post('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: 'TOKEN_RESEND_INELIGIBLE',
+        message: 'Token cannot be resent safely',
+      });
+    });
+  });
+});

--- a/apps/backend/tests/unit/auth-reset-password.test.ts
+++ b/apps/backend/tests/unit/auth-reset-password.test.ts
@@ -193,9 +193,7 @@ describe('Forgot Password and Reset Password API', () => {
       prismaMock.authSession.updateMany.mockResolvedValue({ count: 1 });
       prismaMock.refreshToken.updateMany.mockResolvedValue({ count: 1 });
 
-      const response = await request(createApp())
-        .post('/auth/reset-password')
-        .send(validPayload);
+      const response = await request(createApp()).post('/auth/reset-password').send(validPayload);
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({ success: true });
@@ -227,9 +225,7 @@ describe('Forgot Password and Reset Password API', () => {
         token: { id: 'token-123' },
       });
 
-      const response = await request(createApp())
-        .post('/auth/reset-password')
-        .send(validPayload);
+      const response = await request(createApp()).post('/auth/reset-password').send(validPayload);
 
       expect(response.status).toBe(401);
       expect(response.body).toHaveProperty('error', 'RESET_TOKEN_EXPIRED');
@@ -241,9 +237,7 @@ describe('Forgot Password and Reset Password API', () => {
         token: { id: 'token-123' },
       });
 
-      const response = await request(createApp())
-        .post('/auth/reset-password')
-        .send(validPayload);
+      const response = await request(createApp()).post('/auth/reset-password').send(validPayload);
 
       expect(response.status).toBe(409);
       expect(response.body).toHaveProperty('error', 'RESET_TOKEN_USED');
@@ -263,9 +257,7 @@ describe('Forgot Password and Reset Password API', () => {
         authStatus: 'DISABLED',
       });
 
-      const response = await request(createApp())
-        .post('/auth/reset-password')
-        .send(validPayload);
+      const response = await request(createApp()).post('/auth/reset-password').send(validPayload);
 
       expect(response.status).toBe(403);
       expect(response.body).toHaveProperty('error', 'USER_DISABLED');
@@ -294,8 +286,9 @@ describe('Forgot Password and Reset Password API', () => {
         flow: 'PASSWORD_RESET',
       });
 
-      const response = await request(createApp())
-        .get('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/context');
+      const response = await request(createApp()).get(
+        '/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/context',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
@@ -321,8 +314,9 @@ describe('Forgot Password and Reset Password API', () => {
     it('resends token successfully', async () => {
       actionTokenServiceMock.resendActionToken.mockResolvedValue(undefined);
 
-      const response = await request(createApp())
-        .post('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend');
+      const response = await request(createApp()).post(
+        '/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({ success: true });
@@ -341,8 +335,9 @@ describe('Forgot Password and Reset Password API', () => {
         ),
       );
 
-      const response = await request(createApp())
-        .post('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend');
+      const response = await request(createApp()).post(
+        '/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend',
+      );
 
       expect(response.status).toBe(429);
       expect(response.body).toEqual({
@@ -361,8 +356,9 @@ describe('Forgot Password and Reset Password API', () => {
         ),
       );
 
-      const response = await request(createApp())
-        .post('/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend');
+      const response = await request(createApp()).post(
+        '/auth/tokens/exampleResetTokenValueWithAtLeast32Chars/resend',
+      );
 
       expect(response.status).toBe(400);
       expect(response.body).toEqual({

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -35,7 +35,12 @@ const expectedSchemas = [
   'AuthMeResponse',
   'AuthResendVerificationRequest',
   'AuthResendVerificationResponse',
+  'AuthForgotPasswordRequest',
+  'AuthForgotPasswordResponse',
+  'AuthResetPasswordRequest',
+  'AuthResetPasswordResponse',
   'AuthRateLimitErrorResponse',
+  'TokenContextResponse',
   'SetupTokenState',
   'SetupTokenContextResponse',
   'SetupCompleteRequest',
@@ -132,6 +137,8 @@ const expectedRequestBodies = [
   'SubmitQuizAttempt',
   'SetupComplete',
   'CreateOrganisationRegistrationRequest',
+  'AuthForgotPassword',
+  'AuthResetPassword',
 ] as const;
 
 const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
@@ -142,6 +149,10 @@ const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
   ['post', '/auth/logout', ['200', '500']],
   ['post', '/auth/refresh', ['200', '401', '403', '429', '500']],
   ['post', '/auth/resend-verification', ['200', '400', '429', '500']],
+  ['post', '/auth/forgot-password', ['200', '400', '429', '500']],
+  ['post', '/auth/reset-password', ['200', '400', '401', '403', '409', '429', '500']],
+  ['get', '/auth/tokens/{token}/context', ['200', '400', '429', '500']],
+  ['post', '/auth/tokens/{token}/resend', ['200', '400', '429', '500']],
   ['get', '/setup/token/{token}/context', ['200', '400', '401', '409', '429', '500']],
   ['post', '/setup/token/{token}/complete', ['201', '400', '401', '409', '429', '500']],
   ['post', '/organisation-registration-requests', ['201', '409', '422', '429', '500']],

--- a/packages/shared/src/validation/auth.schemas.ts
+++ b/packages/shared/src/validation/auth.schemas.ts
@@ -108,3 +108,40 @@ export const authForgotPasswordRequestSchema = z
     email: emailSchema,
   })
   .strict();
+
+export const authResetPasswordRequestSchema = z
+  .object({
+    token: z
+      .string({
+        required_error: 'Token is required.',
+        invalid_type_error: 'Token must be a string.',
+      })
+      .min(1, 'Token is required.'),
+    newPassword: passwordSchema,
+    confirmNewPassword: z.string({
+      required_error: 'Please confirm your password.',
+      invalid_type_error: 'Please confirm your password.',
+    }),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.newPassword !== value.confirmNewPassword) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['confirmNewPassword'],
+        message: 'Password confirmation must match password.',
+      });
+    }
+  });
+
+export const tokenParamsSchema = z
+  .object({
+    token: z
+      .string()
+      .min(32, 'Token is invalid.')
+      .max(512, 'Token is invalid.')
+      .regex(/^[A-Za-z0-9_-]+$/, 'Token is invalid.'),
+  })
+  .strict();
+
+

--- a/packages/shared/src/validation/auth.schemas.ts
+++ b/packages/shared/src/validation/auth.schemas.ts
@@ -143,5 +143,3 @@ export const tokenParamsSchema = z
       .regex(/^[A-Za-z0-9_-]+$/, 'Token is invalid.'),
   })
   .strict();
-
-


### PR DESCRIPTION
# feat(auth): implement forgot password, reset password, and token context/resend endpoints

## Summary

Implemented the backend password recovery flow and standardized tokenized-link error responses for Sprint 4:

1. **Forgot Password (`POST /auth/forgot-password`)**:
   - Accepts `email` and validates format.
   - If eligible, invalidates prior tokens, creates a new hashed `PASSWORD_RESET` action token, and sends a reset link email.
   - Generic accepted response prevents account enumeration for missing or disabled accounts.
2. **Reset Password (`POST /auth/reset-password`)**:
   - Accepts `token`, `newPassword`, and `confirmNewPassword`.
   - Validates password complexity policy and matches confirmation. On mismatch/weakness, returns `422 Unprocessable Entity`.
   - Updates `passwordHash`, marks token as used, and revokes all active auth sessions and refresh tokens (using the `PASSWORD_RESET` reason) within a transaction.
   - Dispatches a `PASSWORD_CHANGED` confirmation email.
3. **Token Context & Resend (`GET /auth/tokens/:token/context` & `POST /auth/tokens/:token/resend`)**:
   - Exposes safe validation status for tokenized links (`VALID`, `INVALID`, `EXPIRED`, `USED`, `REVOKED`).
   - Calculates resend eligibility depending on token purpose (e.g., active user, pending verification, pending invitation).
   - Enforces a 60-second cooldown on token resends, responding with a `429 Too Many Requests` showing the remaining cooldown duration.

## Linked Issue

Closes #239
Closes #242
Closes #245

## Type of change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Chore/Maintenance

## Testing

Verified using the backend Vitest automated test suite:
- Run `pnpm --filter @insightful-phish/backend test --run` (all 548 unit tests pass successfully).
- **`tests/unit/auth-reset-password.test.ts`**: Verifies all route behaviors, status codes (200, 401, 403, 409, 422, 429), session/refresh token revocation, and generic response logic.
- **`tests/unit/action-token.service.test.ts`**: Asserts token context lookup, resend eligibility criteria, and cooldown tracking.
- **`tests/unit/swagger.spec.test.ts`**: Asserts that Swagger OpenAPI specification schemas, request bodies, and route responses remain fully documented and verified.
- Re-run `pnpm typecheck` and `pnpm lint` to ensure workspace files compile and format correctly.

## Review Notes

Reviewers should focus on:
- Transaction-scoped revoking of `AuthSession` and `RefreshToken` when a password reset succeeds.
- Enumeration-safe generic messages returned for both forgot password and token resend requests.
- Correct mapping of path params validation using the new `tokenParamsSchema`.

## Checklist

- [x] I tested the change locally
- [x] Accessibility impact was considered if applicable
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable
- [x] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed
