### PR TITLE
Feat/security settings db/adriano

### DIFF
--- a/apps/backend/prisma/migrations/20260702120000_security_settings_foundation/migration.sql
+++ b/apps/backend/prisma/migrations/20260702120000_security_settings_foundation/migration.sql
@@ -1,0 +1,93 @@
+-- Create organisation security settings and optional user security preferences.
+CREATE TABLE "UserSecurityPreferences" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "preferredRegularSessionLengthHours" INTEGER,
+  "preferredRememberMeSessionLengthHours" INTEGER,
+  "preferredIdleTimeoutMinutes" INTEGER,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "UserSecurityPreferences_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "OrganisationSecuritySettings" (
+  "id" TEXT NOT NULL,
+  "organisationId" TEXT NOT NULL,
+  "enforceRememberMePolicy" BOOLEAN NOT NULL DEFAULT true,
+  "allowRememberMe" BOOLEAN NOT NULL DEFAULT true,
+  "maxRememberedSessionHours" INTEGER DEFAULT 168,
+  "enforceRegularSessionLength" BOOLEAN NOT NULL DEFAULT true,
+  "regularSessionLengthHours" INTEGER DEFAULT 8,
+  "enforceIdleTimeout" BOOLEAN NOT NULL DEFAULT false,
+  "idleTimeoutMinutes" INTEGER,
+  "requireReauthenticationForSensitiveActions" BOOLEAN NOT NULL DEFAULT true,
+  "allowTraineeEmailChange" BOOLEAN NOT NULL DEFAULT true,
+  "updatedByOrganisationAdminId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "OrganisationSecuritySettings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "UserSecurityPreferences_userId_key"
+  ON "UserSecurityPreferences"("userId");
+
+CREATE UNIQUE INDEX "OrganisationSecuritySettings_organisationId_key"
+  ON "OrganisationSecuritySettings"("organisationId");
+
+CREATE INDEX "OrganisationSecuritySettings_updatedByOrganisationAdminId_idx"
+  ON "OrganisationSecuritySettings"("updatedByOrganisationAdminId");
+
+ALTER TABLE "UserSecurityPreferences"
+  ADD CONSTRAINT "UserSecurityPreferences_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "OrganisationSecuritySettings"
+  ADD CONSTRAINT "OrganisationSecuritySettings_organisationId_fkey"
+  FOREIGN KEY ("organisationId") REFERENCES "Organisation"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "OrganisationSecuritySettings"
+  ADD CONSTRAINT "OrganisationSecuritySettings_updatedByOrganisationAdminId_fkey"
+  FOREIGN KEY ("updatedByOrganisationAdminId") REFERENCES "OrganisationAdminProfile"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+INSERT INTO "OrganisationSecuritySettings" (
+  "id",
+  "organisationId",
+  "enforceRememberMePolicy",
+  "allowRememberMe",
+  "maxRememberedSessionHours",
+  "enforceRegularSessionLength",
+  "regularSessionLengthHours",
+  "enforceIdleTimeout",
+  "idleTimeoutMinutes",
+  "requireReauthenticationForSensitiveActions",
+  "allowTraineeEmailChange",
+  "updatedByOrganisationAdminId",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  CONCAT('organisation-security-settings-', o."id"),
+  o."id",
+  true,
+  true,
+  168,
+  true,
+  8,
+  false,
+  NULL,
+  true,
+  true,
+  NULL,
+  NOW(),
+  NOW()
+FROM "Organisation" o
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "OrganisationSecuritySettings" settings
+  WHERE settings."organisationId" = o."id"
+);

