### PR TITLE
Fix/register enumeration safe/johan

### DIFF
--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -260,11 +260,6 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             'Too many requests from this IP, please try again after 15 minutes',
           ),
         },
-        AuthEmailExistsErrorResponse: errorResponseSchema(
-          'ApiErrorResponse',
-          'AUTH_EMAIL_EXISTS',
-          'A user with the provided email already exists',
-        ),
         AuthInvalidErrorResponse: errorResponseSchema(
           'ApiErrorResponse',
           'AUTH_INVALID',
@@ -485,14 +480,12 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         },
         AuthRegisterResponse: {
           type: 'object',
-          required: ['user', 'verificationEmailQueued'],
+          required: ['message'],
           properties: {
-            user: {
-              $ref: '#/components/schemas/PublicUser',
-            },
-            verificationEmailQueued: {
-              type: 'boolean',
-              example: false,
+            message: {
+              type: 'string',
+              example:
+                "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
             },
           },
         },
@@ -2171,10 +2164,6 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         AuthEmailExists: responseComponent(
           'A user with the provided email already exists.',
           'AuthEmailExistsErrorResponse',
-        ),
-        AuthInvalid: responseComponent(
-          'Email, password, or account status is invalid.',
-          'AuthInvalidErrorResponse',
         ),
         AuthRateLimited: responseComponent(
           'Too many authentication requests.',

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -427,7 +427,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         },
         AuthRegisterRequest: {
           type: 'object',
-          required: ['email', 'password', 'firstName', 'lastName'],
+          required: ['email', 'password', 'confirmPassword', 'firstName', 'lastName'],
           additionalProperties: false,
           properties: {
             email: {
@@ -437,6 +437,12 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
               example: 'johan@example.com',
             },
             password: {
+              type: 'string',
+              format: 'password',
+              minLength: 12,
+              example: 'ExampleLocalPassword1!',
+            },
+            confirmPassword: {
               type: 'string',
               format: 'password',
               minLength: 12,
@@ -508,7 +514,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         },
         AuthOrganisationContext: {
           type: 'object',
-          required: ['id', 'status'],
+          required: ['id', 'status', 'name'],
           properties: {
             id: {
               type: 'string',
@@ -519,11 +525,22 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
               type: 'string',
               example: 'ACTIVE',
             },
+            name: {
+              type: 'string',
+              example: 'Example Organisation',
+            },
           },
         },
         AuthContext: {
           type: 'object',
-          required: ['user', 'role', 'organisation', 'permissions', 'redirectTo'],
+          required: [
+            'user',
+            'role',
+            'organisation',
+            'platformAdminRole',
+            'permissions',
+            'redirectTo',
+          ],
           properties: {
             user: {
               $ref: '#/components/schemas/AuthContextUser',
@@ -538,6 +555,12 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
                   $ref: '#/components/schemas/AuthOrganisationContext',
                 },
               ],
+            },
+            platformAdminRole: {
+              type: 'string',
+              nullable: true,
+              enum: ['SUPER_ADMIN', 'NORMAL_ADMIN'],
+              example: 'NORMAL_ADMIN',
             },
             permissions: {
               type: 'array',
@@ -875,9 +898,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
           type: 'object',
           required: [
             'organisationName',
-            'organisationDescription',
             'organisationSize',
-            'organisationWebsiteUrl',
             'representativeFirstName',
             'representativeLastName',
             'representativeEmail',
@@ -892,7 +913,6 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             },
             organisationDescription: {
               type: 'string',
-              minLength: 1,
               maxLength: 2000,
               description: 'Stored using the current onboarding request description field.',
               example: 'Small consulting company that wants phishing awareness training.',
@@ -907,7 +927,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             organisationWebsiteUrl: {
               type: 'string',
               format: 'uri',
-              description: 'Must use http or https.',
+              description: 'Optional. Must use http or https when provided.',
               maxLength: 2048,
               example: 'https://example-consulting.test',
             },

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -812,6 +812,21 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
               format: 'email',
               example: 'learner@example.com',
             },
+            targetFirstName: {
+              type: 'string',
+              nullable: true,
+              example: 'Jane',
+            },
+            targetLastName: {
+              type: 'string',
+              nullable: true,
+              example: 'Doe',
+            },
+            role: {
+              type: 'string',
+              enum: ['ORGANISATION_TRAINEE', 'ORGANISATION_ADMIN', 'IP_ADMIN'],
+              example: 'ORGANISATION_TRAINEE',
+            },
             organisationName: {
               type: 'string',
               example: 'Example Organisation',

--- a/apps/backend/src/controllers/auth.controller.ts
+++ b/apps/backend/src/controllers/auth.controller.ts
@@ -1,6 +1,5 @@
 import type { Request, Response } from 'express';
 import {
-  AuthConflictError,
   AuthUnauthorizedError,
   AuthStatusGuardError,
   AuthRefreshTokenReuseError,
@@ -37,19 +36,8 @@ function getCookie(req: Request, name: string): string | null {
 }
 
 export async function register(req: Request, res: Response) {
-  try {
-    const response = await registerUser(req.body);
-    return res.status(201).json(response);
-  } catch (error) {
-    if (error instanceof AuthConflictError) {
-      return res.status(409).json({
-        error: 'AUTH_EMAIL_EXISTS',
-        message: error.message,
-      });
-    }
-
-    throw error;
-  }
+  const response = await registerUser(req.body);
+  return res.status(201).json(response);
 }
 
 export async function login(req: Request, res: Response) {

--- a/apps/backend/src/repositories/organisation-registration-request.repository.ts
+++ b/apps/backend/src/repositories/organisation-registration-request.repository.ts
@@ -18,10 +18,10 @@ const conflictingOrganisationStatuses: OrganisationStatus[] = ['PENDING_ONBOARDI
 
 export type CreateOrganisationRegistrationRequestRecordInput = {
   submittedOrganisationName: string;
-  submittedWebsite: string;
-  submittedOrganisationDescription: string;
+  submittedWebsite: string | null;
+  submittedOrganisationDescription: string | null;
   submittedOrganisationSize: number;
-  submittedPrimaryDomain: string;
+  submittedPrimaryDomain: string | null;
   representativeFirstName: string;
   representativeLastName: string;
   representativeEmail: string;

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -103,6 +103,7 @@ export function toGuardAuthSubject(user: UserWithAuthSubject | null): GuardAuthS
           organisation: {
             id: user.traineeProfile.organisationTraineeProfile.organisation.id,
             status: user.traineeProfile.organisationTraineeProfile.organisation.status,
+            name: user.traineeProfile.organisationTraineeProfile.organisation.name,
           },
         }
       : null,
@@ -112,12 +113,14 @@ export function toGuardAuthSubject(user: UserWithAuthSubject | null): GuardAuthS
           organisation: {
             id: user.organisationAdminProfile.organisation.id,
             status: user.organisationAdminProfile.organisation.status,
+            name: user.organisationAdminProfile.organisation.name,
           },
         }
       : null,
     ipAdminProfile: user.ipAdminProfile
       ? {
           adminStatus: user.ipAdminProfile.adminStatus,
+          platformAdminRole: user.ipAdminProfile.platformAdminRole,
         }
       : null,
   };

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -34,7 +34,7 @@ export const authRouter = Router();
  *   post:
  *     tags: [Auth]
  *     summary: Register a trainee account
- *     description: Creates a general trainee account in pending email-verification state and sends a verification email through the email hook.
+ *     description: Accepts a public general trainee registration request, and always returns a generic check-email response to avoid account enumeration.
  *     security: []
  *     requestBody:
  *       $ref: '#/components/requestBodies/AuthRegister'

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -43,8 +43,6 @@ export const authRouter = Router();
  *         $ref: '#/components/responses/AuthRegisterCreated'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
- *       409:
- *         $ref: '#/components/responses/AuthEmailExists'
  *       429:
  *         $ref: '#/components/responses/AuthRateLimited'
  *       500:

--- a/apps/backend/src/services/auth-context.service.ts
+++ b/apps/backend/src/services/auth-context.service.ts
@@ -21,6 +21,7 @@ export type AuthContextUser = {
 export type AuthOrganisationContext = {
   id: string;
   status: GuardOrganisation['status'];
+  name: string;
 };
 
 export type AuthContext = {
@@ -29,6 +30,7 @@ export type AuthContext = {
   organisation: AuthOrganisationContext | null;
   permissions: string[];
   redirectTo: AuthRedirectTarget;
+  platformAdminRole: 'SUPER_ADMIN' | 'NORMAL_ADMIN' | null;
 };
 
 export function buildAuthContext(subject: GuardAuthSubject): AuthContext {
@@ -46,6 +48,7 @@ export function buildAuthContext(subject: GuardAuthSubject): AuthContext {
     organisation: resolveOrganisationContext(subject),
     permissions: resolvePermissions(subject),
     redirectTo: resolveRedirectTarget(subject.user),
+    platformAdminRole: subject.ipAdminProfile?.platformAdminRole ?? null,
   };
 }
 
@@ -62,6 +65,7 @@ function resolveOrganisationContext(subject: GuardAuthSubject): AuthOrganisation
   return {
     id: organisation.id,
     status: organisation.status,
+    name: organisation.name,
   };
 }
 

--- a/apps/backend/src/services/auth-status-guard.service.ts
+++ b/apps/backend/src/services/auth-status-guard.service.ts
@@ -33,6 +33,7 @@ export type GuardUser = {
 
 export type GuardOrganisation = {
   id: string;
+  name: string;
   status: 'PENDING_ONBOARDING' | 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'DISABLED' | 'ARCHIVED';
 };
 
@@ -50,6 +51,7 @@ export type GuardOrganisationAdminProfile = {
 
 export type GuardIpAdminProfile = {
   adminStatus: 'ACTIVE' | 'DISABLED';
+  platformAdminRole?: 'SUPER_ADMIN' | 'NORMAL_ADMIN' | null;
 };
 
 export type GuardAuthSubject = {

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -29,7 +29,8 @@ import { recordUserLogin, recordAuthSessionRevoked } from './auth-audit.service.
 import { buildAuthContext } from './auth-context.service.js';
 
 const EMAIL_VERIFICATION_TOKEN_TTL_HOURS = 24;
-
+const REGISTER_GENERIC_MESSAGE =
+  "If this email can be registered, we'll send you an email verification link. Please check your inbox.";
 export class AuthConflictError extends Error {
   constructor(message = 'A user with the provided email already exists') {
     super(message);
@@ -59,56 +60,119 @@ export async function registerUser(
   input: AuthRegisterRequestDto,
 ): Promise<AuthRegisterResponseDto> {
   const existingUser = await UserRepository.findUserByEmail(input.email);
-
-  if (existingUser) {
-    throw new AuthConflictError();
-  }
-
   const passwordHash = await PasswordService.hashPassword(input.password);
 
-  const { newUser, verification } = await prisma.$transaction(async (tx) => {
-    const createdUser = await UserRepository.createGeneralTraineeUser(
-      {
-        email: input.email,
-        firstName: input.firstName,
-        lastName: input.lastName,
-        passwordHash,
+  if (!existingUser) {
+    const { newUser, verification } = await prisma.$transaction(async (tx) => {
+      const createdUser = await UserRepository.createGeneralTraineeUser(
+        {
+          email: input.email,
+          firstName: input.firstName,
+          lastName: input.lastName,
+          passwordHash,
+        },
+        tx,
+      );
+      const verificationToken = await issueActionToken(
+        {
+          purpose: 'EMAIL_VERIFICATION',
+          userId: createdUser.id,
+          targetEmail: createdUser.email,
+          expiresAt: new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000),
+        },
+        tx,
+      );
+      return {
+        newUser: createdUser,
+        verification: verificationToken,
+      };
+    });
+
+    await requestAuthEmailSend({
+      emailType: 'EMAIL_VERIFICATION',
+      recipientEmail: newUser.email,
+      userId: newUser.id,
+      actionTokenId: verification.token.id,
+      templateData: {
+        firstName: newUser.firstName,
+        actionToken: verification.rawToken,
+        actionTokenExpiresAt: verification.token.expiresAt,
       },
-      tx,
+    });
+
+    return { message: REGISTER_GENERIC_MESSAGE };
+  } //if
+
+  if (existingUser.authStatus === 'PENDING_EMAIL_VERIFICATION') {
+    await maybeSendReplacementVerificationEmail(existingUser);
+  }
+
+  return { message: REGISTER_GENERIC_MESSAGE };
+}
+async function maybeSendReplacementVerificationEmail(user: {
+  id: string;
+  email: string;
+  firstName: string;
+  authStatus: string;
+}) {
+  const latestToken = await prisma.actionToken.findFirst({
+    where: {
+      userId: user.id,
+      targetEmail: user.email,
+      purpose: 'EMAIL_VERIFICATION',
+      usedAt: null,
+      revokedAt: null,
+    },
+    include: { emailDeliveryLogs: true },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  const shouldReissue =
+    !latestToken ||
+    latestToken.expiresAt.getTime() <= Date.now() ||
+    !latestToken.emailDeliveryLogs.some(
+      (log) => log.emailType === 'EMAIL_VERIFICATION' && log.deliveryStatus === 'SENT',
     );
+  if (!shouldReissue) {
+    return;
+  }
+
+  const { verification } = await prisma.$transaction(async (tx) => {
+    await tx.actionToken.updateMany({
+      where: {
+        userId: user.id,
+        targetEmail: user.email,
+        purpose: 'EMAIL_VERIFICATION',
+        usedAt: null,
+        revokedAt: null,
+      },
+      data: { revokedAt: new Date(), revokedReason: 'REGISTRATION_VERIFICATION_REISSUED' },
+    });
 
     const verificationToken = await issueActionToken(
       {
         purpose: 'EMAIL_VERIFICATION',
-        userId: createdUser.id,
-        targetEmail: createdUser.email,
+        userId: user.id,
+        targetEmail: user.email,
         expiresAt: new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000),
       },
       tx,
     );
 
-    return {
-      newUser: createdUser,
-      verification: verificationToken,
-    };
+    return { verification: verificationToken };
   });
 
-  const emailResult = await requestAuthEmailSend({
+  await requestAuthEmailSend({
     emailType: 'EMAIL_VERIFICATION',
-    recipientEmail: newUser.email,
-    userId: newUser.id,
+    recipientEmail: user.email,
+    userId: user.id,
     actionTokenId: verification.token.id,
     templateData: {
-      firstName: newUser.firstName,
+      firstName: user.firstName,
       actionToken: verification.rawToken,
       actionTokenExpiresAt: verification.token.expiresAt,
     },
   });
-
-  return {
-    user: toPublicUserDto(newUser),
-    verificationEmailQueued: emailResult.queued,
-  };
 }
 
 export class AuthStatusGuardError extends Error {

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -8,10 +8,15 @@ import type {
   PublicUserDto,
 } from '@insightful-phish/shared';
 import type { AuthSessionRevokedReason } from '../generated/prisma/enums.js';
+import type { Prisma } from '../generated/prisma/client.js';
 import { prisma } from '../lib/prisma.js';
 import { toPublicUserDto } from '../mappers/user.mapper.js';
 import * as UserRepository from '../repositories/user.repository.js';
-import { issueActionToken, validateActionToken } from './action-token.service.js';
+import {
+  issueActionToken,
+  validateActionToken,
+  type IssueActionTokenResult,
+} from './action-token.service.js';
 import { recordAuditLog } from './audit-log.service.js';
 import { requestAuthEmailSend } from './auth-email-hook.service.js';
 import { generateAuthToken } from './auth-token.service.js';
@@ -36,6 +41,44 @@ export class AuthConflictError extends Error {
     super(message);
     this.name = 'AuthConflictError';
   }
+}
+type EmailVerificationUser = {
+  id: string;
+  email: string;
+  firstName: string;
+};
+function getEmailVerificationExpiresAt() {
+  return new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000);
+}
+function issueEmailVerificationToken(
+  user: EmailVerificationUser,
+  client?: Prisma.TransactionClient,
+) {
+  return issueActionToken(
+    {
+      purpose: 'EMAIL_VERIFICATION',
+      userId: user.id,
+      targetEmail: user.email,
+      expiresAt: getEmailVerificationExpiresAt(),
+    },
+    client,
+  );
+}
+async function sendEmailVerification(
+  user: EmailVerificationUser,
+  verification: IssueActionTokenResult,
+) {
+  await requestAuthEmailSend({
+    emailType: 'EMAIL_VERIFICATION',
+    recipientEmail: user.email,
+    userId: user.id,
+    actionTokenId: verification.token.id,
+    templateData: {
+      firstName: user.firstName,
+      actionToken: verification.rawToken,
+      actionTokenExpiresAt: verification.token.expiresAt,
+    },
+  });
 }
 
 export class AuthResetPasswordError extends Error {
@@ -73,32 +116,14 @@ export async function registerUser(
         },
         tx,
       );
-      const verificationToken = await issueActionToken(
-        {
-          purpose: 'EMAIL_VERIFICATION',
-          userId: createdUser.id,
-          targetEmail: createdUser.email,
-          expiresAt: new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000),
-        },
-        tx,
-      );
+      const verificationToken = await issueEmailVerificationToken(createdUser, tx);
       return {
         newUser: createdUser,
         verification: verificationToken,
       };
     });
 
-    await requestAuthEmailSend({
-      emailType: 'EMAIL_VERIFICATION',
-      recipientEmail: newUser.email,
-      userId: newUser.id,
-      actionTokenId: verification.token.id,
-      templateData: {
-        firstName: newUser.firstName,
-        actionToken: verification.rawToken,
-        actionTokenExpiresAt: verification.token.expiresAt,
-      },
-    });
+    await sendEmailVerification(newUser, verification);
 
     return { message: REGISTER_GENERIC_MESSAGE };
   } //if
@@ -149,30 +174,12 @@ async function maybeSendReplacementVerificationEmail(user: {
       data: { revokedAt: new Date(), revokedReason: 'REGISTRATION_VERIFICATION_REISSUED' },
     });
 
-    const verificationToken = await issueActionToken(
-      {
-        purpose: 'EMAIL_VERIFICATION',
-        userId: user.id,
-        targetEmail: user.email,
-        expiresAt: new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000),
-      },
-      tx,
-    );
+    const verificationToken = await issueEmailVerificationToken(user, tx);
 
     return { verification: verificationToken };
   });
 
-  await requestAuthEmailSend({
-    emailType: 'EMAIL_VERIFICATION',
-    recipientEmail: user.email,
-    userId: user.id,
-    actionTokenId: verification.token.id,
-    templateData: {
-      firstName: user.firstName,
-      actionToken: verification.rawToken,
-      actionTokenExpiresAt: verification.token.expiresAt,
-    },
-  });
+  await sendEmailVerification(user, verification);
 }
 
 export class AuthStatusGuardError extends Error {
@@ -449,31 +456,9 @@ export async function resendVerificationEmail(email: string): Promise<void> {
     return;
   }
 
-  const { verification } = await prisma.$transaction(async (tx) => {
-    const verificationToken = await issueActionToken(
-      {
-        purpose: 'EMAIL_VERIFICATION',
-        userId: user.id,
-        targetEmail: user.email,
-        expiresAt: new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000),
-      },
-      tx,
-    );
+  const verification = await prisma.$transaction((tx) => issueEmailVerificationToken(user, tx));
 
-    return { verification: verificationToken };
-  });
-
-  await requestAuthEmailSend({
-    emailType: 'EMAIL_VERIFICATION',
-    recipientEmail: user.email,
-    userId: user.id,
-    actionTokenId: verification.token.id,
-    templateData: {
-      firstName: user.firstName,
-      actionToken: verification.rawToken,
-      actionTokenExpiresAt: verification.token.expiresAt,
-    },
-  });
+  await sendEmailVerification(user, verification);
 }
 
 export type VerifyEmailResult = {

--- a/apps/backend/src/services/organisation-registration-request.service.ts
+++ b/apps/backend/src/services/organisation-registration-request.service.ts
@@ -21,8 +21,10 @@ export class OrganisationRegistrationRequestError extends Error {
 export async function createOrganisationRegistrationRequest(
   input: CreateOrganisationRegistrationRequestDto,
 ): Promise<OrganisationRegistrationRequestResponseDto> {
-  const normalisedWebsite = normaliseWebsiteUrl(input.organisationWebsiteUrl);
-  const primaryDomain = primaryDomainFromWebsite(normalisedWebsite);
+  const normalisedWebsite = input.organisationWebsiteUrl
+    ? normaliseWebsiteUrl(input.organisationWebsiteUrl)
+    : null;
+  const primaryDomain = normalisedWebsite ? primaryDomainFromWebsite(normalisedWebsite) : null;
 
   await assertNoDuplicateOrganisationRequest({
     organisationName: input.organisationName,
@@ -35,7 +37,7 @@ export async function createOrganisationRegistrationRequest(
   const request = await OrganisationRequestRepository.createOrganisationRegistrationRequest({
     submittedOrganisationName: input.organisationName,
     submittedWebsite: normalisedWebsite,
-    submittedOrganisationDescription: input.organisationDescription,
+    submittedOrganisationDescription: input.organisationDescription ?? null,
     submittedOrganisationSize: input.organisationSize,
     submittedPrimaryDomain: primaryDomain,
     representativeFirstName: input.representativeFirstName,
@@ -60,8 +62,8 @@ export async function createOrganisationRegistrationRequest(
 
 async function assertNoDuplicateOrganisationRequest(input: {
   organisationName: string;
-  website: string;
-  primaryDomain: string;
+  website: string | null;
+  primaryDomain: string | null;
   representativeEmail: string;
 }) {
   const existingOrganisation = await OrganisationRequestRepository.findOrganisationByName(
@@ -78,12 +80,16 @@ async function assertNoDuplicateOrganisationRequest(input: {
     throw duplicateRequestError();
   }
 
-  const duplicateWebsite = await OrganisationRequestRepository.findActiveRequestByWebsiteOrDomain({
-    website: input.website,
-    primaryDomain: input.primaryDomain,
-  });
-  if (duplicateWebsite) {
-    throw duplicateRequestError();
+  if (input.website && input.primaryDomain) {
+    const duplicateWebsite = await OrganisationRequestRepository.findActiveRequestByWebsiteOrDomain(
+      {
+        website: input.website,
+        primaryDomain: input.primaryDomain,
+      },
+    );
+    if (duplicateWebsite) {
+      throw duplicateRequestError();
+    }
   }
 
   const duplicateRepresentative =

--- a/apps/backend/src/services/setup.service.ts
+++ b/apps/backend/src/services/setup.service.ts
@@ -67,6 +67,9 @@ export async function getSetupTokenContext(
       purpose: setupToken.purpose,
     },
     targetEmail: setupTargetEmail(setupToken) ?? undefined,
+    targetFirstName: setupToken.invitation?.recipientFirstName ?? setupToken.user?.firstName,
+    targetLastName: setupToken.invitation?.recipientLastName ?? setupToken.user?.lastName,
+    role: setupUserTypeForPurpose(setupToken.purpose),
     organisationName: setupToken.invitation?.organisation.name,
   };
 }

--- a/apps/backend/src/services/setup.service.ts
+++ b/apps/backend/src/services/setup.service.ts
@@ -29,6 +29,10 @@ const SETUP_TOKEN_PURPOSES = [
 
 type SetupTransaction = Parameters<Parameters<typeof runWithConsumedActionToken>[1]>[0];
 type SetupActionToken = NonNullable<Awaited<ReturnType<typeof findSetupActionTokenById>>>;
+type SetupTokenPurpose = (typeof SETUP_TOKEN_PURPOSES)[number];
+function isSetupTokenPurpose(purpose: ActionTokenPurpose): purpose is SetupTokenPurpose {
+  return SETUP_TOKEN_PURPOSES.includes(purpose as SetupTokenPurpose);
+}
 
 export class SetupFlowError extends Error {
   constructor(
@@ -176,7 +180,12 @@ async function validateSetupToken(rawToken: string) {
   return { state: lastState };
 }
 
-function assertSetupRecordIsUsable(setupToken: SetupActionToken) {
+function assertSetupRecordIsUsable(
+  setupToken: SetupActionToken,
+): asserts setupToken is SetupActionToken & { purpose: SetupTokenPurpose } {
+  if (!isSetupTokenPurpose(setupToken.purpose)) {
+    throw new SetupFlowError(409, 'SETUP_TOKEN_PURPOSE_UNSUPPORTED', 'Setup link is not supported');
+  }
   const invitation = setupToken.invitation;
   if (!invitation) {
     if (setupToken.purpose === 'PLATFORM_ADMIN_INVITE') {
@@ -213,7 +222,7 @@ function setupTargetEmail(setupToken: SetupActionToken) {
   );
 }
 
-function setupUserTypeForPurpose(purpose: ActionTokenPurpose): SetupUserType {
+function setupUserTypeForPurpose(purpose: SetupTokenPurpose): SetupUserType {
   if (purpose === 'INITIAL_ORGANISATION_ADMIN_SETUP') {
     return 'ORGANISATION_ADMIN';
   }

--- a/apps/backend/tests/integration/auth.integration.test.ts
+++ b/apps/backend/tests/integration/auth.integration.test.ts
@@ -716,4 +716,49 @@ describe('Auth Integration Tests', () => {
         "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
     });
   });
+
+  it('reissues verification for a pending unverified account with an expired verification token', async () => {
+    const email = 'pending-expired-register@example.com';
+
+    const { user } = await createTrainee({
+      user: {
+        email,
+        authStatus: 'PENDING_EMAIL_VERIFICATION',
+        emailVerifiedAt: null,
+      },
+    });
+
+    await issueActionToken({
+      purpose: 'EMAIL_VERIFICATION',
+      userId: user.id,
+      targetEmail: email,
+      expiresAt: new Date(Date.now() - 60 * 1000),
+    });
+
+    const response = await request(createApp()).post('/auth/register').send({
+      email,
+      firstName: 'Pending',
+      lastName: 'Expired',
+      password: secureRegisterPassword,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
+
+    const activeTokens = await prisma.actionToken.findMany({
+      where: {
+        userId: user.id,
+        targetEmail: email,
+        purpose: 'EMAIL_VERIFICATION',
+        usedAt: null,
+        revokedAt: null,
+      },
+    });
+
+    expect(activeTokens).toHaveLength(1);
+    expect(activeTokens[0].expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
 });

--- a/apps/backend/tests/integration/auth.integration.test.ts
+++ b/apps/backend/tests/integration/auth.integration.test.ts
@@ -24,6 +24,7 @@ describe('Auth Integration Tests', () => {
       firstName: 'Register',
       lastName: 'Test',
       password: secureRegisterPassword,
+      confirmPassword: secureRegisterPassword,
     };
 
     const response = await request(createApp()).post('/auth/register').send(payload);
@@ -711,6 +712,7 @@ describe('Auth Integration Tests', () => {
       firstName: 'Existing',
       lastName: 'User',
       password: secureRegisterPassword,
+      confirmPassword: secureRegisterPassword,
     });
 
     expect(response.status).toBe(201);
@@ -743,6 +745,7 @@ describe('Auth Integration Tests', () => {
       firstName: 'Pending',
       lastName: 'Expired',
       password: secureRegisterPassword,
+      confirmPassword: secureRegisterPassword,
     });
 
     expect(response.status).toBe(201);

--- a/apps/backend/tests/integration/auth.integration.test.ts
+++ b/apps/backend/tests/integration/auth.integration.test.ts
@@ -284,6 +284,9 @@ describe('Auth Integration Tests', () => {
       expect(response.body.token.state).toBe('VALID');
       expect(response.body.token.purpose).toBe('PLATFORM_ADMIN_INVITE');
       expect(response.body.targetEmail).toBe(email);
+      expect(response.body.targetFirstName).toBe('Test');
+      expect(response.body.targetLastName).toBe('Trainee');
+      expect(response.body.role).toBe('IP_ADMIN');
     });
 
     it('returns EXPIRED for an expired setup token', async () => {

--- a/apps/backend/tests/integration/auth.integration.test.ts
+++ b/apps/backend/tests/integration/auth.integration.test.ts
@@ -29,14 +29,10 @@ describe('Auth Integration Tests', () => {
     const response = await request(createApp()).post('/auth/register').send(payload);
 
     expect(response.status).toBe(201);
-    expect(response.body.user).toBeDefined();
-    expect(response.body.user.email).toBe('new-trainee@example.com');
-    expect(response.body.user.firstName).toBe('Register');
-    expect(response.body.user.lastName).toBe('Test');
-    expect(response.body.user.userType).toBe('GENERAL_TRAINEE');
-    expect(response.body.user.authStatus).toBe('PENDING_EMAIL_VERIFICATION');
-    expect(response.body.verificationEmailQueued).toBe(false);
-    expect(response.body.user.passwordHash).toBeUndefined();
+    expect(response.body).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
 
     // Verify database record creation
     const dbUser = await prisma.user.findUnique({
@@ -697,6 +693,27 @@ describe('Auth Integration Tests', () => {
         .set('Authorization', `Bearer ${mismatchedToken}`);
       expect(res3.status).toBe(401);
       expect(res3.body.error).toBe('AUTH_INVALID');
+    });
+  });
+
+  it('returns generic success for an existing registered email', async () => {
+    await createTrainee({
+      user: {
+        email: 'existing-register@example.com',
+      },
+    });
+
+    const response = await request(createApp()).post('/auth/register').send({
+      email: 'existing-register@example.com',
+      firstName: 'Existing',
+      lastName: 'User',
+      password: secureRegisterPassword,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
     });
   });
 });

--- a/apps/backend/tests/integration/email-delivery.integration.test.ts
+++ b/apps/backend/tests/integration/email-delivery.integration.test.ts
@@ -13,7 +13,7 @@ import { clearAuthRateLimitStore } from '../../src/middleware/authRateLimit.js';
 
 const password = 'SecurePassword@123!';
 function registerPayload(email = 'johan@example.com') {
-  return { email, firstName: 'Johan', lastName: 'Nel', password };
+  return { email, firstName: 'Johan', lastName: 'Nel', password, confirmPassword: password };
 }
 function organisationRequestPayload(email = 'johan@example.com') {
   return {
@@ -40,7 +40,10 @@ describe('email delivery integration', () => {
       .post('/auth/register')
       .send(registerPayload('johanregistersent@example.com'));
     expect(response.status).toBe(201);
-    expect(response.body.verificationEmailQueued).toBe(true);
+    expect(response.body).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
 
     const user = await prisma.user.findUniqueOrThrow({
       where: { email: 'johanregistersent@example.com' },
@@ -74,7 +77,10 @@ describe('email delivery integration', () => {
       .post('/auth/register')
       .send(registerPayload('johanregisterfails@example.com'));
     expect(response.status).toBe(201);
-    expect(response.body.verificationEmailQueued).toBe(false);
+    expect(response.body).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
 
     const user = await prisma.user.findUniqueOrThrow({
       where: { email: 'johanregisterfails@example.com' },

--- a/apps/backend/tests/unit/auth-context.service.test.ts
+++ b/apps/backend/tests/unit/auth-context.service.test.ts
@@ -19,7 +19,10 @@ describe('auth-context serivce', () => {
       user: { ...baseUser, userType },
       organisationAdminProfile:
         userType === 'ORGANISATION_ADMIN'
-          ? { adminStatus: 'ACTIVE', organisation: { id: 'org01', status: 'ACTIVE' } }
+          ? {
+              adminStatus: 'ACTIVE',
+              organisation: { id: 'org01', status: 'ACTIVE', name: 'Acme Security' },
+            }
           : null,
     });
     expect(context).toMatchObject({ role: userType, permissions, redirectTo });

--- a/apps/backend/tests/unit/auth-status-guard.service.test.ts
+++ b/apps/backend/tests/unit/auth-status-guard.service.test.ts
@@ -9,7 +9,7 @@ import {
   ensureUserCanAuthenticate,
 } from '../../src/services/auth-status-guard.service.js';
 const user = { id: 'user01', userType: 'GENERAL_TRAINEE' as const, authStatus: 'ACTIVE' as const };
-const defaultOrg = { id: 'org01', status: 'ACTIVE' as const };
+const defaultOrg = { id: 'org01', name: 'Acme Security', status: 'ACTIVE' as const };
 
 describe('auth-status guard service', () => {
   it.each([
@@ -32,7 +32,7 @@ describe('auth-status guard service', () => {
     ['ARCHIVED', 'ORGANISATION_ARCHIVED'],
     ['INACTIVE', 'ORGANISATION_NOT_ACTIVE'],
   ] as const)('rejects organisation status %s', (status, code) => {
-    expect(ensureActiveOrganisation({ id: 'org01', status })).toMatchObject({
+    expect(ensureActiveOrganisation({ id: 'org01', status, name: 'Acme Security' })).toMatchObject({
       allowed: false,
       code,
     });

--- a/apps/backend/tests/unit/auth.routes.test.ts
+++ b/apps/backend/tests/unit/auth.routes.test.ts
@@ -101,6 +101,7 @@ describe('Auth routes', () => {
       firstName: ' Johan ',
       lastName: ' Nel ',
       password: 'mySecurePassword123!',
+      confirmPassword: 'mySecurePassword123!',
     });
 
     expect(response.status).toBe(201);
@@ -154,6 +155,7 @@ describe('Auth routes', () => {
       firstName: 'Johan',
       lastName: 'Nel',
       password: 'mySecurePassword123!',
+      confirmPassword: 'mySecurePassword123!',
     });
 
     expect(response.status).toBe(201);
@@ -405,6 +407,7 @@ describe('Auth routes', () => {
         firstName: 'Johan',
         lastName: 'Nel',
         password: 'mySecurePassword123!',
+        confirmPassword: 'mySecurePassword123!',
       });
     }
 

--- a/apps/backend/tests/unit/auth.routes.test.ts
+++ b/apps/backend/tests/unit/auth.routes.test.ts
@@ -119,18 +119,9 @@ describe('Auth routes', () => {
     expect(createdData.passwordHash).not.toBe('mySecurePassword123!');
 
     expect(response.body).toEqual({
-      user: {
-        id: 'id-123',
-        firstName: 'Johan',
-        lastName: 'Nel',
-        email: 'johan@exampleemail.com',
-        userType: 'GENERAL_TRAINEE',
-        authStatus: 'PENDING_EMAIL_VERIFICATION',
-        createdAt: '2026-05-12T06:00:00.000Z',
-      },
-      verificationEmailQueued: false,
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
     });
-    expect(response.body.user).not.toHaveProperty('passwordHash');
   });
 
   it('returns 400 for invalid register payload', async () => {
@@ -146,7 +137,7 @@ describe('Auth routes', () => {
     expect(prismaMock.user.create).not.toHaveBeenCalled();
   });
 
-  it('returns 409 when trying to register with an existing email', async () => {
+  it('returns generic success when trying to register with an existing email', async () => {
     prismaMock.user.findUnique.mockResolvedValue({
       id: 'existing-user-id',
       email: 'johan@example.com',
@@ -165,8 +156,11 @@ describe('Auth routes', () => {
       password: 'mySecurePassword123!',
     });
 
-    expect(response.status).toBe(409);
-    expect(response.body).toHaveProperty('error', 'AUTH_EMAIL_EXISTS');
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
     expect(prismaMock.user.create).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/tests/unit/auth.service.test.ts
+++ b/apps/backend/tests/unit/auth.service.test.ts
@@ -61,6 +61,7 @@ const prismaMock = vi.hoisted(() => ({
   },
   actionToken: {
     updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    findFirst: vi.fn(),
   },
   emailChangeRequest: {
     findUnique: vi.fn(),
@@ -114,7 +115,12 @@ vi.mock('../../src/lib/prisma.js', () => ({
 describe('registerUser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prismaMock.$transaction.mockImplementation((action) => action('transaction-client'));
+    actionTokenServiceMock.issueActionToken.mockReset();
+    authEmailHookServiceMock.requestAuthEmailSend.mockReset();
+    prismaMock.actionToken.findFirst.mockReset();
+    prismaMock.actionToken.updateMany.mockReset();
+    prismaMock.actionToken.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.$transaction.mockImplementation((action) => action(prismaMock));
   });
 
   it('hashes the password, creates a trainee user, and returns a safe public user', async () => {
@@ -153,7 +159,7 @@ describe('registerUser', () => {
         lastName: 'Nel',
         passwordHash: 'hashed-password',
       },
-      'transaction-client',
+      prismaMock,
     );
     expect(actionTokenServiceMock.issueActionToken).toHaveBeenCalledWith(
       {
@@ -162,7 +168,7 @@ describe('registerUser', () => {
         targetEmail: 'johan@example.com',
         expiresAt: expect.any(Date),
       },
-      'transaction-client',
+      prismaMock,
     );
     expect(authEmailHookServiceMock.requestAuthEmailSend).toHaveBeenCalledWith({
       emailType: 'EMAIL_VERIFICATION',
@@ -232,15 +238,170 @@ describe('registerUser', () => {
     expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
     expect(userRepositoryMock.createGeneralTraineeUser).toHaveBeenCalledWith(
       expect.any(Object),
-      'transaction-client',
+      prismaMock,
     );
     expect(actionTokenServiceMock.issueActionToken).toHaveBeenCalledWith(
       expect.any(Object),
-      'transaction-client',
+      prismaMock,
     );
     expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
   });
-});
+
+  it('does not resend verification for a pending unverified account with a valid sent verification token', async () => {
+    const expiresAt = new Date(Date.now() + 60 + 60 * 1000);
+    userRepositoryMock.findUserByEmail.mockResolvedValue({
+      id: 'pendinguser',
+      email: 'pending@example.com',
+      firstName: 'Pending',
+      authStatus: 'PENDING_EMAIL_VERIFICATION',
+    });
+    passwordServiceMock.hashPassword.mockResolvedValue('hashedpassword');
+    prismaMock.actionToken.findFirst.mockResolvedValue({
+      id: 'existingtoken',
+      userId: 'pendinguser',
+      targetEmail: 'pending@example.com',
+      purpose: 'EMAIL_VERIFICATION',
+      expiresAt,
+      usedAt: null,
+      revokedAt: null,
+      emailDeliveryLogs: [{ emailType: 'EMAIL_VERIFICATION', deliveryStatus: 'SENT' }],
+    });
+    const response = await registerUser({
+      email: 'pending@example.com',
+      firstName: 'Pending',
+      lastName: 'User',
+      password: 'mySecurePassword123!',
+    });
+    expect(response).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
+    expect(prismaMock.actionToken.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: 'pendinguser',
+        targetEmail: 'pending@example.com',
+        purpose: 'EMAIL_VERIFICATION',
+        usedAt: null,
+        revokedAt: null,
+      },
+      include: { emailDeliveryLogs: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(prismaMock.actionToken.updateMany).not.toHaveBeenCalled();
+    expect(actionTokenServiceMock.issueActionToken).not.toHaveBeenCalled();
+    expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
+  });
+
+  it('revokes existing cerification tokens and sends a new verification email for an expired pending token', async () => {
+    const newExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    userRepositoryMock.findUserByEmail.mockResolvedValue({
+      id: 'pendinguser',
+      email: 'pending@example.com',
+      firstName: 'Pending',
+      authStatus: 'PENDING_EMAIL_VERIFICATION',
+    });
+    passwordServiceMock.hashPassword.mockResolvedValue('hashedpassword');
+    prismaMock.actionToken.findFirst.mockResolvedValue({
+      id: 'expiredtoken',
+      userId: 'pendinguser',
+      targetEmail: 'pending@example.com',
+      expiresAt: new Date(Date.now() - 60 * 1000),
+      usedAt: null,
+      revokedAt: null,
+      emailDeliveryLogs: [{ emailType: 'EMAIL_VERIFICATION', deliveryStatus: 'SENT' }],
+    });
+    authEmailHookServiceMock.requestAuthEmailSend.mockResolvedValue({ queued: true });
+    actionTokenServiceMock.issueActionToken.mockResolvedValue({
+      rawToken: 'newrawtoken',
+      token: { id: 'newtoken', expiresAt: newExpiresAt },
+    });
+    const response = await registerUser({
+      email: 'pending@example.com',
+      firstName: 'Pending',
+      lastName: 'User',
+      password: 'mySecurePassword123!',
+    });
+    expect(response).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
+    expect(prismaMock.actionToken.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'pendinguser',
+        targetEmail: 'pending@example.com',
+        purpose: 'EMAIL_VERIFICATION',
+        usedAt: null,
+        revokedAt: null,
+      },
+      data: { revokedAt: expect.any(Date), revokedReason: 'REGISTRATION_VERIFICATION_REISSUED' },
+    });
+    expect(actionTokenServiceMock.issueActionToken).toHaveBeenCalledWith(
+      {
+        purpose: 'EMAIL_VERIFICATION',
+        userId: 'pendinguser',
+        targetEmail: 'pending@example.com',
+        expiresAt: expect.any(Date),
+      },
+      prismaMock,
+    );
+    expect(authEmailHookServiceMock.requestAuthEmailSend).toHaveBeenCalledWith({
+      emailType: 'EMAIL_VERIFICATION',
+      recipientEmail: 'pending@example.com',
+      userId: 'pendinguser',
+      actionTokenId: 'newtoken',
+      templateData: {
+        firstName: 'Pending',
+        actionToken: 'newrawtoken',
+        actionTokenExpiresAt: newExpiresAt,
+      },
+    });
+  });
+
+  it('sends a new verification email for a pending unverified account with no existing verificationtoken', async () => {
+    const newExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    userRepositoryMock.findUserByEmail.mockResolvedValue({
+      id: 'pending-user',
+      email: 'pending@example.com',
+      firstName: 'Pending',
+      authStatus: 'PENDING_EMAIL_VERIFICATION',
+    });
+    passwordServiceMock.hashPassword.mockResolvedValue('hashed-password');
+    prismaMock.actionToken.findFirst.mockResolvedValue(null);
+    actionTokenServiceMock.issueActionToken.mockResolvedValue({
+      rawToken: 'new-raw-token',
+      token: { id: 'new-token', expiresAt: newExpiresAt },
+    });
+    authEmailHookServiceMock.requestAuthEmailSend.mockResolvedValue({ queued: true });
+
+    const response = await registerUser({
+      email: 'pending@example.com',
+      firstName: 'Pending',
+      lastName: 'User',
+      password: 'mySecurePassword123!',
+    });
+
+    expect(response).toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
+    expect(prismaMock.actionToken.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'pending-user',
+        targetEmail: 'pending@example.com',
+        purpose: 'EMAIL_VERIFICATION',
+        usedAt: null,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: expect.any(Date),
+        revokedReason: 'REGISTRATION_VERIFICATION_REISSUED',
+      },
+    });
+    expect(actionTokenServiceMock.issueActionToken).toHaveBeenCalled();
+    expect(authEmailHookServiceMock.requestAuthEmailSend).toHaveBeenCalled();
+  });
+}); //describe
 
 describe('loginUser', () => {
   beforeEach(() => {

--- a/apps/backend/tests/unit/auth.service.test.ts
+++ b/apps/backend/tests/unit/auth.service.test.ts
@@ -148,6 +148,7 @@ describe('registerUser', () => {
       firstName: 'Johan',
       lastName: 'Nel',
       password: 'mySecurePassword123!',
+      confirmPassword: 'mySecurePassword123!',
     });
 
     expect(userRepositoryMock.findUserByEmail).toHaveBeenCalledWith('johan@example.com');
@@ -199,6 +200,7 @@ describe('registerUser', () => {
         firstName: 'Johan',
         lastName: 'Nel',
         password: 'mySecurePassword123!',
+        confirmPassword: 'mySecurePassword123!',
       }),
     ).resolves.toEqual({
       message:
@@ -232,6 +234,7 @@ describe('registerUser', () => {
         firstName: 'Johan',
         lastName: 'Nel',
         password: 'mySecurePassword123!',
+        confirmPassword: 'mySecurePassword123!',
       }),
     ).rejects.toThrow('token creation failed');
 
@@ -271,6 +274,7 @@ describe('registerUser', () => {
       firstName: 'Pending',
       lastName: 'User',
       password: 'mySecurePassword123!',
+      confirmPassword: 'mySecurePassword123!',
     });
     expect(response).toEqual({
       message:
@@ -320,6 +324,7 @@ describe('registerUser', () => {
       firstName: 'Pending',
       lastName: 'User',
       password: 'mySecurePassword123!',
+      confirmPassword: 'mySecurePassword123!',
     });
     expect(response).toEqual({
       message:
@@ -379,6 +384,7 @@ describe('registerUser', () => {
       firstName: 'Pending',
       lastName: 'User',
       password: 'mySecurePassword123!',
+      confirmPassword: 'mySecurePassword123!',
     });
 
     expect(response).toEqual({

--- a/apps/backend/tests/unit/auth.service.test.ts
+++ b/apps/backend/tests/unit/auth.service.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  AuthConflictError,
   AuthUnauthorizedError,
   getCurrentUser,
   loginUser,
@@ -177,21 +176,12 @@ describe('registerUser', () => {
       },
     });
     expect(response).toEqual({
-      user: {
-        id: 'user-1',
-        firstName: 'Johan',
-        lastName: 'Nel',
-        email: 'johan@example.com',
-        userType: 'GENERAL_TRAINEE',
-        authStatus: 'PENDING_EMAIL_VERIFICATION',
-        createdAt: '2026-05-12T06:00:00.000Z',
-      },
-      verificationEmailQueued: false,
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
     });
-    expect(response.user).not.toHaveProperty('passwordHash');
   });
 
-  it('throws an auth conflict error when the email is already registered', async () => {
+  it('returns a generic success when the email is already registered', async () => {
     userRepositoryMock.findUserByEmail.mockResolvedValue({
       id: 'existing-user',
       email: 'johan@example.com',
@@ -204,10 +194,12 @@ describe('registerUser', () => {
         lastName: 'Nel',
         password: 'mySecurePassword123!',
       }),
-    ).rejects.toBeInstanceOf(AuthConflictError);
+    ).resolves.toEqual({
+      message:
+        "If this email can be registered, we'll send you an email verification link. Please check your inbox.",
+    });
 
     expect(prismaMock.$transaction).not.toHaveBeenCalled();
-    expect(passwordServiceMock.hashPassword).not.toHaveBeenCalled();
     expect(userRepositoryMock.createGeneralTraineeUser).not.toHaveBeenCalled();
     expect(actionTokenServiceMock.issueActionToken).not.toHaveBeenCalled();
     expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();

--- a/apps/backend/tests/unit/setup.routes.test.ts
+++ b/apps/backend/tests/unit/setup.routes.test.ts
@@ -62,6 +62,9 @@ describe('Setup routes', () => {
       },
       targetEmail: 'trainee@example.com',
       organisationName: 'Acme Security',
+      targetFirstName: 'Johan',
+      targetLastName: 'Nel',
+      role: 'ORGANISATION_TRAINEE',
     });
 
     const response = await request(createApp()).get(setupContextPath);
@@ -76,6 +79,9 @@ describe('Setup routes', () => {
       },
       targetEmail: 'trainee@example.com',
       organisationName: 'Acme Security',
+      targetFirstName: 'Johan',
+      targetLastName: 'Nel',
+      role: 'ORGANISATION_TRAINEE',
     });
   });
 

--- a/apps/backend/tests/unit/setup.service.test.ts
+++ b/apps/backend/tests/unit/setup.service.test.ts
@@ -105,6 +105,8 @@ function setupToken(overrides = {}) {
       id: 'invitation-1',
       recipientEmail: 'trainee@example.com',
       organisationId: 'org-1',
+      recipientFirstName: 'Johan',
+      recipientLastName: 'Nel',
       status: 'PENDING',
       expiresAt: new Date(Date.now() + setupInvitationExpiryMs),
       organisation: activeOrganisation,
@@ -162,6 +164,9 @@ describe('setup service', () => {
       },
       targetEmail: 'trainee@example.com',
       organisationName: 'Acme Security',
+      targetFirstName: 'Johan',
+      role: 'ORGANISATION_TRAINEE',
+      targetLastName: 'Nel',
     });
   });
 

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -149,7 +149,7 @@ const expectedRequestBodies = [
 
 const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
   ['get', '/health', ['200', '500']],
-  ['post', '/auth/register', ['201', '400', '409', '429', '500']],
+  ['post', '/auth/register', ['201', '400', '429', '500']],
   ['post', '/auth/login', ['200', '400', '401', '403', '429', '500']],
   ['get', '/auth/me', ['200', '401', '403', '429', '500']],
   ['post', '/auth/logout', ['200', '500']],

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -354,7 +354,7 @@ describe('swaggerSpec', () => {
   it('documents organisation request web URL restrictions', () => {
     const schema = JSON.stringify(spec.components?.schemas?.CreateOrganisationRegistrationRequest);
 
-    expect(schema).toContain('Must use http or https.');
+    expect(schema).toContain('Optional. Must use http or https when provided.');
   });
 
   it('keeps simulated email detail free of pre-classification answers', () => {

--- a/apps/frontend/src/pages/RegisterPage.tsx
+++ b/apps/frontend/src/pages/RegisterPage.tsx
@@ -16,7 +16,6 @@ import { authRegisterRequestSchema } from '@insightful-phish/shared';
 function RegisterPage() {
   const navigate = useNavigate();
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
@@ -34,16 +33,11 @@ function RegisterPage() {
       lastName,
       email,
       password,
+      confirmPassword,
     });
 
     if (!validationResult.success) {
       setMessage(validationResult.error.issues[0]?.message || 'INVALID INPUT');
-
-      return;
-    }
-
-    if (password !== confirmPassword) {
-      setMessage('PASSWORDS DO NOT MATCH');
 
       return;
     }

--- a/apps/frontend/src/pages/RegisterPage.tsx
+++ b/apps/frontend/src/pages/RegisterPage.tsx
@@ -58,6 +58,7 @@ function RegisterPage() {
     }
 
     try {
+      setIsLoading(true);
       const response = await fetch(`${API_BASE_URL}/auth/register`, {
         method: 'POST',
         headers: {

--- a/apps/frontend/src/pages/testing/RegisterPage.test.tsx
+++ b/apps/frontend/src/pages/testing/RegisterPage.test.tsx
@@ -70,7 +70,7 @@ describe('RegisterPage', () => {
     await user.type(screen.getByLabelText(/confirm password/i), 'DifferentPass123!');
     await user.click(screen.getByRole('button', { name: /register/i }));
 
-    expect(screen.getByText('Password confirmation must match password.')).toBeInTheDocument();
+    expect(screen.getByText('Password Confirmation Must Match Password')).toBeInTheDocument();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -103,13 +103,9 @@ describe('RegisterPage', () => {
 
   it('shows the backend error message when registration fails', async () => {
     const user = userEvent.setup();
-
-    expect(JSON.parse(requestInit.body as string)).toEqual({
-      firstName: 'Jane',
-      lastName: 'Doe',
-      email: 'trainee@example.com',
-      password: 'StrongPass123!',
-      confirmPassword: 'StrongPass123!',
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'registration failed' }),
     });
     renderRegisterPage();
     await fillRegistrationForm(user);

--- a/apps/frontend/src/pages/testing/RegisterPage.test.tsx
+++ b/apps/frontend/src/pages/testing/RegisterPage.test.tsx
@@ -70,7 +70,7 @@ describe('RegisterPage', () => {
     await user.type(screen.getByLabelText(/confirm password/i), 'DifferentPass123!');
     await user.click(screen.getByRole('button', { name: /register/i }));
 
-    expect(screen.getByText('PASSWORDS DO NOT MATCH')).toBeInTheDocument();
+    expect(screen.getByText('Password confirmation must match password.')).toBeInTheDocument();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -116,34 +116,11 @@ describe('RegisterPage', () => {
       lastName: 'Doe',
       email: 'trainee@example.com',
       password: 'StrongPass123!',
+      confirmPassword: 'StrongPass123!',
     });
 
     await vi.runAllTimersAsync();
 
     expect(navigateMock).toHaveBeenCalledWith('/login');
-  });
-
-  it('shows a duplicate-account message when the backend returns 409', async () => {
-    const user = userEvent.setup();
-
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 409,
-      json: async () => ({
-        message: 'Conflict',
-      }),
-    });
-
-    renderRegisterPage();
-
-    await fillRegistrationForm(user);
-    await user.type(screen.getByLabelText(/^password$/i), 'StrongPass123!');
-    await user.type(screen.getByLabelText(/confirm password/i), 'StrongPass123!');
-    await user.click(screen.getByRole('button', { name: /register/i }));
-
-    expect(
-      await screen.findByText('AN ACCOUNT WITH THIS EMAIL ALREADY EXISTS'),
-    ).toBeInTheDocument();
-    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -27,8 +27,7 @@ export interface AccountVerifyEmailChangeResponseDto {
 }
 
 export interface AuthRegisterResponseDto {
-  user: PublicUserDto;
-  verificationEmailQueued: boolean;
+  message: string;
 }
 
 export interface SetupTokenContextResponseDto {

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -38,7 +38,7 @@ export type SetupTokenRoleDto = 'ORGANISATION_TRAINEE' | 'ORGANISATION_ADMIN' | 
 export interface SetupTokenContextResponseDto {
   token: {
     state: ActionTokenStateDto;
-    purpose?: string;
+    purpose?: SetupTokenPurposeDto;
   };
   targetEmail?: string;
   targetFirstName?: string | null;

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -57,6 +57,8 @@ export type UserTypeDto =
   | 'ORGANISATION_TRAINEE'
   | 'GENERAL_TRAINEE';
 
+export type PlatformAdminRoleDto = 'SUPER_ADMIN' | 'NORMAL_ADMIN';
+
 export type AuthStatusDto =
   | 'PENDING_EMAIL_VERIFICATION'
   | 'PENDING_INVITE_SETUP'
@@ -106,6 +108,7 @@ export interface AuthContextUserDto {
 
 export interface AuthOrganisationContextDto {
   id: string;
+  name: string;
   status: string;
 }
 
@@ -113,6 +116,7 @@ export interface AuthContextDto {
   user: AuthContextUserDto;
   role: UserTypeDto;
   organisation: AuthOrganisationContextDto | null;
+  platformAdminRole: PlatformAdminRoleDto | null;
   permissions: string[];
   redirectTo: string;
 }

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -30,12 +30,20 @@ export interface AuthRegisterResponseDto {
   message: string;
 }
 
+export type SetupTokenPurposeDto =
+  | 'INITIAL_ORGANISATION_ADMIN_SETUP'
+  | 'ORGANISATION_TRAINEE_INVITE'
+  | 'PLATFORM_ADMIN_INVITE';
+export type SetupTokenRoleDto = 'ORGANISATION_TRAINEE' | 'ORGANISATION_ADMIN' | 'IP_ADMIN';
 export interface SetupTokenContextResponseDto {
   token: {
     state: ActionTokenStateDto;
     purpose?: string;
   };
   targetEmail?: string;
+  targetFirstName?: string | null;
+  targetLastName?: string | null;
+  role?: SetupTokenRoleDto;
   organisationName?: string;
 }
 

--- a/packages/shared/src/validation/auth.schemas.test.ts
+++ b/packages/shared/src/validation/auth.schemas.test.ts
@@ -30,17 +30,21 @@ describe('auth validation schemas', () => {
     overrides: Partial<{
       email: string;
       password: string;
+      confirmPassword: string;
       firstName: string;
       lastName: string;
       role: string;
     }> = {},
-  ) => ({
-    email: 'trainee@example.com',
-    password: 'StrongerPass1!',
-    firstName: 'Jane',
-    lastName: 'Doe',
-    ...overrides,
-  });
+  ) => {
+    const input = {
+      email: 'trainee@example.com',
+      password: 'StrongerPass1!',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      ...overrides,
+    };
+    return { ...input, confirmPassword: overrides.confirmPassword ?? input.password };
+  };
 
   const validLoginInput = (
     overrides: Partial<{
@@ -68,23 +72,20 @@ describe('auth validation schemas', () => {
       password: 'StrongerPass1!',
       firstName: 'Jane',
       lastName: 'Doe',
+      confirmPassword: 'StrongerPass1!',
     });
   });
 
-  it('allows register input without password confirmation', () => {
-    const result = authRegisterRequestSchema.parse({
+  it('requires register password confurmation', () => {
+    const result = authRegisterRequestSchema.safeParse({
       email: '  TRAINEE@EXAMPLE.COM  ',
       password: 'StrongerPass1!',
       firstName: ' Jane ',
       lastName: ' Doe ',
     });
 
-    expect(result).toEqual({
-      email: 'trainee@example.com',
-      password: 'StrongerPass1!',
-      firstName: 'Jane',
-      lastName: 'Doe',
-    });
+    expect(result.success).toBe(false);
+    expect(registerIssueMessagesFor(result)).toContain('Please confirm your password.');
   });
 
   it('rejects invalid register input', () => {
@@ -111,13 +112,16 @@ describe('auth validation schemas', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects register payloads with password confirmation', () => {
+  it('rejects register payloads with mismatched password confirmation', () => {
     const result = authRegisterRequestSchema.safeParse({
       ...validRegisterInput(),
-      confirmPassword: 'StrongerPass1!',
+      confirmPassword: 'DifferentPass1!',
     });
 
     expect(result.success).toBe(false);
+    expect(registerIssueMessagesFor(result)).toContain(
+      'Password confirmation must match password.',
+    );
   });
 
   it('requires password confirmation for setup completion input', () => {
@@ -233,7 +237,7 @@ describe('auth validation schemas', () => {
   });
 
   it('rejects login payloads with other unexpected fields', () => {
-    const result = authLoginRequestSchema.safeParse(validLoginInput({ role: 'IP_ADMIN' } as any));
+    const result = authLoginRequestSchema.safeParse({ ...validLoginInput(), role: 'IP_ADMIN' });
     expect(result.success).toBe(false);
   });
 });

--- a/packages/shared/src/validation/auth.schemas.ts
+++ b/packages/shared/src/validation/auth.schemas.ts
@@ -57,14 +57,13 @@ function withPasswordConfirmation<T extends z.ZodRawShape>(schema: z.ZodObject<T
     });
 }
 
-export const authRegisterRequestSchema = z
-  .object({
+export const authRegisterRequestSchema = withPasswordConfirmation(
+  z.object({
     email: emailSchema,
     firstName: firstNameSchema,
     lastName: lastNameSchema,
-    password: passwordSchema,
-  })
-  .strict();
+  }),
+);
 
 export const setupTokenParamsSchema = z
   .object({

--- a/packages/shared/src/validation/organisation-registration.schemas.test.ts
+++ b/packages/shared/src/validation/organisation-registration.schemas.test.ts
@@ -110,4 +110,45 @@ describe('organisation registration request validation', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it.each([
+    ['ommited', undefined],
+    ['empty string', ''],
+    ['only spaces string', '    '],
+  ])(
+    'treats optional organisation description %s as not provided',
+    (_caseName, organisationDescription) => {
+      const paylod = { ...validPayload };
+      if (organisationDescription === undefined) {
+        delete (paylod as Partial<typeof validPayload>).organisationDescription;
+      } else {
+        paylod.organisationDescription = organisationDescription;
+      }
+      const result = createOrganisationRegistrationRequestSchema.safeParse(paylod);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.organisationDescription).toBeUndefined();
+      }
+    },
+  );
+  it.each([
+    ['ommited', undefined],
+    ['empty string', ''],
+    ['only spaces string', '    '],
+  ])(
+    'treats optional organisation organisation url %s as not provided',
+    (_caseName, organisationDescription) => {
+      const paylod = { ...validPayload };
+      if (organisationDescription === undefined) {
+        delete (paylod as Partial<typeof validPayload>).organisationWebsiteUrl;
+      } else {
+        paylod.organisationWebsiteUrl = organisationDescription;
+      }
+      const result = createOrganisationRegistrationRequestSchema.safeParse(paylod);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.organisationWebsiteUrl).toBeUndefined();
+      }
+    },
+  );
 });

--- a/packages/shared/src/validation/organisation-registration.schemas.ts
+++ b/packages/shared/src/validation/organisation-registration.schemas.ts
@@ -31,6 +31,16 @@ const websiteUrlSchema = z
     }
   }, 'Organisation website URL must use http or https.');
 
+const optionalOrganisationDescriptionSchema = z
+  .string({ invalid_type_error: 'Please enter a valid organisation description.' })
+  .trim()
+  .max(2000, 'Organisation description must be at most 2000 characters.')
+  .optional()
+  .or(z.literal('').transform(() => undefined));
+const optionalWebsiteUrlSchema = websiteUrlSchema
+  .optional()
+  .or(z.literal('').transform(() => undefined));
+
 export const createOrganisationRegistrationRequestSchema = z
   .object({
     organisationName: requiredTrimmedStringSchema({
@@ -38,11 +48,7 @@ export const createOrganisationRegistrationRequestSchema = z
       maxLength: 200,
       maxMessage: 'Organisation name must be at most 200 characters.',
     }),
-    organisationDescription: requiredTrimmedStringSchema({
-      requiredMessage: 'Please enter an organisation description.',
-      maxLength: 2000,
-      maxMessage: 'Organisation description must be at most 2000 characters.',
-    }),
+    organisationDescription: optionalOrganisationDescriptionSchema,
     organisationSize: z
       .number({
         required_error: 'Please enter an approximate organisation size.',
@@ -51,7 +57,7 @@ export const createOrganisationRegistrationRequestSchema = z
       .int('Organisation size must be a whole number.')
       .min(1, 'Organisation size must be at least 1.')
       .max(MAX_ORGANISATION_SIZE, `Organisation size must be at most ${MAX_ORGANISATION_SIZE}.`),
-    organisationWebsiteUrl: websiteUrlSchema,
+    organisationWebsiteUrl: optionalWebsiteUrlSchema,
     representativeFirstName: requiredTrimmedStringSchema({
       requiredMessage: 'Please enter a representative first name.',
       maxLength: 100,

--- a/packages/shared/src/validation/organisation-registration.schemas.ts
+++ b/packages/shared/src/validation/organisation-registration.schemas.ts
@@ -31,15 +31,21 @@ const websiteUrlSchema = z
     }
   }, 'Organisation website URL must use http or https.');
 
-const optionalOrganisationDescriptionSchema = z
-  .string({ invalid_type_error: 'Please enter a valid organisation description.' })
-  .trim()
-  .max(2000, 'Organisation description must be at most 2000 characters.')
-  .optional()
-  .or(z.literal('').transform(() => undefined));
-const optionalWebsiteUrlSchema = websiteUrlSchema
-  .optional()
-  .or(z.literal('').transform(() => undefined));
+const optionalTrimmedString = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+const optionalOrganisationDescriptionSchema = z.preprocess(
+  optionalTrimmedString,
+  z
+    .string({ invalid_type_error: 'Please enter a valid organisation description.' })
+    .max(2000, 'Organisation description must be at most 2000 characters.')
+    .optional(),
+);
+const optionalWebsiteUrlSchema = z.preprocess(optionalTrimmedString, websiteUrlSchema.optional());
 
 export const createOrganisationRegistrationRequestSchema = z
   .object({


### PR DESCRIPTION
## Summary

This PR aligns the Sprint 4 auth and setup contracts with the frontend integration and security requirements identified during planning review.

Public individual registration now returns a generic check-email response instead of exposing whether an email address already belongs to an account. This prevents account enumeration while still allowing the backend to create a new pending account, send verification for a new account, or reissue verification for an existing unverified account when appropriate. The registration response shape was simplified to a generic message so the frontend does not depend on account-existence or email-delivery state.

The setup-token context contract was enriched so the reused register/setup page can show meaningful invite/setup context before final submission. The backend now exposes safe token context such as the setup purpose, target identity fields when available, intended role, and organisation display information where applicable, without consuming the token during context lookup. Token consumption remains reserved for successful setup completion.

Auth context responses now include enough role and organisation metadata for Sprint 4 routing and dashboard decisions. This reduces frontend guesswork after login/current-user refresh and makes platform-admin and organisation-scoped routing more explicit.

Organisation registration requests were aligned with the planned frontend form by allowing optional description and website fields. Duplicate checks still apply when website/domain information is provided, but organisations are no longer forced to supply optional fields.. (kinda weird that an optional field was required by backend...)

Public registration validation now includes password confirmation in the shared contract, so frontend and backend validation expectations match. Swagger and tests were updated to describe and verify the new API semantics.

## Linked Issue

Closes #317 
Other identified mismatched were fixed, without having an explicit issue open...

## Type of change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [x] Chore/Maintenance

## Testing

All tests pass (after a struggle to fix and update them.. but we got there in the end)

## Review Notes

- Public registration should not reveal whether an email is already registered.
- The frontend should not rely on `409 AUTH_EMAIL_EXISTS` or any duplicate-account message for public registration. This can be fixed during the integration issue (not fixed in this PR)
- Setup-token context should remain non-consuming: Only successful setup completion should consume the token.
- The setup context should expose only invite/setup display metadata that is safe for someone holding a valid tokenised link.
- Auth context should provide enough information for frontend routing without requiring extra calls or client-side role inference.
- Optional organisation request fields should now actually be optional without weakening duplicate detection when website/domain data is supplied.
- Email-delivery success/failure may still be recorded internally, but public registration should not expose that state.

## Checklist

- [x] I tested the change locally
- [x] Accessibility impact was considered if applicable NA
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable 
- [x] Documentation was updated if needed NA
- [x] No secrets, credentials, or sensitive values were committed