--- a/apps/backend/prisma/migrations/20260702123000_scope_security_settings_updater/migration.sql
+++ b/apps/backend/prisma/migrations/20260702123000_scope_security_settings_updater/migration.sql
@@ -1,0 +1,19 @@
+-- Enforce that the recorded organisation security settings updater belongs to the same organisation.
+UPDATE "OrganisationSecuritySettings" settings
+SET "updatedByOrganisationAdminId" = NULL
+WHERE settings."updatedByOrganisationAdminId" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "OrganisationAdminProfile" admin_profile
+    WHERE admin_profile."id" = settings."updatedByOrganisationAdminId"
+      AND admin_profile."organisationId" = settings."organisationId"
+  );
+
+ALTER TABLE "OrganisationSecuritySettings"
+  DROP CONSTRAINT "OrganisationSecuritySettings_updatedByOrganisationAdminId_fkey";
+
+ALTER TABLE "OrganisationSecuritySettings"
+  ADD CONSTRAINT "OrganisationSecuritySettings_updatedByOrganisationAdminId_fkey"
+  FOREIGN KEY ("updatedByOrganisationAdminId", "organisationId")
+  REFERENCES "OrganisationAdminProfile"("id", "organisationId")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -698,7 +698,7 @@ model OrganisationSecuritySettings {
   createdAt                                  DateTime                  @default(now())
   updatedAt                                  DateTime                  @updatedAt
   organisation                               Organisation              @relation(fields: [organisationId], references: [id], onDelete: Cascade)
-  updatedByOrganisationAdmin                 OrganisationAdminProfile? @relation("OrganisationSecuritySettingsUpdatedBy", fields: [updatedByOrganisationAdminId], references: [id], onDelete: SetNull)
+  updatedByOrganisationAdmin                 OrganisationAdminProfile? @relation("OrganisationSecuritySettingsUpdatedBy", fields: [updatedByOrganisationAdminId, organisationId], references: [id, organisationId], onDelete: Restrict)
 
   @@index([updatedByOrganisationAdminId])
 }

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -421,6 +421,7 @@ model User {
   traineeProfile               TraineeProfile?
   organisationAdminProfile     OrganisationAdminProfile?
   ipAdminProfile               IpAdminProfile?
+  securityPreferences          UserSecurityPreferences?
   uploadedOrganisationContexts OrganisationContext[]     @relation("OrganisationContextUploadedBy")
   createdCampaigns             Campaign[]                @relation("CampaignCreatedBy")
   assignedCampaignAssignments  CampaignAssignment[]      @relation("CampaignAssignmentAssignedBy")
@@ -488,22 +489,23 @@ model OrganisationTraineeProfile {
 }
 
 model OrganisationAdminProfile {
-  id                      String                        @id @default(uuid())
-  userId                  String                        @unique
+  id                      String                         @id @default(uuid())
+  userId                  String                         @unique
   organisationId          String
-  adminStatus             AdminStatus                   @default(ACTIVE)
-  joinedAt                DateTime                      @default(now())
-  isInitialAdmin          Boolean                       @default(false)
+  adminStatus             AdminStatus                    @default(ACTIVE)
+  joinedAt                DateTime                       @default(now())
+  isInitialAdmin          Boolean                        @default(false)
   createdFromInvitationId String?
   disabledAt              DateTime?
   disabledReason          String?
-  createdAt               DateTime                      @default(now())
-  updatedAt               DateTime                      @updatedAt
-  user                    User                          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organisation            Organisation                  @relation(fields: [organisationId], references: [id], onDelete: Cascade)
-  createdFromInvitation   Invitation?                   @relation("InvitationAcceptedOrganisationAdmin", fields: [createdFromInvitationId, organisationId], references: [id, organisationId], onDelete: Restrict)
-  permissionGrants        OrganisationAdminPermission[] @relation("OrganisationAdminPermissionAdmin")
-  grantedPermissionGrants OrganisationAdminPermission[] @relation("OrganisationAdminPermissionGrantedBy")
+  createdAt               DateTime                       @default(now())
+  updatedAt               DateTime                       @updatedAt
+  user                    User                           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organisation            Organisation                   @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  createdFromInvitation   Invitation?                    @relation("InvitationAcceptedOrganisationAdmin", fields: [createdFromInvitationId, organisationId], references: [id, organisationId], onDelete: Restrict)
+  permissionGrants        OrganisationAdminPermission[]  @relation("OrganisationAdminPermissionAdmin")
+  grantedPermissionGrants OrganisationAdminPermission[]  @relation("OrganisationAdminPermissionGrantedBy")
+  updatedSecuritySettings OrganisationSecuritySettings[] @relation("OrganisationSecuritySettingsUpdatedBy")
 
   @@unique([id, organisationId])
   @@unique([createdFromInvitationId, organisationId])
@@ -555,6 +557,17 @@ model AuthSession {
   @@index([expiresAt])
   @@index([lastActiveAt])
   @@index([revokedAt])
+}
+
+model UserSecurityPreferences {
+  id                                    String   @id @default(uuid())
+  userId                                String   @unique
+  preferredRegularSessionLengthHours    Int?
+  preferredRememberMeSessionLengthHours Int?
+  preferredIdleTimeoutMinutes           Int?
+  createdAt                             DateTime @default(now())
+  updatedAt                             DateTime @updatedAt
+  user                                  User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model RefreshToken {
@@ -666,6 +679,28 @@ model Organisation {
   permissions                OrganisationPermission[]
   adminPermissionGrants      OrganisationAdminPermission[]
   invitationPermissionGrants InvitationPermissionGrant[]
+  securitySettings           OrganisationSecuritySettings?
+}
+
+model OrganisationSecuritySettings {
+  id                                         String                    @id @default(uuid())
+  organisationId                             String                    @unique
+  enforceRememberMePolicy                    Boolean                   @default(true)
+  allowRememberMe                            Boolean                   @default(true)
+  maxRememberedSessionHours                  Int?                      @default(168)
+  enforceRegularSessionLength                Boolean                   @default(true)
+  regularSessionLengthHours                  Int?                      @default(8)
+  enforceIdleTimeout                         Boolean                   @default(false)
+  idleTimeoutMinutes                         Int?
+  requireReauthenticationForSensitiveActions Boolean                   @default(true)
+  allowTraineeEmailChange                    Boolean                   @default(true)
+  updatedByOrganisationAdminId               String?
+  createdAt                                  DateTime                  @default(now())
+  updatedAt                                  DateTime                  @updatedAt
+  organisation                               Organisation              @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  updatedByOrganisationAdmin                 OrganisationAdminProfile? @relation("OrganisationSecuritySettingsUpdatedBy", fields: [updatedByOrganisationAdminId], references: [id], onDelete: SetNull)
+
+  @@index([updatedByOrganisationAdminId])
 }
 
 model OrganisationPermission {

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -5,6 +5,10 @@ import {
   seedOrganisationAdminPermissions,
   type OrganisationPermissionSeedSummary,
 } from './seed-data/organisationPermissionSeed.js';
+import {
+  ensureDefaultOrganisationSecuritySettingsForAllOrganisations,
+  type OrganisationSecuritySettingsSeedSummary,
+} from '../src/repositories/security-settings.repository.js';
 
 async function seedDemo1(): Promise<void> {
   const summary = await seedDemoCore(prisma);
@@ -25,6 +29,14 @@ function printAuthBootstrapSeedSummary(summary: AuthBootstrapSeedSummary): void 
 function printOrganisationPermissionSeedSummary(summary: OrganisationPermissionSeedSummary): void {
   console.log(
     `Organisation admin permissions seeded for ${summary.organisationCount} organisations: ${summary.permissionCount} permission records, ${summary.initialAdminGrantCount} initial-admin grants.`,
+  );
+}
+
+function printOrganisationSecuritySettingsSeedSummary(
+  summary: OrganisationSecuritySettingsSeedSummary,
+): void {
+  console.log(
+    `Organisation security settings ensured for ${summary.organisationCount} organisations: ${summary.createdSettingsCount} settings records created.`,
   );
 }
 
@@ -63,6 +75,10 @@ try {
 
   const organisationPermissionSummary = await seedOrganisationAdminPermissions(prisma);
   printOrganisationPermissionSeedSummary(organisationPermissionSummary);
+
+  const organisationSecuritySettingsSummary =
+    await ensureDefaultOrganisationSecuritySettingsForAllOrganisations(prisma);
+  printOrganisationSecuritySettingsSeedSummary(organisationSecuritySettingsSummary);
 
   await seedDemo1();
 } catch (error: unknown) {

--- a/apps/backend/src/repositories/auth-session.repository.ts
+++ b/apps/backend/src/repositories/auth-session.repository.ts
@@ -51,6 +51,19 @@ export function touchAuthSession(id: string, client: AuthSessionClient = prisma)
   });
 }
 
+export function updateAuthSessionPolicy(
+  input: { id: string; expiresAt: Date; idleTimeoutMinutes?: number | null },
+  client: AuthSessionClient = prisma,
+) {
+  return client.authSession.update({
+    data: {
+      expiresAt: input.expiresAt,
+      idleTimeoutMinutes: input.idleTimeoutMinutes ?? null,
+    },
+    where: { id: input.id },
+  });
+}
+
 export function revokeAuthSession(
   input: { id: string; revokedReason: AuthSessionRevokedReason },
   client: AuthSessionClient = prisma,

--- a/apps/backend/src/repositories/security-settings.repository.ts
+++ b/apps/backend/src/repositories/security-settings.repository.ts
@@ -1,0 +1,144 @@
+import type { Prisma, PrismaClient } from '../generated/prisma/client.js';
+import { prisma } from '../lib/prisma.js';
+
+type SecuritySettingsClient = PrismaClient | Prisma.TransactionClient;
+
+export const DEFAULT_ORGANISATION_SECURITY_SETTINGS = {
+  enforceRememberMePolicy: true,
+  allowRememberMe: true,
+  maxRememberedSessionHours: 168,
+  enforceRegularSessionLength: true,
+  regularSessionLengthHours: 8,
+  enforceIdleTimeout: false,
+  idleTimeoutMinutes: null,
+  requireReauthenticationForSensitiveActions: true,
+  allowTraineeEmailChange: true,
+} as const;
+
+export type OrganisationSecuritySettingsSeedSummary = {
+  readonly organisationCount: number;
+  readonly createdSettingsCount: number;
+};
+
+type OrganisationCountRow = {
+  readonly count: bigint;
+};
+
+function supportsExecuteRaw(client: SecuritySettingsClient): boolean {
+  return typeof (client as { $executeRaw?: unknown }).$executeRaw === 'function';
+}
+
+function supportsQueryRaw(client: SecuritySettingsClient): boolean {
+  return typeof (client as { $queryRaw?: unknown }).$queryRaw === 'function';
+}
+
+export function buildOrganisationSecuritySettingsId(organisationId: string): string {
+  return ['organisation-security-settings', organisationId].join('-');
+}
+
+export async function ensureDefaultOrganisationSecuritySettings(
+  input: { organisationId: string },
+  client: SecuritySettingsClient = prisma,
+): Promise<number> {
+  if (!supportsExecuteRaw(client)) {
+    return Promise.resolve(0);
+  }
+
+  return client.$executeRaw`
+    INSERT INTO "OrganisationSecuritySettings" (
+      "id",
+      "organisationId",
+      "enforceRememberMePolicy",
+      "allowRememberMe",
+      "maxRememberedSessionHours",
+      "enforceRegularSessionLength",
+      "regularSessionLengthHours",
+      "enforceIdleTimeout",
+      "idleTimeoutMinutes",
+      "requireReauthenticationForSensitiveActions",
+      "allowTraineeEmailChange",
+      "updatedByOrganisationAdminId",
+      "createdAt",
+      "updatedAt"
+    )
+    VALUES (
+      ${buildOrganisationSecuritySettingsId(input.organisationId)},
+      ${input.organisationId},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceRememberMePolicy},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.allowRememberMe},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.maxRememberedSessionHours},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceRegularSessionLength},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.regularSessionLengthHours},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceIdleTimeout},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.idleTimeoutMinutes},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.requireReauthenticationForSensitiveActions},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.allowTraineeEmailChange},
+      NULL,
+      CURRENT_TIMESTAMP,
+      CURRENT_TIMESTAMP
+    )
+    ON CONFLICT ("organisationId")
+    DO NOTHING
+  `;
+}
+
+export async function ensureDefaultOrganisationSecuritySettingsForAllOrganisations(
+  client: SecuritySettingsClient = prisma,
+): Promise<OrganisationSecuritySettingsSeedSummary> {
+  if (!supportsExecuteRaw(client) || !supportsQueryRaw(client)) {
+    return {
+      organisationCount: 0,
+      createdSettingsCount: 0,
+    };
+  }
+
+  const organisationRows = await client.$queryRaw<OrganisationCountRow[]>`
+    SELECT COUNT(*) AS "count"
+    FROM "Organisation"
+  `;
+
+  const createdSettingsCount = await client.$executeRaw`
+    INSERT INTO "OrganisationSecuritySettings" (
+      "id",
+      "organisationId",
+      "enforceRememberMePolicy",
+      "allowRememberMe",
+      "maxRememberedSessionHours",
+      "enforceRegularSessionLength",
+      "regularSessionLengthHours",
+      "enforceIdleTimeout",
+      "idleTimeoutMinutes",
+      "requireReauthenticationForSensitiveActions",
+      "allowTraineeEmailChange",
+      "updatedByOrganisationAdminId",
+      "createdAt",
+      "updatedAt"
+    )
+    SELECT
+      CONCAT('organisation-security-settings-', organisation."id"),
+      organisation."id",
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceRememberMePolicy},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.allowRememberMe},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.maxRememberedSessionHours},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceRegularSessionLength},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.regularSessionLengthHours},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceIdleTimeout},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.idleTimeoutMinutes},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.requireReauthenticationForSensitiveActions},
+      ${DEFAULT_ORGANISATION_SECURITY_SETTINGS.allowTraineeEmailChange},
+      NULL,
+      CURRENT_TIMESTAMP,
+      CURRENT_TIMESTAMP
+    FROM "Organisation" organisation
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "OrganisationSecuritySettings" settings
+      WHERE settings."organisationId" = organisation."id"
+    )
+  `;
+
+  return {
+    organisationCount: Number(organisationRows[0]?.count ?? 0n),
+    createdSettingsCount,
+  };
+}

--- a/apps/backend/src/repositories/security-settings.repository.ts
+++ b/apps/backend/src/repositories/security-settings.repository.ts
@@ -20,6 +20,26 @@ export type OrganisationSecuritySettingsSeedSummary = {
   readonly createdSettingsCount: number;
 };
 
+export type OrganisationSecuritySettingsRecord = {
+  readonly organisationId: string;
+  readonly enforceRememberMePolicy: boolean;
+  readonly allowRememberMe: boolean;
+  readonly maxRememberedSessionHours: number | null;
+  readonly enforceRegularSessionLength: boolean;
+  readonly regularSessionLengthHours: number | null;
+  readonly enforceIdleTimeout: boolean;
+  readonly idleTimeoutMinutes: number | null;
+  readonly requireReauthenticationForSensitiveActions: boolean;
+  readonly allowTraineeEmailChange: boolean;
+};
+
+export type UserSecurityPreferencesRecord = {
+  readonly userId: string;
+  readonly preferredRegularSessionLengthHours: number | null;
+  readonly preferredRememberMeSessionLengthHours: number | null;
+  readonly preferredIdleTimeoutMinutes: number | null;
+};
+
 type OrganisationCountRow = {
   readonly count: bigint;
 };
@@ -80,6 +100,56 @@ export async function ensureDefaultOrganisationSecuritySettings(
     ON CONFLICT ("organisationId")
     DO NOTHING
   `;
+}
+
+export async function findOrganisationSecuritySettings(
+  input: { organisationId: string },
+  client: SecuritySettingsClient = prisma,
+): Promise<OrganisationSecuritySettingsRecord | null> {
+  if (!supportsQueryRaw(client)) {
+    return null;
+  }
+
+  const rows = await client.$queryRaw<OrganisationSecuritySettingsRecord[]>`
+    SELECT
+      "organisationId",
+      "enforceRememberMePolicy",
+      "allowRememberMe",
+      "maxRememberedSessionHours",
+      "enforceRegularSessionLength",
+      "regularSessionLengthHours",
+      "enforceIdleTimeout",
+      "idleTimeoutMinutes",
+      "requireReauthenticationForSensitiveActions",
+      "allowTraineeEmailChange"
+    FROM "OrganisationSecuritySettings"
+    WHERE "organisationId" = ${input.organisationId}
+    LIMIT 1
+  `;
+
+  return rows[0] ?? null;
+}
+
+export async function findUserSecurityPreferences(
+  input: { userId: string },
+  client: SecuritySettingsClient = prisma,
+): Promise<UserSecurityPreferencesRecord | null> {
+  if (!supportsQueryRaw(client)) {
+    return null;
+  }
+
+  const rows = await client.$queryRaw<UserSecurityPreferencesRecord[]>`
+    SELECT
+      "userId",
+      "preferredRegularSessionLengthHours",
+      "preferredRememberMeSessionLengthHours",
+      "preferredIdleTimeoutMinutes"
+    FROM "UserSecurityPreferences"
+    WHERE "userId" = ${input.userId}
+    LIMIT 1
+  `;
+
+  return rows[0] ?? null;
 }
 
 export async function ensureDefaultOrganisationSecuritySettingsForAllOrganisations(

--- a/apps/backend/src/repositories/setup.repository.ts
+++ b/apps/backend/src/repositories/setup.repository.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from '../generated/prisma/client.js';
 import { prisma } from '../lib/prisma.js';
+import { ensureDefaultOrganisationSecuritySettings } from './security-settings.repository.js';
 
 type SetupClient = PrismaClient | Prisma.TransactionClient;
 
@@ -46,7 +47,7 @@ export function findSetupUserByEmail(email: string, client: SetupClient = prisma
   });
 }
 
-export function createOrganisationAdminUser(
+export async function createOrganisationAdminUser(
   input: {
     email: string;
     firstName: string;
@@ -58,6 +59,8 @@ export function createOrganisationAdminUser(
   },
   client: SetupClient,
 ) {
+  await ensureDefaultOrganisationSecuritySettings({ organisationId: input.organisationId }, client);
+
   return client.user.create({
     data: {
       email: input.email,
@@ -79,7 +82,7 @@ export function createOrganisationAdminUser(
   });
 }
 
-export function createOrganisationTraineeUser(
+export async function createOrganisationTraineeUser(
   input: {
     email: string;
     firstName: string;
@@ -91,6 +94,8 @@ export function createOrganisationTraineeUser(
   },
   client: SetupClient,
 ) {
+  await ensureDefaultOrganisationSecuritySettings({ organisationId: input.organisationId }, client);
+
   return client.user.create({
     data: {
       email: input.email,
@@ -154,6 +159,8 @@ export async function activateOrganisationAdminUser(
   },
   client: SetupClient,
 ) {
+  await ensureDefaultOrganisationSecuritySettings({ organisationId: input.organisationId }, client);
+
   await client.user.update({
     where: { id: input.userId },
     data: {
@@ -196,6 +203,8 @@ export async function activateOrganisationTraineeUser(
   },
   client: SetupClient,
 ) {
+  await ensureDefaultOrganisationSecuritySettings({ organisationId: input.organisationId }, client);
+
   await client.user.update({
     where: { id: input.userId },
     data: {

--- a/apps/backend/src/services/auth-session.service.ts
+++ b/apps/backend/src/services/auth-session.service.ts
@@ -6,6 +6,7 @@ import {
   revokeAuthSession,
   revokeUserAuthSessions,
   touchAuthSession,
+  updateAuthSessionPolicy,
   type CreateAuthSessionInput,
 } from '../repositories/auth-session.repository.js';
 
@@ -91,4 +92,16 @@ export async function revokeSessionsForUser(input: {
 
 export async function touchSession(id: string) {
   return touchAuthSession(id);
+}
+
+export async function updateSessionPolicy(input: {
+  sessionId: string;
+  expiresAt: Date;
+  idleTimeoutMinutes?: number | null;
+}) {
+  return updateAuthSessionPolicy({
+    id: input.sessionId,
+    expiresAt: input.expiresAt,
+    idleTimeoutMinutes: input.idleTimeoutMinutes ?? null,
+  });
 }

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -17,8 +17,13 @@ import { requestAuthEmailSend } from './auth-email-hook.service.js';
 import { generateAuthToken } from './auth-token.service.js';
 import * as PasswordService from './password.service.js';
 import { ensureUserCanAuthenticate } from './auth-status-guard.service.js';
-import { resolveSessionPolicy } from './session-policy.service.js';
-import { issueAuthSession, revokeSessionById, touchSession } from './auth-session.service.js';
+import {
+  calculateSessionExpiresAt,
+  issueAuthSession,
+  revokeSessionById,
+  touchSession,
+  updateSessionPolicy,
+} from './auth-session.service.js';
 import {
   issueRefreshToken,
   rotateRefreshToken,
@@ -27,6 +32,10 @@ import {
 } from './refresh-token.service.js';
 import { recordUserLogin, recordAuthSessionRevoked } from './auth-audit.service.js';
 import { buildAuthContext } from './auth-context.service.js';
+import {
+  resolveEffectiveSecurityPolicy,
+  type EffectiveSecurityPolicy,
+} from './security-policy.service.js';
 
 const EMAIL_VERIFICATION_TOKEN_TTL_HOURS = 24;
 
@@ -136,13 +145,6 @@ export class AuthRefreshTokenInvalidError extends Error {
   }
 }
 
-const PLATFORM_SESSION_POLICY = {
-  regularSessionSeconds: 900,
-  rememberedSessionSeconds: 604800,
-  idleTimeoutMinutes: 30,
-  allowRememberMe: true,
-};
-
 export async function loginUser(
   input: AuthLoginRequestDto & { ipAddress?: string | null; userAgent?: string | null },
 ): Promise<{
@@ -169,15 +171,20 @@ export async function loginUser(
     throw new AuthStatusGuardError(guardResult.code, guardResult.statusCode, guardResult.message);
   }
 
-  const policy = resolveSessionPolicy({
+  const policy = await resolveEffectiveSecurityPolicy({
+    subject,
     rememberMeRequested: !!input.rememberMe,
-    platform: PLATFORM_SESSION_POLICY,
+  });
+  const sessionExpiresAt = calculateSessionExpiresAt({
+    rememberMe: policy.rememberMeApplied,
+    regularSessionSeconds: policy.regularSessionSeconds,
+    rememberedSessionSeconds: policy.rememberedSessionSeconds,
   });
 
   const session = await issueAuthSession({
     userId: user.id,
     rememberMe: policy.rememberMeApplied,
-    expiresAt: new Date(Date.now() + policy.effectiveSessionSeconds * 1000),
+    expiresAt: sessionExpiresAt,
     idleTimeoutMinutes: policy.idleTimeoutMinutes,
     userAgent: input.userAgent ?? null,
     ipAddress: input.ipAddress ?? null,
@@ -216,6 +223,49 @@ export async function loginUser(
     rawRefreshToken: refreshResult.rawToken,
     sessionExpiresAt: session.expiresAt,
   };
+}
+
+function earlierDate(first: Date, second: Date): Date {
+  return first.getTime() <= second.getTime() ? first : second;
+}
+
+function sessionExpiresAtForPolicy(input: {
+  createdAt: Date;
+  rememberMe: boolean;
+  policy: EffectiveSecurityPolicy;
+}): Date {
+  return calculateSessionExpiresAt({
+    now: input.createdAt,
+    rememberMe: input.rememberMe,
+    regularSessionSeconds: input.policy.regularSessionSeconds,
+    rememberedSessionSeconds: input.policy.rememberedSessionSeconds,
+  });
+}
+
+function isIdleExpired(input: {
+  lastActiveAt: Date;
+  idleTimeoutMinutes: number | null;
+  now: Date;
+}): boolean {
+  if (input.idleTimeoutMinutes === null) {
+    return false;
+  }
+
+  return input.lastActiveAt.getTime() + input.idleTimeoutMinutes * 60 * 1000 <= input.now.getTime();
+}
+
+async function revokeSessionForPolicyFailure(input: {
+  sessionId: string;
+  sessionReason: AuthSessionRevokedReason;
+}) {
+  await revokeSessionById({
+    sessionId: input.sessionId,
+    reason: input.sessionReason,
+  });
+  await revokeRefreshTokensForSession({
+    authSessionId: input.sessionId,
+    reason: input.sessionReason === 'EXPIRED' ? 'EXPIRED' : 'OTHER',
+  });
 }
 
 export async function getCurrentUser(userId: string): Promise<AuthMeResponseDto> {
@@ -286,11 +336,59 @@ export async function refreshUserToken(
     throw new AuthStatusGuardError(guardResult.code, guardResult.statusCode, guardResult.message);
   }
 
+  const policy = await resolveEffectiveSecurityPolicy({
+    subject,
+    rememberMeRequested: token.authSession.rememberMe,
+  });
+  const now = new Date();
+
+  if (token.authSession.rememberMe && !policy.rememberMeAllowed) {
+    await revokeSessionForPolicyFailure({
+      sessionId: token.authSessionId,
+      sessionReason: 'OTHER',
+    });
+    throw new AuthRefreshTokenInvalidError();
+  }
+
+  const policyExpiresAt = sessionExpiresAtForPolicy({
+    createdAt: token.authSession.createdAt,
+    rememberMe: token.authSession.rememberMe,
+    policy,
+  });
+
+  if (policyExpiresAt.getTime() <= now.getTime()) {
+    await revokeSessionForPolicyFailure({
+      sessionId: token.authSessionId,
+      sessionReason: 'EXPIRED',
+    });
+    throw new AuthRefreshTokenInvalidError();
+  }
+
+  if (
+    isIdleExpired({
+      lastActiveAt: token.authSession.lastActiveAt,
+      idleTimeoutMinutes: policy.idleTimeoutMinutes,
+      now,
+    })
+  ) {
+    await revokeSessionForPolicyFailure({
+      sessionId: token.authSessionId,
+      sessionReason: 'EXPIRED',
+    });
+    throw new AuthRefreshTokenInvalidError();
+  }
+
+  const nextSessionExpiresAt = earlierDate(token.authSession.expiresAt, policyExpiresAt);
+  await updateSessionPolicy({
+    sessionId: token.authSessionId,
+    expiresAt: nextSessionExpiresAt,
+    idleTimeoutMinutes: policy.idleTimeoutMinutes,
+  });
   await touchSession(token.authSessionId);
 
   const rotationResult = await rotateRefreshToken({
     rawToken,
-    nextExpiresAt: token.authSession.expiresAt,
+    nextExpiresAt: nextSessionExpiresAt,
     ipAddress,
     userAgent,
   });
@@ -317,7 +415,7 @@ export async function refreshUserToken(
     },
     accessTokenExpiresAt: tokenResult.expiresAt,
     rawRefreshToken: rotationResult.rawToken,
-    sessionExpiresAt: token.authSession.expiresAt,
+    sessionExpiresAt: nextSessionExpiresAt,
   };
 }
 

--- a/apps/backend/src/services/security-policy.service.ts
+++ b/apps/backend/src/services/security-policy.service.ts
@@ -1,0 +1,173 @@
+import type { GuardAuthSubject } from './auth-status-guard.service.js';
+import {
+  DEFAULT_ORGANISATION_SECURITY_SETTINGS,
+  ensureDefaultOrganisationSecuritySettings,
+  findOrganisationSecuritySettings,
+  findUserSecurityPreferences,
+  type OrganisationSecuritySettingsRecord,
+  type UserSecurityPreferencesRecord,
+} from '../repositories/security-settings.repository.js';
+import {
+  resolveSessionPolicy,
+  type OrganisationSessionPolicy,
+  type PlatformSessionPolicy,
+  type ResolvedSessionPolicy,
+  type UserSessionPreference,
+} from './session-policy.service.js';
+
+const SECONDS_PER_HOUR = 60 * 60;
+
+export type PlatformSecurityPolicy = PlatformSessionPolicy & {
+  requireReauthenticationForSensitiveActions: boolean;
+  allowEmailChange: boolean;
+};
+
+export type EffectiveSecurityPolicy = ResolvedSessionPolicy & {
+  organisationId: string | null;
+  requireReauthenticationForSensitiveActions: boolean;
+  allowEmailChange: boolean;
+};
+
+export type EffectiveSecurityPolicyInput = {
+  subject: GuardAuthSubject;
+  rememberMeRequested: boolean;
+  platform?: PlatformSecurityPolicy;
+};
+
+export const PLATFORM_SECURITY_POLICY = {
+  regularSessionSeconds: 15 * 60,
+  rememberedSessionSeconds: 7 * 24 * SECONDS_PER_HOUR,
+  idleTimeoutMinutes: 30,
+  allowRememberMe: true,
+  requireReauthenticationForSensitiveActions: true,
+  allowEmailChange: true,
+} as const satisfies PlatformSecurityPolicy;
+
+function positiveHoursToSeconds(hours: number | null | undefined): number | null {
+  if (typeof hours !== 'number' || !Number.isFinite(hours) || hours <= 0) {
+    return null;
+  }
+
+  return hours * SECONDS_PER_HOUR;
+}
+
+function defaultOrganisationSettings(organisationId: string): OrganisationSecuritySettingsRecord {
+  return {
+    organisationId,
+    ...DEFAULT_ORGANISATION_SECURITY_SETTINGS,
+  };
+}
+
+function toOrganisationSessionPolicy(
+  settings: OrganisationSecuritySettingsRecord | null,
+): OrganisationSessionPolicy | null {
+  if (!settings) {
+    return null;
+  }
+
+  return {
+    enforceRememberMePolicy: settings.enforceRememberMePolicy,
+    allowRememberMe: settings.allowRememberMe,
+    maxRememberedSessionSeconds: positiveHoursToSeconds(settings.maxRememberedSessionHours),
+    enforceRegularSessionLength: settings.enforceRegularSessionLength,
+    regularSessionSeconds: positiveHoursToSeconds(settings.regularSessionLengthHours),
+    enforceIdleTimeout: settings.enforceIdleTimeout,
+    idleTimeoutMinutes: settings.idleTimeoutMinutes,
+  };
+}
+
+function toUserSessionPreference(
+  preferences: UserSecurityPreferencesRecord | null,
+): UserSessionPreference | null {
+  if (!preferences) {
+    return null;
+  }
+
+  return {
+    preferredRegularSessionSeconds: positiveHoursToSeconds(
+      preferences.preferredRegularSessionLengthHours,
+    ),
+    preferredRememberedSessionSeconds: positiveHoursToSeconds(
+      preferences.preferredRememberMeSessionLengthHours,
+    ),
+    preferredIdleTimeoutMinutes: preferences.preferredIdleTimeoutMinutes,
+  };
+}
+
+export function organisationIdForSecurityPolicy(subject: GuardAuthSubject): string | null {
+  if (subject.user?.userType === 'ORGANISATION_ADMIN') {
+    return subject.organisationAdminProfile?.organisation?.id ?? null;
+  }
+
+  if (subject.user?.userType === 'ORGANISATION_TRAINEE') {
+    return subject.organisationTraineeProfile?.organisation?.id ?? null;
+  }
+
+  return null;
+}
+
+async function findOrganisationSettingsOrDefault(
+  organisationId: string | null,
+): Promise<OrganisationSecuritySettingsRecord | null> {
+  if (!organisationId) {
+    return null;
+  }
+
+  const settings = await findOrganisationSecuritySettings({ organisationId });
+  if (settings) {
+    return settings;
+  }
+
+  await ensureDefaultOrganisationSecuritySettings({ organisationId });
+  return defaultOrganisationSettings(organisationId);
+}
+
+export async function resolveEffectiveSecurityPolicy(
+  input: EffectiveSecurityPolicyInput,
+): Promise<EffectiveSecurityPolicy> {
+  const organisationId = organisationIdForSecurityPolicy(input.subject);
+  const userId = input.subject.user?.id ?? null;
+  const [organisationSettings, userPreferences] = await Promise.all([
+    findOrganisationSettingsOrDefault(organisationId),
+    userId ? findUserSecurityPreferences({ userId }) : Promise.resolve(null),
+  ]);
+
+  const sessionPolicy = resolveSessionPolicy({
+    rememberMeRequested: input.rememberMeRequested,
+    platform: input.platform ?? PLATFORM_SECURITY_POLICY,
+    organisationPolicy: toOrganisationSessionPolicy(organisationSettings),
+    userPreference: toUserSessionPreference(userPreferences),
+  });
+
+  return {
+    ...sessionPolicy,
+    organisationId,
+    requireReauthenticationForSensitiveActions:
+      organisationSettings?.requireReauthenticationForSensitiveActions ??
+      (input.platform ?? PLATFORM_SECURITY_POLICY).requireReauthenticationForSensitiveActions,
+    allowEmailChange: resolveEmailChangePermission(
+      input.subject,
+      organisationSettings,
+      input.platform ?? PLATFORM_SECURITY_POLICY,
+    ),
+  };
+}
+
+export async function canUserChangeOwnEmail(subject: GuardAuthSubject): Promise<boolean> {
+  const organisationSettings = await findOrganisationSettingsOrDefault(
+    organisationIdForSecurityPolicy(subject),
+  );
+  return resolveEmailChangePermission(subject, organisationSettings, PLATFORM_SECURITY_POLICY);
+}
+
+function resolveEmailChangePermission(
+  subject: GuardAuthSubject,
+  organisationSettings: OrganisationSecuritySettingsRecord | null,
+  platform: PlatformSecurityPolicy,
+): boolean {
+  if (subject.user?.userType === 'ORGANISATION_TRAINEE' && organisationSettings) {
+    return organisationSettings.allowTraineeEmailChange;
+  }
+
+  return platform.allowEmailChange;
+}

--- a/apps/backend/src/services/security-policy.service.ts
+++ b/apps/backend/src/services/security-policy.service.ts
@@ -95,11 +95,24 @@ function toUserSessionPreference(
 }
 
 export function organisationIdForSecurityPolicy(subject: GuardAuthSubject): string | null {
-  if (subject.user?.userType === 'ORGANISATION_ADMIN') {
+  if (subject.user?.authStatus !== 'ACTIVE') {
+    return null;
+  }
+
+  if (
+    subject.user.userType === 'ORGANISATION_ADMIN' &&
+    subject.organisationAdminProfile?.adminStatus === 'ACTIVE' &&
+    subject.organisationAdminProfile.organisation?.status === 'ACTIVE'
+  ) {
     return subject.organisationAdminProfile?.organisation?.id ?? null;
   }
 
-  if (subject.user?.userType === 'ORGANISATION_TRAINEE') {
+  if (
+    subject.user.userType === 'ORGANISATION_TRAINEE' &&
+    subject.traineeProfile?.traineeStatus === 'ACTIVE' &&
+    subject.organisationTraineeProfile?.membershipStatus === 'ACTIVE' &&
+    subject.organisationTraineeProfile.organisation?.status === 'ACTIVE'
+  ) {
     return subject.organisationTraineeProfile?.organisation?.id ?? null;
   }
 

--- a/apps/backend/tests/unit/auth-session.service.test.ts
+++ b/apps/backend/tests/unit/auth-session.service.test.ts
@@ -5,6 +5,7 @@ const repoMock = vi.hoisted(() => ({
   revokeAuthSession: vi.fn(),
   revokeUserAuthSessions: vi.fn(),
   touchAuthSession: vi.fn(),
+  updateAuthSessionPolicy: vi.fn(),
 }));
 vi.mock('../../src/repositories/auth-session.repository.js', () => repoMock);
 import {
@@ -12,6 +13,7 @@ import {
   issueAuthSession,
   revokeSessionById,
   revokeSessionsForUser,
+  updateSessionPolicy,
   validateAuthSession,
 } from '../../src/services/auth-session.service.js';
 const now = new Date('2026-06-26T10:00:00.000Z');
@@ -101,6 +103,22 @@ describe('auth-session serivce', () => {
       userId: 'user01',
       revokedReason: 'PASSWORD_CHANGE',
       exceptSessionId: 'session02',
+    });
+  });
+
+  it('delegates policy updates to the repository', async () => {
+    const expiresAt = new Date('2026-06-26T10:30:00.000Z');
+
+    await updateSessionPolicy({
+      sessionId: 'session01',
+      expiresAt,
+      idleTimeoutMinutes: 5,
+    });
+
+    expect(repoMock.updateAuthSessionPolicy).toHaveBeenCalledWith({
+      id: 'session01',
+      expiresAt,
+      idleTimeoutMinutes: 5,
     });
   });
 }); //describe

--- a/apps/backend/tests/unit/security-policy.service.test.ts
+++ b/apps/backend/tests/unit/security-policy.service.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const securitySettingsRepositoryMock = vi.hoisted(() => ({
+  DEFAULT_ORGANISATION_SECURITY_SETTINGS: {
+    enforceRememberMePolicy: true,
+    allowRememberMe: true,
+    maxRememberedSessionHours: 168,
+    enforceRegularSessionLength: true,
+    regularSessionLengthHours: 8,
+    enforceIdleTimeout: false,
+    idleTimeoutMinutes: null,
+    requireReauthenticationForSensitiveActions: true,
+    allowTraineeEmailChange: true,
+  },
+  ensureDefaultOrganisationSecuritySettings: vi.fn(),
+  findOrganisationSecuritySettings: vi.fn(),
+  findUserSecurityPreferences: vi.fn(),
+}));
+
+vi.mock(
+  '../../src/repositories/security-settings.repository.js',
+  () => securitySettingsRepositoryMock,
+);
+
+import {
+  canUserChangeOwnEmail,
+  organisationIdForSecurityPolicy,
+  resolveEffectiveSecurityPolicy,
+} from '../../src/services/security-policy.service.js';
+import type { GuardAuthSubject } from '../../src/services/auth-status-guard.service.js';
+
+const platform = {
+  regularSessionSeconds: 900,
+  rememberedSessionSeconds: 604800,
+  idleTimeoutMinutes: 30,
+  allowRememberMe: true,
+  requireReauthenticationForSensitiveActions: true,
+  allowEmailChange: true,
+};
+
+function organisationTraineeSubject(): GuardAuthSubject {
+  return {
+    user: {
+      id: 'user-1',
+      userType: 'ORGANISATION_TRAINEE',
+      authStatus: 'ACTIVE',
+    },
+    organisationTraineeProfile: {
+      membershipStatus: 'ACTIVE',
+      organisation: {
+        id: 'org-1',
+        status: 'ACTIVE',
+      },
+    },
+  };
+}
+
+function organisationAdminSubject(): GuardAuthSubject {
+  return {
+    user: {
+      id: 'admin-user-1',
+      userType: 'ORGANISATION_ADMIN',
+      authStatus: 'ACTIVE',
+    },
+    organisationAdminProfile: {
+      adminStatus: 'ACTIVE',
+      organisation: {
+        id: 'org-1',
+        status: 'ACTIVE',
+      },
+    },
+  };
+}
+
+describe('security policy service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    securitySettingsRepositoryMock.findOrganisationSecuritySettings.mockResolvedValue(null);
+    securitySettingsRepositoryMock.findUserSecurityPreferences.mockResolvedValue(null);
+    securitySettingsRepositoryMock.ensureDefaultOrganisationSecuritySettings.mockResolvedValue(1);
+  });
+
+  it('resolves organisation trainee policy from organisation settings', async () => {
+    securitySettingsRepositoryMock.findOrganisationSecuritySettings.mockResolvedValue({
+      organisationId: 'org-1',
+      enforceRememberMePolicy: true,
+      allowRememberMe: false,
+      maxRememberedSessionHours: 12,
+      enforceRegularSessionLength: true,
+      regularSessionLengthHours: 2,
+      enforceIdleTimeout: true,
+      idleTimeoutMinutes: 10,
+      requireReauthenticationForSensitiveActions: false,
+      allowTraineeEmailChange: false,
+    });
+    securitySettingsRepositoryMock.findUserSecurityPreferences.mockResolvedValue({
+      userId: 'user-1',
+      preferredRegularSessionLengthHours: 20,
+      preferredRememberMeSessionLengthHours: 100,
+      preferredIdleTimeoutMinutes: 60,
+    });
+
+    await expect(
+      resolveEffectiveSecurityPolicy({
+        subject: organisationTraineeSubject(),
+        rememberMeRequested: true,
+        platform,
+      }),
+    ).resolves.toMatchObject({
+      organisationId: 'org-1',
+      rememberMeAllowed: false,
+      rememberMeApplied: false,
+      regularSessionSeconds: 7200,
+      effectiveSessionSeconds: 7200,
+      idleTimeoutMinutes: 10,
+      requireReauthenticationForSensitiveActions: false,
+      allowEmailChange: false,
+      sources: {
+        rememberMe: 'ORGANISATION_POLICY',
+        regularSession: 'ORGANISATION_POLICY',
+        idleTimeout: 'ORGANISATION_POLICY',
+      },
+    });
+  });
+
+  it('uses user preferences for general trainees without loading organisation settings', async () => {
+    securitySettingsRepositoryMock.findUserSecurityPreferences.mockResolvedValue({
+      userId: 'user-2',
+      preferredRegularSessionLengthHours: 4,
+      preferredRememberMeSessionLengthHours: 48,
+      preferredIdleTimeoutMinutes: 20,
+    });
+
+    await expect(
+      resolveEffectiveSecurityPolicy({
+        subject: {
+          user: {
+            id: 'user-2',
+            userType: 'GENERAL_TRAINEE',
+            authStatus: 'ACTIVE',
+          },
+        },
+        rememberMeRequested: true,
+        platform,
+      }),
+    ).resolves.toMatchObject({
+      organisationId: null,
+      regularSessionSeconds: 14400,
+      rememberedSessionSeconds: 172800,
+      idleTimeoutMinutes: 20,
+      allowEmailChange: true,
+      sources: {
+        regularSession: 'USER_PREFERENCE',
+        rememberedSession: 'USER_PREFERENCE',
+        idleTimeout: 'USER_PREFERENCE',
+      },
+    });
+    expect(securitySettingsRepositoryMock.findOrganisationSecuritySettings).not.toHaveBeenCalled();
+    expect(
+      securitySettingsRepositoryMock.ensureDefaultOrganisationSecuritySettings,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('defaults missing organisation settings without blocking login policy resolution', async () => {
+    await expect(
+      resolveEffectiveSecurityPolicy({
+        subject: organisationAdminSubject(),
+        rememberMeRequested: false,
+        platform,
+      }),
+    ).resolves.toMatchObject({
+      organisationId: 'org-1',
+      regularSessionSeconds: 28800,
+      idleTimeoutMinutes: 30,
+      requireReauthenticationForSensitiveActions: true,
+      allowEmailChange: true,
+    });
+    expect(
+      securitySettingsRepositoryMock.ensureDefaultOrganisationSecuritySettings,
+    ).toHaveBeenCalledWith({
+      organisationId: 'org-1',
+    });
+  });
+
+  it('identifies only organisation users as organisation-scoped for policy', () => {
+    expect(organisationIdForSecurityPolicy(organisationTraineeSubject())).toBe('org-1');
+    expect(organisationIdForSecurityPolicy(organisationAdminSubject())).toBe('org-1');
+    expect(
+      organisationIdForSecurityPolicy({
+        user: { id: 'platform-1', userType: 'IP_ADMIN', authStatus: 'ACTIVE' },
+      }),
+    ).toBeNull();
+  });
+
+  it('blocks trainee email changes from organisation settings only', async () => {
+    securitySettingsRepositoryMock.findOrganisationSecuritySettings.mockResolvedValue({
+      organisationId: 'org-1',
+      enforceRememberMePolicy: true,
+      allowRememberMe: true,
+      maxRememberedSessionHours: 168,
+      enforceRegularSessionLength: true,
+      regularSessionLengthHours: 8,
+      enforceIdleTimeout: false,
+      idleTimeoutMinutes: null,
+      requireReauthenticationForSensitiveActions: true,
+      allowTraineeEmailChange: false,
+    });
+
+    await expect(canUserChangeOwnEmail(organisationTraineeSubject())).resolves.toBe(false);
+    await expect(canUserChangeOwnEmail(organisationAdminSubject())).resolves.toBe(true);
+  });
+});

--- a/apps/backend/tests/unit/security-policy.service.test.ts
+++ b/apps/backend/tests/unit/security-policy.service.test.ts
@@ -38,40 +38,65 @@ const platform = {
   allowEmailChange: true,
 };
 
-const activeOrganisationStatus = 'ACTIVE';
+type GuardOrganisationFixture = {
+  id: string;
+  name: string;
+  status: 'PENDING_ONBOARDING' | 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'DISABLED' | 'ARCHIVED';
+};
 
-function createGuardOrganisation(): { id: string; name: string; status: 'ACTIVE' } {
+function createGuardOrganisation(
+  overrides: Partial<GuardOrganisationFixture> = {},
+): GuardOrganisationFixture {
   return {
     id: 'org-1',
     name: 'Test Organisation',
-    status: activeOrganisationStatus,
+    status: 'ACTIVE',
+    ...overrides,
   };
 }
 
-function organisationTraineeSubject(): GuardAuthSubject {
+function organisationTraineeSubject(
+  overrides: {
+    userAuthStatus?: 'PENDING_EMAIL_VERIFICATION' | 'PENDING_INVITE_SETUP' | 'ACTIVE' | 'DISABLED';
+    traineeStatus?: 'ACTIVE' | 'INACTIVE';
+    membershipStatus?: 'ACTIVE' | 'INACTIVE';
+    organisation?: GuardOrganisationFixture | null;
+  } = {},
+): GuardAuthSubject {
   return {
     user: {
       id: 'user-1',
       userType: 'ORGANISATION_TRAINEE',
-      authStatus: 'ACTIVE',
+      authStatus: overrides.userAuthStatus ?? 'ACTIVE',
+    },
+    traineeProfile: {
+      traineeStatus: overrides.traineeStatus ?? 'ACTIVE',
     },
     organisationTraineeProfile: {
-      membershipStatus: 'ACTIVE',
-      organisation: createGuardOrganisation(),
+      membershipStatus: overrides.membershipStatus ?? 'ACTIVE',
+      organisation:
+        overrides.organisation === undefined ? createGuardOrganisation() : overrides.organisation,
     },
   };
 }
 
-function organisationAdminSubject(): GuardAuthSubject {
+function organisationAdminSubject(
+  overrides: {
+    userAuthStatus?: 'PENDING_EMAIL_VERIFICATION' | 'PENDING_INVITE_SETUP' | 'ACTIVE' | 'DISABLED';
+    adminStatus?: 'ACTIVE' | 'DISABLED';
+    organisation?: GuardOrganisationFixture | null;
+  } = {},
+): GuardAuthSubject {
   return {
     user: {
       id: 'admin-user-1',
       userType: 'ORGANISATION_ADMIN',
-      authStatus: 'ACTIVE',
+      authStatus: overrides.userAuthStatus ?? 'ACTIVE',
     },
     organisationAdminProfile: {
-      adminStatus: 'ACTIVE',
-      organisation: createGuardOrganisation(),
+      adminStatus: overrides.adminStatus ?? 'ACTIVE',
+      organisation:
+        overrides.organisation === undefined ? createGuardOrganisation() : overrides.organisation,
     },
   };
 }
@@ -186,12 +211,57 @@ describe('security policy service', () => {
     });
   });
 
-  it('identifies only organisation users as organisation-scoped for policy', () => {
+  it('does not load organisation settings for inactive organisation contexts', async () => {
+    await expect(
+      resolveEffectiveSecurityPolicy({
+        subject: organisationAdminSubject({
+          organisation: createGuardOrganisation({ status: 'SUSPENDED' }),
+        }),
+        rememberMeRequested: false,
+        platform,
+      }),
+    ).resolves.toMatchObject({
+      organisationId: null,
+      regularSessionSeconds: 900,
+      idleTimeoutMinutes: 30,
+      sources: {
+        regularSession: 'PLATFORM_DEFAULT',
+        idleTimeout: 'PLATFORM_DEFAULT',
+      },
+    });
+    expect(securitySettingsRepositoryMock.findOrganisationSecuritySettings).not.toHaveBeenCalled();
+    expect(
+      securitySettingsRepositoryMock.ensureDefaultOrganisationSecuritySettings,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('identifies only active organisation users in active organisations as organisation-scoped', () => {
     expect(organisationIdForSecurityPolicy(organisationTraineeSubject())).toBe('org-1');
     expect(organisationIdForSecurityPolicy(organisationAdminSubject())).toBe('org-1');
     expect(
+      organisationIdForSecurityPolicy(organisationAdminSubject({ adminStatus: 'DISABLED' })),
+    ).toBeNull();
+    expect(
+      organisationIdForSecurityPolicy(organisationTraineeSubject({ membershipStatus: 'INACTIVE' })),
+    ).toBeNull();
+    expect(
+      organisationIdForSecurityPolicy(organisationTraineeSubject({ traineeStatus: 'INACTIVE' })),
+    ).toBeNull();
+    expect(
+      organisationIdForSecurityPolicy(
+        organisationAdminSubject({
+          organisation: createGuardOrganisation({ status: 'SUSPENDED' }),
+        }),
+      ),
+    ).toBeNull();
+    expect(
       organisationIdForSecurityPolicy({
         user: { id: 'platform-1', userType: 'IP_ADMIN', authStatus: 'ACTIVE' },
+      }),
+    ).toBeNull();
+    expect(
+      organisationIdForSecurityPolicy({
+        user: { id: 'general-1', userType: 'GENERAL_TRAINEE', authStatus: 'ACTIVE' },
       }),
     ).toBeNull();
   });

--- a/apps/backend/tests/unit/security-policy.service.test.ts
+++ b/apps/backend/tests/unit/security-policy.service.test.ts
@@ -38,6 +38,16 @@ const platform = {
   allowEmailChange: true,
 };
 
+const activeOrganisationStatus = 'ACTIVE';
+
+function createGuardOrganisation(): { id: string; name: string; status: 'ACTIVE' } {
+  return {
+    id: 'org-1',
+    name: 'Test Organisation',
+    status: activeOrganisationStatus,
+  };
+}
+
 function organisationTraineeSubject(): GuardAuthSubject {
   return {
     user: {
@@ -47,10 +57,7 @@ function organisationTraineeSubject(): GuardAuthSubject {
     },
     organisationTraineeProfile: {
       membershipStatus: 'ACTIVE',
-      organisation: {
-        id: 'org-1',
-        status: 'ACTIVE',
-      },
+      organisation: createGuardOrganisation(),
     },
   };
 }
@@ -64,10 +71,7 @@ function organisationAdminSubject(): GuardAuthSubject {
     },
     organisationAdminProfile: {
       adminStatus: 'ACTIVE',
-      organisation: {
-        id: 'org-1',
-        status: 'ACTIVE',
-      },
+      organisation: createGuardOrganisation(),
     },
   };
 }

--- a/apps/backend/tests/unit/security-settings-auth-hooks.test.ts
+++ b/apps/backend/tests/unit/security-settings-auth-hooks.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const userRepositoryMock = vi.hoisted(() => ({
+  findUserByEmail: vi.fn(),
+  findAuthSubjectByUserId: vi.fn(),
+  findUserWithAuthSubjectById: vi.fn(),
+}));
+
+const passwordServiceMock = vi.hoisted(() => ({
+  verifyPassword: vi.fn(),
+}));
+
+const authTokenServiceMock = vi.hoisted(() => ({
+  generateAuthToken: vi.fn(),
+}));
+
+const securityPolicyServiceMock = vi.hoisted(() => ({
+  resolveEffectiveSecurityPolicy: vi.fn(),
+}));
+
+const authSessionServiceMock = vi.hoisted(() => ({
+  calculateSessionExpiresAt: vi.fn(
+    (input: {
+      now?: Date;
+      rememberMe: boolean;
+      regularSessionSeconds: number;
+      rememberedSessionSeconds: number;
+    }) => {
+      const now = input.now ?? new Date('2026-07-02T10:00:00.000Z');
+      const seconds = input.rememberMe
+        ? input.rememberedSessionSeconds
+        : input.regularSessionSeconds;
+      return new Date(now.getTime() + seconds * 1000);
+    },
+  ),
+  issueAuthSession: vi.fn(),
+  revokeSessionById: vi.fn(),
+  touchSession: vi.fn(),
+  updateSessionPolicy: vi.fn(),
+}));
+
+const refreshTokenServiceMock = vi.hoisted(() => ({
+  issueRefreshToken: vi.fn(),
+  rotateRefreshToken: vi.fn(),
+  validateRefreshToken: vi.fn(),
+  revokeRefreshTokensForSession: vi.fn(),
+}));
+
+const auditServiceMock = vi.hoisted(() => ({
+  recordUserLogin: vi.fn(),
+  recordAuthSessionRevoked: vi.fn(),
+}));
+
+const authContextServiceMock = vi.hoisted(() => ({
+  buildAuthContext: vi.fn(),
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
+}));
+
+vi.mock('../../src/repositories/user.repository.js', () => userRepositoryMock);
+vi.mock('../../src/services/password.service.js', () => passwordServiceMock);
+vi.mock('../../src/services/auth-token.service.js', () => authTokenServiceMock);
+vi.mock('../../src/services/security-policy.service.js', () => securityPolicyServiceMock);
+vi.mock('../../src/services/auth-session.service.js', () => authSessionServiceMock);
+vi.mock('../../src/services/refresh-token.service.js', () => refreshTokenServiceMock);
+vi.mock('../../src/services/auth-audit.service.js', () => auditServiceMock);
+vi.mock('../../src/services/auth-context.service.js', () => authContextServiceMock);
+vi.mock('../../src/lib/prisma.js', () => ({ prisma: prismaMock }));
+
+import {
+  AuthRefreshTokenInvalidError,
+  loginUser,
+  refreshUserToken,
+} from '../../src/services/auth.service.js';
+
+const activeSubject = {
+  user: {
+    id: 'user-1',
+    userType: 'ORGANISATION_TRAINEE',
+    authStatus: 'ACTIVE',
+  },
+  traineeProfile: { traineeStatus: 'ACTIVE' },
+  organisationTraineeProfile: {
+    membershipStatus: 'ACTIVE',
+    organisation: { id: 'org-1', status: 'ACTIVE' },
+  },
+};
+
+const defaultPolicy = {
+  organisationId: 'org-1',
+  rememberMeRequested: true,
+  rememberMeAllowed: true,
+  rememberMeApplied: true,
+  regularSessionSeconds: 900,
+  rememberedSessionSeconds: 604800,
+  effectiveSessionSeconds: 604800,
+  idleTimeoutMinutes: 30,
+  requireReauthenticationForSensitiveActions: true,
+  allowEmailChange: true,
+  sources: {
+    rememberMe: 'ORGANISATION_POLICY',
+    regularSession: 'ORGANISATION_POLICY',
+    rememberedSession: 'ORGANISATION_POLICY',
+    idleTimeout: 'ORGANISATION_POLICY',
+  },
+};
+
+describe('security settings auth hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userRepositoryMock.findUserByEmail.mockResolvedValue({
+      id: 'user-1',
+      firstName: 'Org',
+      lastName: 'Trainee',
+      email: 'org.trainee@example.test',
+      passwordHash: 'hashed-password',
+      userType: 'ORGANISATION_TRAINEE',
+      authStatus: 'ACTIVE',
+      createdAt: new Date('2026-07-02T08:00:00.000Z'),
+    });
+    userRepositoryMock.findAuthSubjectByUserId.mockResolvedValue(activeSubject);
+    userRepositoryMock.findUserWithAuthSubjectById.mockResolvedValue({
+      id: 'user-1',
+      firstName: 'Org',
+      lastName: 'Trainee',
+      email: 'org.trainee@example.test',
+      passwordHash: 'hashed-password',
+      userType: 'ORGANISATION_TRAINEE',
+      authStatus: 'ACTIVE',
+      createdAt: new Date('2026-07-02T08:00:00.000Z'),
+    });
+    passwordServiceMock.verifyPassword.mockResolvedValue(true);
+    securityPolicyServiceMock.resolveEffectiveSecurityPolicy.mockResolvedValue(defaultPolicy);
+    authSessionServiceMock.issueAuthSession.mockResolvedValue({
+      id: 'session-1',
+      userId: 'user-1',
+      rememberMe: true,
+      expiresAt: new Date('2026-07-09T10:00:00.000Z'),
+      idleTimeoutMinutes: 30,
+    });
+    refreshTokenServiceMock.issueRefreshToken.mockResolvedValue({
+      rawToken: 'raw-refresh-token',
+      token: { id: 'refresh-token-1' },
+    });
+    authTokenServiceMock.generateAuthToken.mockReturnValue({
+      token: 'access-token',
+      expiresAt: '2026-07-02T10:15:00.000Z',
+    });
+    authContextServiceMock.buildAuthContext.mockReturnValue({
+      role: 'ORGANISATION_TRAINEE',
+      permissions: ['ORGANISATION_TRAINEE'],
+      redirectTo: '/trainee/campaigns',
+    });
+  });
+
+  it('creates login sessions from the resolved effective security policy', async () => {
+    securityPolicyServiceMock.resolveEffectiveSecurityPolicy.mockResolvedValue({
+      ...defaultPolicy,
+      rememberMeRequested: true,
+      rememberMeAllowed: false,
+      rememberMeApplied: false,
+      regularSessionSeconds: 7200,
+      rememberedSessionSeconds: 604800,
+      effectiveSessionSeconds: 7200,
+      idleTimeoutMinutes: 10,
+    });
+
+    await loginUser({
+      email: 'org.trainee@example.test',
+      password: 'correct-password',
+      rememberMe: true,
+    });
+
+    expect(securityPolicyServiceMock.resolveEffectiveSecurityPolicy).toHaveBeenCalledWith({
+      subject: activeSubject,
+      rememberMeRequested: true,
+    });
+    expect(authSessionServiceMock.calculateSessionExpiresAt).toHaveBeenCalledWith({
+      rememberMe: false,
+      regularSessionSeconds: 7200,
+      rememberedSessionSeconds: 604800,
+    });
+    expect(authSessionServiceMock.issueAuthSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        rememberMe: false,
+        idleTimeoutMinutes: 10,
+      }),
+    );
+    expect(refreshTokenServiceMock.issueRefreshToken).toHaveBeenCalledWith({
+      authSessionId: 'session-1',
+      expiresAt: new Date('2026-07-09T10:00:00.000Z'),
+    });
+  });
+
+  it('revokes remembered sessions on refresh when policy now disallows remember me', async () => {
+    refreshTokenServiceMock.validateRefreshToken.mockResolvedValue({
+      state: 'VALID',
+      token: {
+        id: 'refresh-token-1',
+        authSessionId: 'session-1',
+        authSession: {
+          id: 'session-1',
+          userId: 'user-1',
+          rememberMe: true,
+          createdAt: new Date('2026-07-02T10:00:00.000Z'),
+          expiresAt: new Date('2026-07-09T10:00:00.000Z'),
+          lastActiveAt: new Date(),
+          user: {
+            id: 'user-1',
+            firstName: 'Org',
+            lastName: 'Trainee',
+            email: 'org.trainee@example.test',
+            userType: 'ORGANISATION_TRAINEE',
+            authStatus: 'ACTIVE',
+            createdAt: new Date('2026-07-02T08:00:00.000Z'),
+          },
+        },
+      },
+    });
+    securityPolicyServiceMock.resolveEffectiveSecurityPolicy.mockResolvedValue({
+      ...defaultPolicy,
+      rememberMeAllowed: false,
+      rememberMeApplied: false,
+    });
+
+    await expect(refreshUserToken('raw-refresh-token')).rejects.toBeInstanceOf(
+      AuthRefreshTokenInvalidError,
+    );
+    expect(authSessionServiceMock.revokeSessionById).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      reason: 'OTHER',
+    });
+    expect(refreshTokenServiceMock.revokeRefreshTokensForSession).toHaveBeenCalledWith({
+      authSessionId: 'session-1',
+      reason: 'OTHER',
+    });
+    expect(refreshTokenServiceMock.rotateRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('updates session policy before refresh token rotation', async () => {
+    const createdAt = new Date(Date.now() - 60_000);
+    const expectedExpiresAt = new Date(createdAt.getTime() + 600 * 1000);
+    refreshTokenServiceMock.validateRefreshToken.mockResolvedValue({
+      state: 'VALID',
+      token: {
+        id: 'refresh-token-1',
+        authSessionId: 'session-1',
+        authSession: {
+          id: 'session-1',
+          userId: 'user-1',
+          rememberMe: true,
+          createdAt,
+          expiresAt: new Date(createdAt.getTime() + 604800 * 1000),
+          lastActiveAt: new Date(),
+          user: {
+            id: 'user-1',
+            firstName: 'Org',
+            lastName: 'Trainee',
+            email: 'org.trainee@example.test',
+            userType: 'ORGANISATION_TRAINEE',
+            authStatus: 'ACTIVE',
+            createdAt,
+          },
+        },
+      },
+    });
+    securityPolicyServiceMock.resolveEffectiveSecurityPolicy.mockResolvedValue({
+      ...defaultPolicy,
+      rememberMeAllowed: true,
+      rememberMeApplied: true,
+      rememberedSessionSeconds: 600,
+      idleTimeoutMinutes: 5,
+    });
+    refreshTokenServiceMock.rotateRefreshToken.mockResolvedValue({
+      state: 'ROTATED',
+      rawToken: 'next-refresh-token',
+    });
+
+    await refreshUserToken('raw-refresh-token');
+
+    expect(authSessionServiceMock.updateSessionPolicy).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      expiresAt: expectedExpiresAt,
+      idleTimeoutMinutes: 5,
+    });
+    expect(authSessionServiceMock.touchSession).toHaveBeenCalledWith('session-1');
+    expect(refreshTokenServiceMock.rotateRefreshToken).toHaveBeenCalledWith({
+      rawToken: 'raw-refresh-token',
+      nextExpiresAt: expectedExpiresAt,
+      ipAddress: undefined,
+      userAgent: undefined,
+    });
+  });
+});

--- a/apps/backend/tests/unit/security-settings.repository.test.ts
+++ b/apps/backend/tests/unit/security-settings.repository.test.ts
@@ -77,10 +77,20 @@ describe('security settings repository', () => {
       ),
       'utf8',
     );
+    const updaterScopeMigration = readFileSync(
+      resolve(
+        process.cwd(),
+        'prisma/migrations/20260702123000_scope_security_settings_updater/migration.sql',
+      ),
+      'utf8',
+    );
 
     expect(schema).toContain('model OrganisationSecuritySettings');
     expect(schema).toContain(
       'organisationId                             String                    @unique',
+    );
+    expect(schema).toContain(
+      'fields: [updatedByOrganisationAdminId, organisationId], references: [id, organisationId]',
     );
     expect(schema).toContain('model UserSecurityPreferences');
     expect(schema).toContain('userId                                String   @unique');
@@ -91,6 +101,16 @@ describe('security settings repository', () => {
     expect(migration).toContain('INSERT INTO "OrganisationSecuritySettings"');
     expect(migration).toContain('FROM "Organisation" o');
     expect(migration).toContain('WHERE NOT EXISTS');
+    expect(updaterScopeMigration).toContain('SET "updatedByOrganisationAdminId" = NULL');
+    expect(updaterScopeMigration).toContain(
+      'admin_profile."organisationId" = settings."organisationId"',
+    );
+    expect(updaterScopeMigration).toContain(
+      'FOREIGN KEY ("updatedByOrganisationAdminId", "organisationId")',
+    );
+    expect(updaterScopeMigration).toContain(
+      'REFERENCES "OrganisationAdminProfile"("id", "organisationId")',
+    );
   });
 
   it('builds deterministic settings ids and inserts safe defaults idempotently', async () => {

--- a/apps/backend/tests/unit/security-settings.repository.test.ts
+++ b/apps/backend/tests/unit/security-settings.repository.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ORGANISATION_SECURITY_SETTINGS,
+  buildOrganisationSecuritySettingsId,
+  ensureDefaultOrganisationSecuritySettings,
+  ensureDefaultOrganisationSecuritySettingsForAllOrganisations,
+  findOrganisationSecuritySettings,
+  findUserSecurityPreferences,
+} from '../../src/repositories/security-settings.repository.js';
+
+type RawCall = {
+  readonly sql: string;
+  readonly values: readonly unknown[];
+};
+
+type SecuritySettingsTestClient = NonNullable<
+  Parameters<typeof ensureDefaultOrganisationSecuritySettings>[1]
+>;
+
+function normaliseSql(strings: TemplateStringsArray): string {
+  return strings.join('?').replace(/\s+/g, ' ').trim();
+}
+
+function createSecuritySettingsClient(input: {
+  readonly organisationCount?: bigint;
+  readonly createdSettingsCount?: number;
+  readonly organisationSettingsRows?: readonly unknown[];
+  readonly userPreferenceRows?: readonly unknown[];
+}) {
+  const queryCalls: RawCall[] = [];
+  const executeCalls: RawCall[] = [];
+
+  const client = {
+    $queryRaw: async <T = unknown>(
+      strings: TemplateStringsArray,
+      ...values: readonly unknown[]
+    ): Promise<T> => {
+      const sql = normaliseSql(strings);
+      queryCalls.push({ sql, values });
+
+      if (sql.includes('COUNT(*) AS "count"')) {
+        return [{ count: input.organisationCount ?? 0n }] as T;
+      }
+
+      if (sql.includes('FROM "OrganisationSecuritySettings"')) {
+        return (input.organisationSettingsRows ?? []) as T;
+      }
+
+      if (sql.includes('FROM "UserSecurityPreferences"')) {
+        return (input.userPreferenceRows ?? []) as T;
+      }
+
+      throw new Error(`Unexpected security settings query: ${sql}`);
+    },
+    $executeRaw: async (strings: TemplateStringsArray, ...values: readonly unknown[]) => {
+      executeCalls.push({ sql: normaliseSql(strings), values });
+      return input.createdSettingsCount ?? 1;
+    },
+  };
+
+  return {
+    client: client as SecuritySettingsTestClient,
+    queryCalls,
+    executeCalls,
+  };
+}
+
+describe('security settings repository', () => {
+  it('defines schema uniqueness and backfill for organisation security settings', () => {
+    const schema = readFileSync(resolve(process.cwd(), 'prisma/schema.prisma'), 'utf8');
+    const migration = readFileSync(
+      resolve(
+        process.cwd(),
+        'prisma/migrations/20260702120000_security_settings_foundation/migration.sql',
+      ),
+      'utf8',
+    );
+
+    expect(schema).toContain('model OrganisationSecuritySettings');
+    expect(schema).toContain(
+      'organisationId                             String                    @unique',
+    );
+    expect(schema).toContain('model UserSecurityPreferences');
+    expect(schema).toContain('userId                                String   @unique');
+    expect(migration).toContain(
+      'CREATE UNIQUE INDEX "OrganisationSecuritySettings_organisationId_key"',
+    );
+    expect(migration).toContain('CREATE UNIQUE INDEX "UserSecurityPreferences_userId_key"');
+    expect(migration).toContain('INSERT INTO "OrganisationSecuritySettings"');
+    expect(migration).toContain('FROM "Organisation" o');
+    expect(migration).toContain('WHERE NOT EXISTS');
+  });
+
+  it('builds deterministic settings ids and inserts safe defaults idempotently', async () => {
+    const seedClient = createSecuritySettingsClient({ createdSettingsCount: 1 });
+
+    const createdCount = await ensureDefaultOrganisationSecuritySettings(
+      { organisationId: 'org-1' },
+      seedClient.client,
+    );
+
+    expect(buildOrganisationSecuritySettingsId('org-1')).toBe(
+      'organisation-security-settings-org-1',
+    );
+    expect(createdCount).toBe(1);
+    expect(seedClient.executeCalls).toHaveLength(1);
+    expect(seedClient.executeCalls[0]?.sql).toContain('ON CONFLICT ("organisationId") DO NOTHING');
+    expect(seedClient.executeCalls[0]?.values).toEqual([
+      'organisation-security-settings-org-1',
+      'org-1',
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceRememberMePolicy,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.allowRememberMe,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.maxRememberedSessionHours,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceRegularSessionLength,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.regularSessionLengthHours,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.enforceIdleTimeout,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.idleTimeoutMinutes,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.requireReauthenticationForSensitiveActions,
+      DEFAULT_ORGANISATION_SECURITY_SETTINGS.allowTraineeEmailChange,
+    ]);
+  });
+
+  it('reports actual default settings created while seeding all organisations', async () => {
+    const seedClient = createSecuritySettingsClient({
+      organisationCount: 3n,
+      createdSettingsCount: 2,
+    });
+
+    await expect(
+      ensureDefaultOrganisationSecuritySettingsForAllOrganisations(seedClient.client),
+    ).resolves.toEqual({
+      organisationCount: 3,
+      createdSettingsCount: 2,
+    });
+    expect(seedClient.executeCalls[0]?.sql).toContain('WHERE NOT EXISTS');
+  });
+
+  it('reads organisation settings and optional user preferences', async () => {
+    const organisationSettings = {
+      organisationId: 'org-1',
+      enforceRememberMePolicy: true,
+      allowRememberMe: false,
+      maxRememberedSessionHours: 24,
+      enforceRegularSessionLength: true,
+      regularSessionLengthHours: 2,
+      enforceIdleTimeout: true,
+      idleTimeoutMinutes: 10,
+      requireReauthenticationForSensitiveActions: true,
+      allowTraineeEmailChange: false,
+    };
+    const userPreferences = {
+      userId: 'user-1',
+      preferredRegularSessionLengthHours: 4,
+      preferredRememberMeSessionLengthHours: 48,
+      preferredIdleTimeoutMinutes: 15,
+    };
+    const seedClient = createSecuritySettingsClient({
+      organisationSettingsRows: [organisationSettings],
+      userPreferenceRows: [userPreferences],
+    });
+
+    await expect(
+      findOrganisationSecuritySettings({ organisationId: 'org-1' }, seedClient.client),
+    ).resolves.toEqual(organisationSettings);
+    await expect(
+      findUserSecurityPreferences({ userId: 'user-1' }, seedClient.client),
+    ).resolves.toEqual(userPreferences);
+  });
+});

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -194,6 +194,33 @@ export interface OrganisationDto {
   updatedAt: string;
 }
 
+export interface OrganisationSecuritySettingsDto {
+  id: string;
+  organisationId: string;
+  enforceRememberMePolicy: boolean;
+  allowRememberMe: boolean;
+  maxRememberedSessionHours?: number | null;
+  enforceRegularSessionLength: boolean;
+  regularSessionLengthHours?: number | null;
+  enforceIdleTimeout: boolean;
+  idleTimeoutMinutes?: number | null;
+  requireReauthenticationForSensitiveActions: boolean;
+  allowTraineeEmailChange: boolean;
+  updatedByOrganisationAdminId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UserSecurityPreferencesDto {
+  id: string;
+  userId: string;
+  preferredRegularSessionLengthHours?: number | null;
+  preferredRememberMeSessionLengthHours?: number | null;
+  preferredIdleTimeoutMinutes?: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface OrganisationContextDto {
   id: string;
   organisationId: string;


### PR DESCRIPTION
PR Title: feat: add organisation security settings foundation

## Summary

Adds the Sprint 4 database foundation and auth/session hooks for UC-11 organisation security settings.

This introduces organisation-level security settings so each organisation can have one policy record for remember-me behaviour, regular session length, idle timeout, sensitive-action reauthentication, and trainee email-change policy. It also adds user security preferences where supported by the Sprint 4 account-settings scope.

The auth/session flow now has support for resolving effective security policy during login, refresh, and session creation so organisation policies can influence session expiry, remembered sessions, idle timeout handling, and refresh behaviour.

This PR does not include the frontend organisation security settings page, the organisation security settings API endpoints, advanced MFA enforcement, or account-settings UI work.

## Linked Issue

Closes #284

## Type of change

* [x] Feature
* [ ] Bug Fix
* [ ] Documentation
* [x] Chore/Maintenance

## Testing

Ran:

```bash
pnpm --filter @insightful-phish/backend exec prisma validate
pnpm --filter @insightful-phish/backend exec prisma generate
pnpm build:shared
pnpm --filter @insightful-phish/backend test -- security-settings
pnpm --filter @insightful-phish/backend test -- security-policy
pnpm --filter @insightful-phish/backend test -- auth
pnpm --filter @insightful-phish/backend test -- session
pnpm --filter @insightful-phish/backend test
pnpm typecheck:backend
pnpm lint:backend
git diff --check
```

Verified:

* Prisma schema and migration add organisation security settings with one record per organisation.
* Existing organisations receive default security settings through migration/backfill.
* New or seeded organisations receive default settings without duplicate records.
* User security preferences are optional and one-per-user where included.
* Effective security policy resolves organisation policy for organisation admins and organisation trainees.
* Organisation policy does not apply to platform admins or general trainees.
* Login/session creation applies remember-me, regular session length, and idle-timeout policy.
* Refresh re-checks effective policy and handles expired or policy-invalid sessions.
* Trainee email-change policy can be resolved for later account-settings enforcement.

## Review Notes

Reviewers should focus on:

* Prisma schema relations and uniqueness constraints.
* Default organisation security settings and migration backfill behaviour.
* Whether every organisation reliably gets exactly one security-settings record.
* Effective policy resolution for organisation admins, organisation trainees, general trainees, and platform admins.
* Session expiry calculations for regular and remembered sessions.
* Idle-timeout handling during refresh.
* Whether organisation policy correctly overrides user security preferences for organisation users.
* Ensuring this PR stays within foundation/auth-hook scope and does not implement the later settings page or API endpoints.

This intentionally does not include frontend work, organisation security settings GET/PATCH endpoints, advanced MFA, or full account-settings endpoint implementation.

## Checklist

* [x] I tested the change locally
* [x] Accessibility impact was considered if applicable
* [x] No unrelated changes are included
* [x] Relevant tests were added or updated if applicable
* [x] Documentation was updated if needed
* [x] No secrets, credentials, or sensitive values were committed
