### PR TITLE
Feat/security settings api/adriano

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -14,6 +14,7 @@ import { errorHandler } from './middleware/errorHandler.js';
 import { setupRouter } from './routes/setup.routes.js';
 import { organisationRegistrationRequestRouter } from './routes/organisation-registration-request.routes.js';
 import { organisationAdminRouter } from './routes/organisation-admin.routes.js';
+import { organisationSecuritySettingsRouter } from './routes/organisation-security-settings.routes.js';
 
 export function createApp() {
   const app = express();
@@ -41,6 +42,7 @@ export function createApp() {
   app.use(setupRouter);
   app.use(organisationRegistrationRequestRouter);
   app.use(organisationAdminRouter);
+  app.use(organisationSecuritySettingsRouter);
   app.use('/trainee', traineeRouter);
   app.use(traineeTrainingRouter);
   app.use('/trainee/campaign-items', traineeQuizRouter);

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -59,6 +59,60 @@ function nullableString(example: string): OpenApiSchema {
   };
 }
 
+function booleanProperty(example: boolean): OpenApiSchema {
+  return {
+    type: 'boolean',
+    example,
+  };
+}
+
+function nullableIntegerRange(input: {
+  minimum: number;
+  maximum: number;
+  example: number;
+}): OpenApiSchema {
+  return {
+    type: 'integer',
+    nullable: true,
+    minimum: input.minimum,
+    maximum: input.maximum,
+    example: input.example,
+  };
+}
+
+function integerOptionsLimit(input: {
+  minimum: number;
+  maximum: number;
+  defaultValue: number;
+  options: number[];
+}): OpenApiSchema {
+  return {
+    type: 'object',
+    required: ['min', 'max', 'default', 'options'],
+    properties: {
+      min: {
+        type: 'integer',
+        example: input.minimum,
+      },
+      max: {
+        type: 'integer',
+        example: input.maximum,
+      },
+      default: {
+        type: 'integer',
+        example: input.defaultValue,
+      },
+      options: {
+        type: 'array',
+        items: {
+          type: 'integer',
+        },
+        example: input.options,
+      },
+    },
+  };
+}
+
 function trueSuccessProperty(): OpenApiSchema {
   return {
     type: 'boolean',
@@ -108,6 +162,41 @@ function responseComponent(description: string, schemaName: string) {
   return {
     description,
     ...jsonContent(schemaRef(schemaName)),
+  };
+}
+
+const organisationSecuritySettingsValueRequired = [
+  'enforceRememberMePolicy',
+  'allowRememberMe',
+  'enforceRegularSessionLength',
+  'enforceIdleTimeout',
+  'requireReauthenticationForSensitiveActions',
+  'allowTraineeEmailChange',
+] as const;
+
+function organisationSecuritySettingsValueProperties(): Record<string, OpenApiSchema> {
+  return {
+    enforceRememberMePolicy: booleanProperty(true),
+    allowRememberMe: booleanProperty(true),
+    maxRememberedSessionHours: nullableIntegerRange({
+      minimum: 1,
+      maximum: 720,
+      example: 168,
+    }),
+    enforceRegularSessionLength: booleanProperty(true),
+    regularSessionLengthHours: nullableIntegerRange({
+      minimum: 1,
+      maximum: 24,
+      example: 8,
+    }),
+    enforceIdleTimeout: booleanProperty(true),
+    idleTimeoutMinutes: nullableIntegerRange({
+      minimum: 5,
+      maximum: 480,
+      example: 30,
+    }),
+    requireReauthenticationForSensitiveActions: booleanProperty(true),
+    allowTraineeEmailChange: booleanProperty(false),
   };
 }
 
@@ -1216,12 +1305,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
           required: [
             'id',
             'organisationId',
-            'enforceRememberMePolicy',
-            'allowRememberMe',
-            'enforceRegularSessionLength',
-            'enforceIdleTimeout',
-            'requireReauthenticationForSensitiveActions',
-            'allowTraineeEmailChange',
+            ...organisationSecuritySettingsValueRequired,
             'createdAt',
             'updatedAt',
           ],
@@ -1232,51 +1316,7 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
             organisationId: {
               ...uuidString('11111111-1111-4111-8111-111111111111'),
             },
-            enforceRememberMePolicy: {
-              type: 'boolean',
-              example: true,
-            },
-            allowRememberMe: {
-              type: 'boolean',
-              example: true,
-            },
-            maxRememberedSessionHours: {
-              type: 'integer',
-              nullable: true,
-              minimum: 1,
-              maximum: 720,
-              example: 168,
-            },
-            enforceRegularSessionLength: {
-              type: 'boolean',
-              example: true,
-            },
-            regularSessionLengthHours: {
-              type: 'integer',
-              nullable: true,
-              minimum: 1,
-              maximum: 24,
-              example: 8,
-            },
-            enforceIdleTimeout: {
-              type: 'boolean',
-              example: true,
-            },
-            idleTimeoutMinutes: {
-              type: 'integer',
-              nullable: true,
-              minimum: 5,
-              maximum: 480,
-              example: 30,
-            },
-            requireReauthenticationForSensitiveActions: {
-              type: 'boolean',
-              example: true,
-            },
-            allowTraineeEmailChange: {
-              type: 'boolean',
-              example: false,
-            },
+            ...organisationSecuritySettingsValueProperties(),
             updatedByOrganisationAdminId: {
               ...nullableUuidString('22222222-2222-4222-8222-222222222222'),
             },
@@ -1307,16 +1347,13 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
               ...nullableUuidString('11111111-1111-4111-8111-111111111111'),
             },
             rememberMeRequested: {
-              type: 'boolean',
-              example: false,
+              ...booleanProperty(false),
             },
             rememberMeAllowed: {
-              type: 'boolean',
-              example: true,
+              ...booleanProperty(true),
             },
             rememberMeApplied: {
-              type: 'boolean',
-              example: false,
+              ...booleanProperty(false),
             },
             regularSessionSeconds: {
               type: 'integer',
@@ -1336,12 +1373,10 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
               example: 30,
             },
             requireReauthenticationForSensitiveActions: {
-              type: 'boolean',
-              example: true,
+              ...booleanProperty(true),
             },
             allowEmailChange: {
-              type: 'boolean',
-              example: false,
+              ...booleanProperty(false),
             },
           },
         },
@@ -1353,93 +1388,36 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
               type: 'object',
               required: ['maxRememberedSessionHours'],
               properties: {
-                maxRememberedSessionHours: {
-                  type: 'object',
-                  required: ['min', 'max', 'default', 'options'],
-                  properties: {
-                    min: {
-                      type: 'integer',
-                      example: 1,
-                    },
-                    max: {
-                      type: 'integer',
-                      example: 720,
-                    },
-                    default: {
-                      type: 'integer',
-                      example: 168,
-                    },
-                    options: {
-                      type: 'array',
-                      items: {
-                        type: 'integer',
-                      },
-                      example: [24, 72, 168, 336, 720],
-                    },
-                  },
-                },
+                maxRememberedSessionHours: integerOptionsLimit({
+                  minimum: 1,
+                  maximum: 720,
+                  defaultValue: 168,
+                  options: [24, 72, 168, 336, 720],
+                }),
               },
             },
             regularSession: {
               type: 'object',
               required: ['regularSessionLengthHours'],
               properties: {
-                regularSessionLengthHours: {
-                  type: 'object',
-                  required: ['min', 'max', 'default', 'options'],
-                  properties: {
-                    min: {
-                      type: 'integer',
-                      example: 1,
-                    },
-                    max: {
-                      type: 'integer',
-                      example: 24,
-                    },
-                    default: {
-                      type: 'integer',
-                      example: 8,
-                    },
-                    options: {
-                      type: 'array',
-                      items: {
-                        type: 'integer',
-                      },
-                      example: [4, 8, 12, 24],
-                    },
-                  },
-                },
+                regularSessionLengthHours: integerOptionsLimit({
+                  minimum: 1,
+                  maximum: 24,
+                  defaultValue: 8,
+                  options: [4, 8, 12, 24],
+                }),
               },
             },
             idleTimeout: {
               type: 'object',
               required: ['idleTimeoutMinutes'],
               properties: {
-                idleTimeoutMinutes: {
-                  type: 'object',
-                  required: ['min', 'max', 'default', 'options'],
-                  properties: {
-                    min: {
-                      type: 'integer',
-                      example: 5,
-                    },
-                    max: {
-                      type: 'integer',
-                      example: 480,
-                    },
-                    default: {
-                      type: 'integer',
-                      example: 30,
-                    },
-                    options: {
-                      type: 'array',
-                      items: {
-                        type: 'integer',
-                      },
-                      example: [15, 30, 60, 120, 240, 480],
-                    },
-                  },
-                },
+                idleTimeoutMinutes: integerOptionsLimit({
+                  minimum: 5,
+                  maximum: 480,
+                  defaultValue: 30,
+                  options: [15, 30, 60, 120, 240, 480],
+                }),
               },
             },
           },
@@ -1472,12 +1450,10 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
           required: ['canView', 'canEdit', 'readOnlyReason', 'changesApply'],
           properties: {
             canView: {
-              type: 'boolean',
-              example: true,
+              ...booleanProperty(true),
             },
             canEdit: {
-              type: 'boolean',
-              example: true,
+              ...booleanProperty(true),
             },
             readOnlyReason: {
               type: 'string',
@@ -1520,64 +1496,13 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         OrganisationSecuritySettingsUpdateRequest: {
           type: 'object',
           required: [
-            'enforceRememberMePolicy',
-            'allowRememberMe',
+            ...organisationSecuritySettingsValueRequired,
             'maxRememberedSessionHours',
-            'enforceRegularSessionLength',
             'regularSessionLengthHours',
-            'enforceIdleTimeout',
             'idleTimeoutMinutes',
-            'requireReauthenticationForSensitiveActions',
-            'allowTraineeEmailChange',
           ],
           additionalProperties: false,
-          properties: {
-            enforceRememberMePolicy: {
-              type: 'boolean',
-              example: true,
-            },
-            allowRememberMe: {
-              type: 'boolean',
-              example: true,
-            },
-            maxRememberedSessionHours: {
-              type: 'integer',
-              nullable: true,
-              minimum: 1,
-              maximum: 720,
-              example: 168,
-            },
-            enforceRegularSessionLength: {
-              type: 'boolean',
-              example: true,
-            },
-            regularSessionLengthHours: {
-              type: 'integer',
-              nullable: true,
-              minimum: 1,
-              maximum: 24,
-              example: 8,
-            },
-            enforceIdleTimeout: {
-              type: 'boolean',
-              example: true,
-            },
-            idleTimeoutMinutes: {
-              type: 'integer',
-              nullable: true,
-              minimum: 5,
-              maximum: 480,
-              example: 30,
-            },
-            requireReauthenticationForSensitiveActions: {
-              type: 'boolean',
-              example: true,
-            },
-            allowTraineeEmailChange: {
-              type: 'boolean',
-              example: false,
-            },
-          },
+          properties: organisationSecuritySettingsValueProperties(),
         },
         DifficultyLevel: enumString(
           ['BEGINNER', 'INTERMEDIATE', 'ADVANCED', 'ADAPTIVE'],

--- a/apps/backend/src/config/swagger.ts
+++ b/apps/backend/src/config/swagger.ts
@@ -152,6 +152,10 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         description: 'Organisation admin management and permission workflows.',
       },
       {
+        name: 'Organisation Security Settings',
+        description: 'Organisation-scoped security policy settings for active organisation admins.',
+      },
+      {
         name: 'Trainee Simulation',
         description: 'Trainee simulated phishing email workflows.',
       },
@@ -1205,6 +1209,374 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
               ...uuidString('22222222-2222-4222-8222-222222222222'),
             },
             status: enumString(['DISABLED'], 'DISABLED'),
+          },
+        },
+        OrganisationSecuritySettings: {
+          type: 'object',
+          required: [
+            'id',
+            'organisationId',
+            'enforceRememberMePolicy',
+            'allowRememberMe',
+            'enforceRegularSessionLength',
+            'enforceIdleTimeout',
+            'requireReauthenticationForSensitiveActions',
+            'allowTraineeEmailChange',
+            'createdAt',
+            'updatedAt',
+          ],
+          properties: {
+            id: {
+              ...uuidString('33333333-3333-4333-8333-333333333333'),
+            },
+            organisationId: {
+              ...uuidString('11111111-1111-4111-8111-111111111111'),
+            },
+            enforceRememberMePolicy: {
+              type: 'boolean',
+              example: true,
+            },
+            allowRememberMe: {
+              type: 'boolean',
+              example: true,
+            },
+            maxRememberedSessionHours: {
+              type: 'integer',
+              nullable: true,
+              minimum: 1,
+              maximum: 720,
+              example: 168,
+            },
+            enforceRegularSessionLength: {
+              type: 'boolean',
+              example: true,
+            },
+            regularSessionLengthHours: {
+              type: 'integer',
+              nullable: true,
+              minimum: 1,
+              maximum: 24,
+              example: 8,
+            },
+            enforceIdleTimeout: {
+              type: 'boolean',
+              example: true,
+            },
+            idleTimeoutMinutes: {
+              type: 'integer',
+              nullable: true,
+              minimum: 5,
+              maximum: 480,
+              example: 30,
+            },
+            requireReauthenticationForSensitiveActions: {
+              type: 'boolean',
+              example: true,
+            },
+            allowTraineeEmailChange: {
+              type: 'boolean',
+              example: false,
+            },
+            updatedByOrganisationAdminId: {
+              ...nullableUuidString('22222222-2222-4222-8222-222222222222'),
+            },
+            createdAt: {
+              ...dateTimeString('2026-07-01T08:00:00.000Z'),
+            },
+            updatedAt: {
+              ...dateTimeString('2026-07-02T08:00:00.000Z'),
+            },
+          },
+        },
+        OrganisationSecuritySettingsEffectivePolicy: {
+          type: 'object',
+          required: [
+            'organisationId',
+            'rememberMeRequested',
+            'rememberMeAllowed',
+            'rememberMeApplied',
+            'regularSessionSeconds',
+            'rememberedSessionSeconds',
+            'effectiveSessionSeconds',
+            'idleTimeoutMinutes',
+            'requireReauthenticationForSensitiveActions',
+            'allowEmailChange',
+          ],
+          properties: {
+            organisationId: {
+              ...nullableUuidString('11111111-1111-4111-8111-111111111111'),
+            },
+            rememberMeRequested: {
+              type: 'boolean',
+              example: false,
+            },
+            rememberMeAllowed: {
+              type: 'boolean',
+              example: true,
+            },
+            rememberMeApplied: {
+              type: 'boolean',
+              example: false,
+            },
+            regularSessionSeconds: {
+              type: 'integer',
+              example: 28800,
+            },
+            rememberedSessionSeconds: {
+              type: 'integer',
+              example: 604800,
+            },
+            effectiveSessionSeconds: {
+              type: 'integer',
+              example: 28800,
+            },
+            idleTimeoutMinutes: {
+              type: 'integer',
+              nullable: true,
+              example: 30,
+            },
+            requireReauthenticationForSensitiveActions: {
+              type: 'boolean',
+              example: true,
+            },
+            allowEmailChange: {
+              type: 'boolean',
+              example: false,
+            },
+          },
+        },
+        OrganisationSecuritySettingsLimits: {
+          type: 'object',
+          required: ['rememberMe', 'regularSession', 'idleTimeout'],
+          properties: {
+            rememberMe: {
+              type: 'object',
+              required: ['maxRememberedSessionHours'],
+              properties: {
+                maxRememberedSessionHours: {
+                  type: 'object',
+                  required: ['min', 'max', 'default', 'options'],
+                  properties: {
+                    min: {
+                      type: 'integer',
+                      example: 1,
+                    },
+                    max: {
+                      type: 'integer',
+                      example: 720,
+                    },
+                    default: {
+                      type: 'integer',
+                      example: 168,
+                    },
+                    options: {
+                      type: 'array',
+                      items: {
+                        type: 'integer',
+                      },
+                      example: [24, 72, 168, 336, 720],
+                    },
+                  },
+                },
+              },
+            },
+            regularSession: {
+              type: 'object',
+              required: ['regularSessionLengthHours'],
+              properties: {
+                regularSessionLengthHours: {
+                  type: 'object',
+                  required: ['min', 'max', 'default', 'options'],
+                  properties: {
+                    min: {
+                      type: 'integer',
+                      example: 1,
+                    },
+                    max: {
+                      type: 'integer',
+                      example: 24,
+                    },
+                    default: {
+                      type: 'integer',
+                      example: 8,
+                    },
+                    options: {
+                      type: 'array',
+                      items: {
+                        type: 'integer',
+                      },
+                      example: [4, 8, 12, 24],
+                    },
+                  },
+                },
+              },
+            },
+            idleTimeout: {
+              type: 'object',
+              required: ['idleTimeoutMinutes'],
+              properties: {
+                idleTimeoutMinutes: {
+                  type: 'object',
+                  required: ['min', 'max', 'default', 'options'],
+                  properties: {
+                    min: {
+                      type: 'integer',
+                      example: 5,
+                    },
+                    max: {
+                      type: 'integer',
+                      example: 480,
+                    },
+                    default: {
+                      type: 'integer',
+                      example: 30,
+                    },
+                    options: {
+                      type: 'array',
+                      items: {
+                        type: 'integer',
+                      },
+                      example: [15, 30, 60, 120, 240, 480],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        OrganisationSecuritySettingsChangesApply: {
+          type: 'object',
+          required: [
+            'rememberMePolicy',
+            'regularSessionLength',
+            'idleTimeout',
+            'requireReauthenticationForSensitiveActions',
+            'allowTraineeEmailChange',
+          ],
+          properties: {
+            rememberMePolicy: enumString(['NEXT_REFRESH_OR_LOGIN'], 'NEXT_REFRESH_OR_LOGIN'),
+            regularSessionLength: enumString(['NEXT_REFRESH_OR_LOGIN'], 'NEXT_REFRESH_OR_LOGIN'),
+            idleTimeout: enumString(['NEXT_REFRESH'], 'NEXT_REFRESH'),
+            requireReauthenticationForSensitiveActions: enumString(
+              ['IMMEDIATE_FOR_NEW_ACTIONS'],
+              'IMMEDIATE_FOR_NEW_ACTIONS',
+            ),
+            allowTraineeEmailChange: enumString(
+              ['IMMEDIATE_FOR_NEW_REQUESTS'],
+              'IMMEDIATE_FOR_NEW_REQUESTS',
+            ),
+          },
+        },
+        OrganisationSecuritySettingsCapabilities: {
+          type: 'object',
+          required: ['canView', 'canEdit', 'readOnlyReason', 'changesApply'],
+          properties: {
+            canView: {
+              type: 'boolean',
+              example: true,
+            },
+            canEdit: {
+              type: 'boolean',
+              example: true,
+            },
+            readOnlyReason: {
+              type: 'string',
+              nullable: true,
+              enum: ['MISSING_PERMISSION', 'ORGANISATION_SUSPENDED', 'ORGANISATION_DISABLED'],
+              example: null,
+            },
+            changesApply: {
+              $ref: '#/components/schemas/OrganisationSecuritySettingsChangesApply',
+            },
+          },
+        },
+        OrganisationSecuritySettingsResponse: {
+          type: 'object',
+          required: [
+            'organisationId',
+            'settings',
+            'effectivePolicy',
+            'platformLimits',
+            'capabilities',
+          ],
+          properties: {
+            organisationId: {
+              ...uuidString('11111111-1111-4111-8111-111111111111'),
+            },
+            settings: {
+              $ref: '#/components/schemas/OrganisationSecuritySettings',
+            },
+            effectivePolicy: {
+              $ref: '#/components/schemas/OrganisationSecuritySettingsEffectivePolicy',
+            },
+            platformLimits: {
+              $ref: '#/components/schemas/OrganisationSecuritySettingsLimits',
+            },
+            capabilities: {
+              $ref: '#/components/schemas/OrganisationSecuritySettingsCapabilities',
+            },
+          },
+        },
+        OrganisationSecuritySettingsUpdateRequest: {
+          type: 'object',
+          required: [
+            'enforceRememberMePolicy',
+            'allowRememberMe',
+            'maxRememberedSessionHours',
+            'enforceRegularSessionLength',
+            'regularSessionLengthHours',
+            'enforceIdleTimeout',
+            'idleTimeoutMinutes',
+            'requireReauthenticationForSensitiveActions',
+            'allowTraineeEmailChange',
+          ],
+          additionalProperties: false,
+          properties: {
+            enforceRememberMePolicy: {
+              type: 'boolean',
+              example: true,
+            },
+            allowRememberMe: {
+              type: 'boolean',
+              example: true,
+            },
+            maxRememberedSessionHours: {
+              type: 'integer',
+              nullable: true,
+              minimum: 1,
+              maximum: 720,
+              example: 168,
+            },
+            enforceRegularSessionLength: {
+              type: 'boolean',
+              example: true,
+            },
+            regularSessionLengthHours: {
+              type: 'integer',
+              nullable: true,
+              minimum: 1,
+              maximum: 24,
+              example: 8,
+            },
+            enforceIdleTimeout: {
+              type: 'boolean',
+              example: true,
+            },
+            idleTimeoutMinutes: {
+              type: 'integer',
+              nullable: true,
+              minimum: 5,
+              maximum: 480,
+              example: 30,
+            },
+            requireReauthenticationForSensitiveActions: {
+              type: 'boolean',
+              example: true,
+            },
+            allowTraineeEmailChange: {
+              type: 'boolean',
+              example: false,
+            },
           },
         },
         DifficultyLevel: enumString(
@@ -2436,6 +2808,10 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
           required: true,
           ...jsonContent(schemaRef('OrganisationAdminRemoveRequest')),
         },
+        OrganisationSecuritySettingsUpdate: {
+          required: true,
+          ...jsonContent(schemaRef('OrganisationSecuritySettingsUpdateRequest')),
+        },
       },
       responses: {
         HealthOk: responseComponent('API and database are reachable.', 'HealthStatus'),
@@ -2501,6 +2877,14 @@ This reference covers the currently mounted Demo 1 backend routes. Planned or un
         OrganisationAdminRemoved: responseComponent(
           'Organisation admin privileges removed.',
           'OrganisationAdminRemoveResponse',
+        ),
+        OrganisationSecuritySettingsOk: responseComponent(
+          'Organisation security settings and effective policy.',
+          'OrganisationSecuritySettingsResponse',
+        ),
+        OrganisationSecuritySettingsUpdated: responseComponent(
+          'Organisation security settings updated.',
+          'OrganisationSecuritySettingsResponse',
         ),
         TraineeCampaignsOk: responseComponent(
           'Campaigns accessible to the authenticated active trainee.',

--- a/apps/backend/src/controllers/organisation-security-settings.controller.ts
+++ b/apps/backend/src/controllers/organisation-security-settings.controller.ts
@@ -1,0 +1,78 @@
+import type { Request, Response } from 'express';
+import {
+  getOrganisationSecuritySettings,
+  OrganisationSecuritySettingsServiceError,
+  patchOrganisationSecuritySettings,
+} from '../services/organisation-security-settings.service.js';
+
+function requireActorUserId(req: Request, res: Response): string | null {
+  if (!req.auth?.userId) {
+    res.status(401).json({
+      error: 'AUTH_REQUIRED',
+      message: 'Authentication credentials are required',
+    });
+    return null;
+  }
+
+  return req.auth.userId;
+}
+
+function requiredParam(req: Request, name: string) {
+  const value = req.params[name];
+  if (typeof value !== 'string') {
+    throw new OrganisationSecuritySettingsServiceError(
+      404,
+      'ROUTE_PARAM_MISSING',
+      'Route parameter is missing',
+    );
+  }
+
+  return value;
+}
+
+function handleOrganisationSecuritySettingsError(error: unknown, res: Response) {
+  if (error instanceof OrganisationSecuritySettingsServiceError) {
+    return res.status(error.statusCode).json({
+      error: error.error,
+      message: error.message,
+      ...(error.fieldErrors.length > 0 ? { details: error.fieldErrors } : {}),
+    });
+  }
+
+  throw error;
+}
+
+export async function getOrganisationSecuritySettingsController(req: Request, res: Response) {
+  const actorUserId = requireActorUserId(req, res);
+  if (!actorUserId) {
+    return;
+  }
+
+  try {
+    const result = await getOrganisationSecuritySettings(
+      actorUserId,
+      requiredParam(req, 'organisationId'),
+    );
+    return res.status(200).json(result);
+  } catch (error) {
+    return handleOrganisationSecuritySettingsError(error, res);
+  }
+}
+
+export async function updateOrganisationSecuritySettingsController(req: Request, res: Response) {
+  const actorUserId = requireActorUserId(req, res);
+  if (!actorUserId) {
+    return;
+  }
+
+  try {
+    const result = await patchOrganisationSecuritySettings(
+      actorUserId,
+      requiredParam(req, 'organisationId'),
+      req.body,
+    );
+    return res.status(200).json(result);
+  } catch (error) {
+    return handleOrganisationSecuritySettingsError(error, res);
+  }
+}

--- a/apps/backend/src/repositories/organisation-security-settings.repository.ts
+++ b/apps/backend/src/repositories/organisation-security-settings.repository.ts
@@ -1,0 +1,153 @@
+import type { UpdateOrganisationSecuritySettingsRequestDto } from '@insightful-phish/shared';
+import type {
+  OrganisationPermissionKey,
+  Prisma,
+  PrismaClient,
+} from '../generated/prisma/client.js';
+import { prisma } from '../lib/prisma.js';
+import { ensureDefaultOrganisationSecuritySettings } from './security-settings.repository.js';
+
+type OrganisationSecuritySettingsClient = PrismaClient | Prisma.TransactionClient;
+
+export const ORGANISATION_SECURITY_SETTINGS_UPDATE_PERMISSION: OrganisationPermissionKey =
+  'CHANGE_ORGANISATION_SECURITY_SETTINGS';
+
+const organisationSecuritySettingsInclude = {
+  organisation: true,
+  updatedByOrganisationAdmin: {
+    include: {
+      user: true,
+    },
+  },
+} satisfies Prisma.OrganisationSecuritySettingsInclude;
+
+const actorOrganisationAdminInclude = {
+  organisation: true,
+  user: true,
+  permissionGrants: {
+    include: {
+      organisationPermission: true,
+    },
+  },
+} satisfies Prisma.OrganisationAdminProfileInclude;
+
+export type OrganisationSecuritySettingsWithRelations =
+  Prisma.OrganisationSecuritySettingsGetPayload<{
+    include: typeof organisationSecuritySettingsInclude;
+  }>;
+
+export type OrganisationSecuritySettingsActorAdmin = Prisma.OrganisationAdminProfileGetPayload<{
+  include: typeof actorOrganisationAdminInclude;
+}>;
+
+export type OrganisationWithSecuritySettings = Prisma.OrganisationGetPayload<{
+  include: {
+    securitySettings: true;
+  };
+}>;
+
+export type UpdateOrganisationSecuritySettingsInput =
+  UpdateOrganisationSecuritySettingsRequestDto & {
+    organisationId: string;
+    updatedByOrganisationAdminId: string;
+  };
+
+export type UpdateOrganisationSecuritySettingsResult = {
+  oldSettings: OrganisationSecuritySettingsWithRelations;
+  newSettings: OrganisationSecuritySettingsWithRelations;
+};
+
+export function findOrganisationSecuritySettingsActorAdmin(
+  input: { actorUserId: string; organisationId: string },
+  client: OrganisationSecuritySettingsClient = prisma,
+): Promise<OrganisationSecuritySettingsActorAdmin | null> {
+  return client.organisationAdminProfile.findFirst({
+    where: {
+      userId: input.actorUserId,
+      organisationId: input.organisationId,
+      adminStatus: 'ACTIVE',
+    },
+    include: actorOrganisationAdminInclude,
+  });
+}
+
+export function findOrganisationWithSecuritySettings(
+  organisationId: string,
+  client: OrganisationSecuritySettingsClient = prisma,
+): Promise<OrganisationWithSecuritySettings | null> {
+  return client.organisation.findUnique({
+    where: {
+      id: organisationId,
+    },
+    include: {
+      securitySettings: true,
+    },
+  });
+}
+
+export async function findOrganisationSecuritySettingsByOrganisationId(
+  organisationId: string,
+  client: OrganisationSecuritySettingsClient = prisma,
+): Promise<OrganisationSecuritySettingsWithRelations | null> {
+  await ensureDefaultOrganisationSecuritySettings({ organisationId }, client);
+
+  return client.organisationSecuritySettings.findUnique({
+    where: {
+      organisationId,
+    },
+    include: organisationSecuritySettingsInclude,
+  });
+}
+
+export async function updateOrganisationSecuritySettings(
+  input: UpdateOrganisationSecuritySettingsInput,
+  client: OrganisationSecuritySettingsClient = prisma,
+): Promise<UpdateOrganisationSecuritySettingsResult | null> {
+  const oldSettings = await client.organisationSecuritySettings.findUnique({
+    where: {
+      organisationId: input.organisationId,
+    },
+    include: organisationSecuritySettingsInclude,
+  });
+
+  if (!oldSettings) {
+    return null;
+  }
+
+  const newSettings = await client.organisationSecuritySettings.update({
+    where: {
+      organisationId: input.organisationId,
+    },
+    data: {
+      enforceRememberMePolicy: input.enforceRememberMePolicy,
+      allowRememberMe: input.allowRememberMe,
+      maxRememberedSessionHours: input.maxRememberedSessionHours,
+      enforceRegularSessionLength: input.enforceRegularSessionLength,
+      regularSessionLengthHours: input.regularSessionLengthHours,
+      enforceIdleTimeout: input.enforceIdleTimeout,
+      idleTimeoutMinutes: input.idleTimeoutMinutes,
+      requireReauthenticationForSensitiveActions: input.requireReauthenticationForSensitiveActions,
+      allowTraineeEmailChange: input.allowTraineeEmailChange,
+      updatedByOrganisationAdmin: {
+        connect: {
+          id_organisationId: {
+            id: input.updatedByOrganisationAdminId,
+            organisationId: input.organisationId,
+          },
+        },
+      },
+    },
+    include: organisationSecuritySettingsInclude,
+  });
+
+  return {
+    oldSettings,
+    newSettings,
+  };
+}
+
+export function runOrganisationSecuritySettingsTransaction<T>(
+  action: (tx: Prisma.TransactionClient) => Promise<T>,
+) {
+  return prisma.$transaction(action);
+}

--- a/apps/backend/src/routes/organisation-security-settings.routes.ts
+++ b/apps/backend/src/routes/organisation-security-settings.routes.ts
@@ -40,9 +40,9 @@ export const organisationSecuritySettingsMutationRateLimit = rateLimit({
   message: organisationSecuritySettingsRateLimitMessage,
 });
 
-export function clearOrganisationSecuritySettingsRateLimitStores() {
-  void organisationSecuritySettingsReadRateLimitStore.resetAll();
-  void organisationSecuritySettingsMutationRateLimitStore.resetAll();
+export async function clearOrganisationSecuritySettingsRateLimitStores() {
+  await organisationSecuritySettingsReadRateLimitStore.resetAll();
+  await organisationSecuritySettingsMutationRateLimitStore.resetAll();
 }
 
 /**

--- a/apps/backend/src/routes/organisation-security-settings.routes.ts
+++ b/apps/backend/src/routes/organisation-security-settings.routes.ts
@@ -45,6 +45,33 @@ export function clearOrganisationSecuritySettingsRateLimitStores() {
   void organisationSecuritySettingsMutationRateLimitStore.resetAll();
 }
 
+/**
+ * @openapi
+ * /organisations/{organisationId}/security-settings:
+ *   get:
+ *     tags: [Organisation Security Settings]
+ *     summary: Get organisation security settings
+ *     description: Returns organisation-scoped security settings, the effective policy, platform limits, and edit capabilities for the authenticated organisation admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/OrganisationIdPathParam'
+ *     responses:
+ *       200:
+ *         $ref: '#/components/responses/OrganisationSecuritySettingsOk'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ *       429:
+ *         $ref: '#/components/responses/TooManyRequests'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 organisationSecuritySettingsRouter.get(
   '/organisations/:organisationId/security-settings',
   organisationSecuritySettingsReadRateLimit,
@@ -53,6 +80,39 @@ organisationSecuritySettingsRouter.get(
   asyncHandler(getOrganisationSecuritySettingsController),
 );
 
+/**
+ * @openapi
+ * /organisations/{organisationId}/security-settings:
+ *   patch:
+ *     tags: [Organisation Security Settings]
+ *     summary: Update organisation security settings
+ *     description: Updates organisation-scoped security settings for an active organisation when the authenticated organisation admin has the required security-settings permission.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - $ref: '#/components/parameters/OrganisationIdPathParam'
+ *     requestBody:
+ *       $ref: '#/components/requestBodies/OrganisationSecuritySettingsUpdate'
+ *     responses:
+ *       200:
+ *         $ref: '#/components/responses/OrganisationSecuritySettingsUpdated'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ *       409:
+ *         $ref: '#/components/responses/Conflict'
+ *       422:
+ *         $ref: '#/components/responses/UnprocessableEntity'
+ *       429:
+ *         $ref: '#/components/responses/TooManyRequests'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 organisationSecuritySettingsRouter.patch(
   '/organisations/:organisationId/security-settings',
   organisationSecuritySettingsMutationRateLimit,

--- a/apps/backend/src/routes/organisation-security-settings.routes.ts
+++ b/apps/backend/src/routes/organisation-security-settings.routes.ts
@@ -1,0 +1,63 @@
+import {
+  organisationIdParamsSchema,
+  updateOrganisationSecuritySettingsRequestSchema,
+} from '@insightful-phish/shared';
+import { Router } from 'express';
+import rateLimit, { MemoryStore } from 'express-rate-limit';
+import {
+  getOrganisationSecuritySettingsController,
+  updateOrganisationSecuritySettingsController,
+} from '../controllers/organisation-security-settings.controller.js';
+import { asyncHandler } from '../middleware/asyncHandler.js';
+import { requireAuth } from '../middleware/requireAuth.js';
+import { validateBody, validateParams } from '../middleware/validateRequest.js';
+
+export const organisationSecuritySettingsRouter = Router();
+
+const organisationSecuritySettingsReadRateLimitStore = new MemoryStore();
+const organisationSecuritySettingsMutationRateLimitStore = new MemoryStore();
+
+const organisationSecuritySettingsRateLimitMessage = {
+  error: 'ORGANISATION_SECURITY_SETTINGS_RATE_LIMITED',
+  message: 'Too many organisation security settings requests. Please try again later.',
+};
+
+export const organisationSecuritySettingsReadRateLimit = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 100,
+  store: organisationSecuritySettingsReadRateLimitStore,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: organisationSecuritySettingsRateLimitMessage,
+});
+
+export const organisationSecuritySettingsMutationRateLimit = rateLimit({
+  windowMs: 5 * 60 * 1000,
+  limit: 20,
+  store: organisationSecuritySettingsMutationRateLimitStore,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: organisationSecuritySettingsRateLimitMessage,
+});
+
+export function clearOrganisationSecuritySettingsRateLimitStores() {
+  void organisationSecuritySettingsReadRateLimitStore.resetAll();
+  void organisationSecuritySettingsMutationRateLimitStore.resetAll();
+}
+
+organisationSecuritySettingsRouter.get(
+  '/organisations/:organisationId/security-settings',
+  organisationSecuritySettingsReadRateLimit,
+  requireAuth,
+  validateParams(organisationIdParamsSchema),
+  asyncHandler(getOrganisationSecuritySettingsController),
+);
+
+organisationSecuritySettingsRouter.patch(
+  '/organisations/:organisationId/security-settings',
+  organisationSecuritySettingsMutationRateLimit,
+  requireAuth,
+  validateParams(organisationIdParamsSchema),
+  validateBody(updateOrganisationSecuritySettingsRequestSchema, { statusCode: 422 }),
+  asyncHandler(updateOrganisationSecuritySettingsController),
+);

--- a/apps/backend/src/services/organisation-security-settings.service.ts
+++ b/apps/backend/src/services/organisation-security-settings.service.ts
@@ -1,0 +1,304 @@
+import {
+  ORGANISATION_SECURITY_SETTINGS_LIMITS,
+  updateOrganisationSecuritySettingsRequestSchema,
+  type OrganisationSecuritySettingsCapabilitiesDto,
+  type OrganisationSecuritySettingsChangesApplyDto,
+  type OrganisationSecuritySettingsDto,
+  type OrganisationSecuritySettingsEffectivePolicyDto,
+  type OrganisationSecuritySettingsReadOnlyReasonDto,
+  type OrganisationSecuritySettingsResponseDto,
+  type UpdateOrganisationSecuritySettingsRequestDto,
+} from '@insightful-phish/shared';
+import type { OrganisationPermissionKey, OrganisationStatus } from '../generated/prisma/enums.js';
+import { recordAuditLog } from './audit-log.service.js';
+import {
+  ORGANISATION_SECURITY_SETTINGS_UPDATE_PERMISSION,
+  findOrganisationSecuritySettingsActorAdmin,
+  findOrganisationSecuritySettingsByOrganisationId,
+  runOrganisationSecuritySettingsTransaction,
+  updateOrganisationSecuritySettings,
+  type OrganisationSecuritySettingsActorAdmin,
+  type OrganisationSecuritySettingsWithRelations,
+} from '../repositories/organisation-security-settings.repository.js';
+import { resolveEffectiveSecurityPolicyFromOrganisationSettings } from './security-policy.service.js';
+
+export type OrganisationSecuritySettingsFieldError = {
+  field: string;
+  message: string;
+};
+
+export class OrganisationSecuritySettingsServiceError extends Error {
+  constructor(
+    public readonly statusCode: 403 | 404 | 409 | 422,
+    public readonly error: string,
+    message: string,
+    public readonly fieldErrors: OrganisationSecuritySettingsFieldError[] = [],
+  ) {
+    super(message);
+    this.name = 'OrganisationSecuritySettingsServiceError';
+  }
+}
+
+const CHANGES_APPLY: OrganisationSecuritySettingsChangesApplyDto = {
+  rememberMePolicy: 'NEXT_REFRESH_OR_LOGIN',
+  regularSessionLength: 'NEXT_REFRESH_OR_LOGIN',
+  idleTimeout: 'NEXT_REFRESH',
+  requireReauthenticationForSensitiveActions: 'IMMEDIATE_FOR_NEW_ACTIONS',
+  allowTraineeEmailChange: 'IMMEDIATE_FOR_NEW_REQUESTS',
+};
+
+export async function getOrganisationSecuritySettings(
+  actorUserId: string,
+  organisationId: string,
+): Promise<OrganisationSecuritySettingsResponseDto> {
+  const actor = await requireActorAdmin(actorUserId, organisationId);
+  const settings = await requireOrganisationSecuritySettings(organisationId);
+
+  return buildOrganisationSecuritySettingsResponse({
+    organisationId,
+    settings,
+    actor,
+  });
+}
+
+export async function patchOrganisationSecuritySettings(
+  actorUserId: string,
+  organisationId: string,
+  input: unknown,
+): Promise<OrganisationSecuritySettingsResponseDto> {
+  const actor = await requireActorAdmin(actorUserId, organisationId);
+  requireUpdatePermission(actor);
+  assertOrganisationAllowsUpdate(actor.organisation.status);
+
+  const parsedInput = parseUpdateInput(input);
+  const updateResult = await runOrganisationSecuritySettingsTransaction(async (tx) => {
+    const result = await updateOrganisationSecuritySettings(
+      {
+        organisationId,
+        updatedByOrganisationAdminId: actor.id,
+        ...parsedInput,
+      },
+      tx,
+    );
+
+    if (!result) {
+      throw notFoundError();
+    }
+
+    await recordAuditLog(
+      {
+        actorUserId,
+        actorType: 'ORGANISATION_ADMIN',
+        organisationId,
+        targetType: 'ORGANISATION_SECURITY_SETTINGS',
+        targetId: result.newSettings.id,
+        actionType: 'SETTINGS_CHANGED',
+        outcome: 'SUCCESS',
+        oldValues: securitySettingsAuditValues(result.oldSettings),
+        newValues: securitySettingsAuditValues(result.newSettings),
+      },
+      tx,
+    );
+
+    return result;
+  });
+
+  return buildOrganisationSecuritySettingsResponse({
+    organisationId,
+    settings: updateResult.newSettings,
+    actor,
+  });
+}
+
+function parseUpdateInput(input: unknown): UpdateOrganisationSecuritySettingsRequestDto {
+  const parseResult = updateOrganisationSecuritySettingsRequestSchema.safeParse(input);
+
+  if (parseResult.success) {
+    return parseResult.data;
+  }
+
+  throw new OrganisationSecuritySettingsServiceError(
+    422,
+    'ORG_SECURITY_SETTINGS_VALIDATION_FAILED',
+    'Organisation security settings are invalid',
+    parseResult.error.issues.map((issue) => ({
+      field: issue.path.join('.'),
+      message: issue.message,
+    })),
+  );
+}
+
+async function requireActorAdmin(actorUserId: string, organisationId: string) {
+  const actor = await findOrganisationSecuritySettingsActorAdmin({ actorUserId, organisationId });
+
+  if (!actor) {
+    throw new OrganisationSecuritySettingsServiceError(
+      403,
+      'ORG_ADMIN_REQUIRED',
+      'Active organisation admin access is required',
+    );
+  }
+
+  return actor;
+}
+
+async function requireOrganisationSecuritySettings(organisationId: string) {
+  const settings = await findOrganisationSecuritySettingsByOrganisationId(organisationId);
+
+  if (!settings) {
+    throw notFoundError();
+  }
+
+  return settings;
+}
+
+function notFoundError() {
+  return new OrganisationSecuritySettingsServiceError(
+    404,
+    'ORG_SECURITY_SETTINGS_NOT_FOUND',
+    'Organisation security settings were not found',
+  );
+}
+
+function requireUpdatePermission(actor: OrganisationSecuritySettingsActorAdmin) {
+  if (permissionKeysForActor(actor).includes(ORGANISATION_SECURITY_SETTINGS_UPDATE_PERMISSION)) {
+    return;
+  }
+
+  throw new OrganisationSecuritySettingsServiceError(
+    403,
+    'ORG_SECURITY_SETTINGS_PERMISSION_REQUIRED',
+    'Required organisation security settings permission is missing',
+  );
+}
+
+function assertOrganisationAllowsUpdate(status: OrganisationStatus) {
+  if (status === 'ACTIVE') {
+    return;
+  }
+
+  throw new OrganisationSecuritySettingsServiceError(
+    409,
+    'ORG_SECURITY_SETTINGS_READ_ONLY',
+    'Organisation security settings cannot be changed while the organisation is not active',
+  );
+}
+
+function buildOrganisationSecuritySettingsResponse(input: {
+  organisationId: string;
+  settings: OrganisationSecuritySettingsWithRelations;
+  actor: OrganisationSecuritySettingsActorAdmin;
+}): OrganisationSecuritySettingsResponseDto {
+  return {
+    organisationId: input.organisationId,
+    settings: toOrganisationSecuritySettingsDto(input.settings),
+    effectivePolicy: toEffectivePolicyDto(
+      resolveEffectiveSecurityPolicyFromOrganisationSettings({
+        settings: input.settings,
+      }),
+    ),
+    platformLimits: ORGANISATION_SECURITY_SETTINGS_LIMITS,
+    capabilities: buildCapabilities(input.actor),
+  };
+}
+
+function buildCapabilities(
+  actor: OrganisationSecuritySettingsActorAdmin,
+): OrganisationSecuritySettingsCapabilitiesDto {
+  const readOnlyReason = readOnlyReasonForActor(actor);
+
+  return {
+    canView: true,
+    canEdit: readOnlyReason === null,
+    readOnlyReason,
+    changesApply: CHANGES_APPLY,
+  };
+}
+
+function readOnlyReasonForActor(
+  actor: OrganisationSecuritySettingsActorAdmin,
+): OrganisationSecuritySettingsReadOnlyReasonDto {
+  if (actor.organisation.status === 'SUSPENDED') {
+    return 'ORGANISATION_SUSPENDED';
+  }
+
+  if (actor.organisation.status !== 'ACTIVE') {
+    return 'ORGANISATION_DISABLED';
+  }
+
+  if (!permissionKeysForActor(actor).includes(ORGANISATION_SECURITY_SETTINGS_UPDATE_PERMISSION)) {
+    return 'MISSING_PERMISSION';
+  }
+
+  return null;
+}
+
+function permissionKeysForActor(
+  actor: OrganisationSecuritySettingsActorAdmin,
+): OrganisationPermissionKey[] {
+  return actor.permissionGrants.map((grant) => grant.organisationPermission.key);
+}
+
+function toOrganisationSecuritySettingsDto(
+  settings: OrganisationSecuritySettingsWithRelations,
+): OrganisationSecuritySettingsDto {
+  return {
+    id: settings.id,
+    organisationId: settings.organisationId,
+    enforceRememberMePolicy: settings.enforceRememberMePolicy,
+    allowRememberMe: settings.allowRememberMe,
+    maxRememberedSessionHours: settings.maxRememberedSessionHours,
+    enforceRegularSessionLength: settings.enforceRegularSessionLength,
+    regularSessionLengthHours: settings.regularSessionLengthHours,
+    enforceIdleTimeout: settings.enforceIdleTimeout,
+    idleTimeoutMinutes: settings.idleTimeoutMinutes,
+    requireReauthenticationForSensitiveActions: settings.requireReauthenticationForSensitiveActions,
+    allowTraineeEmailChange: settings.allowTraineeEmailChange,
+    updatedByOrganisationAdminId: settings.updatedByOrganisationAdminId,
+    createdAt: settings.createdAt.toISOString(),
+    updatedAt: settings.updatedAt.toISOString(),
+  };
+}
+
+function toEffectivePolicyDto(input: {
+  organisationId: string | null;
+  rememberMeRequested: boolean;
+  rememberMeAllowed: boolean;
+  rememberMeApplied: boolean;
+  regularSessionSeconds: number;
+  rememberedSessionSeconds: number;
+  effectiveSessionSeconds: number;
+  idleTimeoutMinutes: number | null;
+  requireReauthenticationForSensitiveActions: boolean;
+  allowEmailChange: boolean;
+}): OrganisationSecuritySettingsEffectivePolicyDto {
+  return {
+    organisationId: input.organisationId,
+    rememberMeRequested: input.rememberMeRequested,
+    rememberMeAllowed: input.rememberMeAllowed,
+    rememberMeApplied: input.rememberMeApplied,
+    regularSessionSeconds: input.regularSessionSeconds,
+    rememberedSessionSeconds: input.rememberedSessionSeconds,
+    effectiveSessionSeconds: input.effectiveSessionSeconds,
+    idleTimeoutMinutes: input.idleTimeoutMinutes,
+    requireReauthenticationForSensitiveActions: input.requireReauthenticationForSensitiveActions,
+    allowEmailChange: input.allowEmailChange,
+  };
+}
+
+function securitySettingsAuditValues(
+  settings: OrganisationSecuritySettingsWithRelations,
+): Record<string, string | number | boolean | null> {
+  return {
+    enforceRememberMePolicy: settings.enforceRememberMePolicy,
+    allowRememberMe: settings.allowRememberMe,
+    maxRememberedSessionHours: settings.maxRememberedSessionHours,
+    enforceRegularSessionLength: settings.enforceRegularSessionLength,
+    regularSessionLengthHours: settings.regularSessionLengthHours,
+    enforceIdleTimeout: settings.enforceIdleTimeout,
+    idleTimeoutMinutes: settings.idleTimeoutMinutes,
+    requireReauthenticationForSensitiveActions: settings.requireReauthenticationForSensitiveActions,
+    allowTraineeEmailChange: settings.allowTraineeEmailChange,
+    updatedByOrganisationAdminId: settings.updatedByOrganisationAdminId,
+  };
+}

--- a/apps/backend/src/services/security-policy.service.ts
+++ b/apps/backend/src/services/security-policy.service.ts
@@ -166,6 +166,27 @@ export async function resolveEffectiveSecurityPolicy(
   };
 }
 
+export function resolveEffectiveSecurityPolicyFromOrganisationSettings(input: {
+  settings: OrganisationSecuritySettingsRecord;
+  rememberMeRequested?: boolean;
+  platform?: PlatformSecurityPolicy;
+}): EffectiveSecurityPolicy {
+  const platform = input.platform ?? PLATFORM_SECURITY_POLICY;
+  const sessionPolicy = resolveSessionPolicy({
+    rememberMeRequested: input.rememberMeRequested ?? false,
+    platform,
+    organisationPolicy: toOrganisationSessionPolicy(input.settings),
+  });
+
+  return {
+    ...sessionPolicy,
+    organisationId: input.settings.organisationId,
+    requireReauthenticationForSensitiveActions:
+      input.settings.requireReauthenticationForSensitiveActions,
+    allowEmailChange: input.settings.allowTraineeEmailChange,
+  };
+}
+
 export async function canUserChangeOwnEmail(subject: GuardAuthSubject): Promise<boolean> {
   const organisationSettings = await findOrganisationSettingsOrDefault(
     organisationIdForSecurityPolicy(subject),

--- a/apps/backend/tests/unit/organisation-security-settings.routes.test.ts
+++ b/apps/backend/tests/unit/organisation-security-settings.routes.test.ts
@@ -1,0 +1,271 @@
+import type { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../src/app.js';
+import { clearOrganisationSecuritySettingsRateLimitStores } from '../../src/routes/organisation-security-settings.routes.js';
+
+const actorUserId = '33333333-3333-4333-8333-333333333333';
+const organisationId = '11111111-1111-4111-8111-111111111111';
+
+const serviceMock = vi.hoisted(() => {
+  class MockOrganisationSecuritySettingsServiceError extends Error {
+    constructor(
+      public readonly statusCode: 403 | 404 | 409 | 422,
+      public readonly error: string,
+      message: string,
+      public readonly fieldErrors: Array<{ field: string; message: string }> = [],
+    ) {
+      super(message);
+      this.name = 'OrganisationSecuritySettingsServiceError';
+    }
+  }
+
+  return {
+    OrganisationSecuritySettingsServiceError: MockOrganisationSecuritySettingsServiceError,
+    getOrganisationSecuritySettings: vi.fn(),
+    patchOrganisationSecuritySettings: vi.fn(),
+  };
+});
+
+vi.mock('../../src/services/organisation-security-settings.service.js', () => serviceMock);
+
+vi.mock('../../src/middleware/requireAuth.js', () => ({
+  requireAuth(req: Request, _res: Response, next: NextFunction) {
+    req.auth = {
+      userId: actorUserId,
+      user: {
+        id: actorUserId,
+        firstName: 'Amina',
+        lastName: 'Admin',
+        email: 'amina@example.test',
+        userType: 'ORGANISATION_ADMIN',
+        authStatus: 'ACTIVE',
+        createdAt: '2026-07-01T08:00:00.000Z',
+      },
+    };
+    next();
+  },
+}));
+
+function settingsResponse() {
+  return {
+    organisationId,
+    settings: {
+      id: '44444444-4444-4444-8444-444444444444',
+      organisationId,
+      enforceRememberMePolicy: true,
+      allowRememberMe: true,
+      maxRememberedSessionHours: 168,
+      enforceRegularSessionLength: true,
+      regularSessionLengthHours: 8,
+      enforceIdleTimeout: true,
+      idleTimeoutMinutes: 30,
+      requireReauthenticationForSensitiveActions: true,
+      allowTraineeEmailChange: false,
+      updatedByOrganisationAdminId: null,
+      createdAt: '2026-07-01T08:00:00.000Z',
+      updatedAt: '2026-07-02T08:00:00.000Z',
+    },
+    effectivePolicy: {
+      organisationId,
+      rememberMeRequested: false,
+      rememberMeAllowed: true,
+      rememberMeApplied: false,
+      regularSessionSeconds: 28800,
+      rememberedSessionSeconds: 604800,
+      effectiveSessionSeconds: 28800,
+      idleTimeoutMinutes: 30,
+      requireReauthenticationForSensitiveActions: true,
+      allowEmailChange: false,
+    },
+    platformLimits: {
+      rememberMe: {
+        maxRememberedSessionHours: {
+          min: 1,
+          max: 720,
+          default: 168,
+          options: [24, 72, 168, 336, 720],
+        },
+      },
+      regularSession: {
+        regularSessionLengthHours: {
+          min: 1,
+          max: 24,
+          default: 8,
+          options: [4, 8, 12, 24],
+        },
+      },
+      idleTimeout: {
+        idleTimeoutMinutes: {
+          min: 5,
+          max: 480,
+          default: 30,
+          options: [15, 30, 60, 120, 240, 480],
+        },
+      },
+    },
+    capabilities: {
+      canView: true,
+      canEdit: true,
+      readOnlyReason: null,
+      changesApply: {
+        rememberMePolicy: 'NEXT_REFRESH_OR_LOGIN',
+        regularSessionLength: 'NEXT_REFRESH_OR_LOGIN',
+        idleTimeout: 'NEXT_REFRESH',
+        requireReauthenticationForSensitiveActions: 'IMMEDIATE_FOR_NEW_ACTIONS',
+        allowTraineeEmailChange: 'IMMEDIATE_FOR_NEW_REQUESTS',
+      },
+    },
+  };
+}
+
+function updatePayload() {
+  return {
+    enforceRememberMePolicy: true,
+    allowRememberMe: true,
+    maxRememberedSessionHours: 72,
+    enforceRegularSessionLength: true,
+    regularSessionLengthHours: 4,
+    enforceIdleTimeout: true,
+    idleTimeoutMinutes: 15,
+    requireReauthenticationForSensitiveActions: false,
+    allowTraineeEmailChange: true,
+  };
+}
+
+describe('organisation security settings routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearOrganisationSecuritySettingsRateLimitStores();
+  });
+
+  it('gets organisation security settings for the authenticated actor and organisation', async () => {
+    serviceMock.getOrganisationSecuritySettings.mockResolvedValue(settingsResponse());
+
+    const response = await request(createApp()).get(
+      `/organisations/${organisationId}/security-settings`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(serviceMock.getOrganisationSecuritySettings).toHaveBeenCalledWith(
+      actorUserId,
+      organisationId,
+    );
+    expect(response.body).toMatchObject({
+      organisationId,
+      capabilities: {
+        canView: true,
+        canEdit: true,
+      },
+    });
+  });
+
+  it('updates organisation security settings with a validated request body', async () => {
+    serviceMock.patchOrganisationSecuritySettings.mockResolvedValue(settingsResponse());
+    const payload = updatePayload();
+
+    const response = await request(createApp())
+      .patch(`/organisations/${organisationId}/security-settings`)
+      .send(payload);
+
+    expect(response.status).toBe(200);
+    expect(serviceMock.patchOrganisationSecuritySettings).toHaveBeenCalledWith(
+      actorUserId,
+      organisationId,
+      payload,
+    );
+  });
+
+  it('rejects invalid update bodies before service work', async () => {
+    const response = await request(createApp())
+      .patch(`/organisations/${organisationId}/security-settings`)
+      .send({
+        ...updatePayload(),
+        regularSessionLengthHours: 25,
+      });
+
+    expect(response.status).toBe(422);
+    expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    expect(serviceMock.patchOrganisationSecuritySettings).not.toHaveBeenCalled();
+  });
+
+  it('maps field-specific service errors to safe validation responses', async () => {
+    serviceMock.patchOrganisationSecuritySettings.mockRejectedValue(
+      new serviceMock.OrganisationSecuritySettingsServiceError(
+        422,
+        'ORG_SECURITY_SETTINGS_VALIDATION_FAILED',
+        'Organisation security settings are invalid',
+        [
+          {
+            field: 'idleTimeoutMinutes',
+            message: 'Idle timeout minutes is required when idle timeout is enforced',
+          },
+        ],
+      ),
+    );
+
+    const response = await request(createApp())
+      .patch(`/organisations/${organisationId}/security-settings`)
+      .send(updatePayload());
+
+    expect(response.status).toBe(422);
+    expect(response.body).toEqual({
+      error: 'ORG_SECURITY_SETTINGS_VALIDATION_FAILED',
+      message: 'Organisation security settings are invalid',
+      details: [
+        {
+          field: 'idleTimeoutMinutes',
+          message: 'Idle timeout minutes is required when idle timeout is enforced',
+        },
+      ],
+    });
+  });
+
+  it('rejects invalid route params before service work', async () => {
+    const response = await request(createApp()).get('/organisations/not-a-uuid/security-settings');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('error', 'VALIDATION_ERROR');
+    expect(serviceMock.getOrganisationSecuritySettings).not.toHaveBeenCalled();
+  });
+
+  it('rate limits organisation security settings reads before service work', async () => {
+    serviceMock.getOrganisationSecuritySettings.mockResolvedValue(settingsResponse());
+
+    const app = createApp();
+    let response: request.Response | undefined;
+
+    for (let index = 0; index <= 100; index += 1) {
+      response = await request(app).get(`/organisations/${organisationId}/security-settings`);
+    }
+
+    expect(response?.status).toBe(429);
+    expect(response?.body).toEqual({
+      error: 'ORGANISATION_SECURITY_SETTINGS_RATE_LIMITED',
+      message: 'Too many organisation security settings requests. Please try again later.',
+    });
+    expect(response?.headers).toHaveProperty('retry-after');
+    expect(serviceMock.getOrganisationSecuritySettings).toHaveBeenCalledTimes(100);
+  });
+
+  it('rate limits organisation security settings updates before service work', async () => {
+    serviceMock.patchOrganisationSecuritySettings.mockResolvedValue(settingsResponse());
+
+    const app = createApp();
+    let response: request.Response | undefined;
+
+    for (let index = 0; index <= 20; index += 1) {
+      response = await request(app)
+        .patch(`/organisations/${organisationId}/security-settings`)
+        .send(updatePayload());
+    }
+
+    expect(response?.status).toBe(429);
+    expect(response?.body).toEqual({
+      error: 'ORGANISATION_SECURITY_SETTINGS_RATE_LIMITED',
+      message: 'Too many organisation security settings requests. Please try again later.',
+    });
+    expect(response?.headers).toHaveProperty('retry-after');
+    expect(serviceMock.patchOrganisationSecuritySettings).toHaveBeenCalledTimes(20);
+  });
+});

--- a/apps/backend/tests/unit/organisation-security-settings.routes.test.ts
+++ b/apps/backend/tests/unit/organisation-security-settings.routes.test.ts
@@ -134,9 +134,9 @@ function updatePayload() {
 }
 
 describe('organisation security settings routes', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
-    clearOrganisationSecuritySettingsRateLimitStores();
+    await clearOrganisationSecuritySettingsRateLimitStores();
   });
 
   it('gets organisation security settings for the authenticated actor and organisation', async () => {

--- a/apps/backend/tests/unit/organisation-security-settings.service.test.ts
+++ b/apps/backend/tests/unit/organisation-security-settings.service.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const repositoryMock = vi.hoisted(() => ({
+  ORGANISATION_SECURITY_SETTINGS_UPDATE_PERMISSION: 'CHANGE_ORGANISATION_SECURITY_SETTINGS',
+  findOrganisationSecuritySettingsActorAdmin: vi.fn(),
+  findOrganisationSecuritySettingsByOrganisationId: vi.fn(),
+  runOrganisationSecuritySettingsTransaction: vi.fn(),
+  updateOrganisationSecuritySettings: vi.fn(),
+}));
+
+const auditLogMock = vi.hoisted(() => ({
+  recordAuditLog: vi.fn(),
+}));
+
+vi.mock(
+  '../../src/repositories/organisation-security-settings.repository.js',
+  () => repositoryMock,
+);
+vi.mock('../../src/services/audit-log.service.js', () => auditLogMock);
+
+import {
+  getOrganisationSecuritySettings,
+  patchOrganisationSecuritySettings,
+} from '../../src/services/organisation-security-settings.service.js';
+
+const actorUserId = '33333333-3333-4333-8333-333333333333';
+const organisationId = '11111111-1111-4111-8111-111111111111';
+const actorAdminId = '22222222-2222-4222-8222-222222222222';
+
+function createActor(permissionKeys = ['CHANGE_ORGANISATION_SECURITY_SETTINGS']) {
+  return {
+    id: actorAdminId,
+    userId: actorUserId,
+    organisationId,
+    adminStatus: 'ACTIVE',
+    organisation: {
+      id: organisationId,
+      name: 'Example Organisation',
+      status: 'ACTIVE',
+    },
+    user: {
+      id: actorUserId,
+      email: 'admin@example.test',
+    },
+    permissionGrants: permissionKeys.map((key) => ({
+      organisationPermission: {
+        key,
+      },
+    })),
+  };
+}
+
+function createSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '44444444-4444-4444-8444-444444444444',
+    organisationId,
+    enforceRememberMePolicy: true,
+    allowRememberMe: true,
+    maxRememberedSessionHours: 168,
+    enforceRegularSessionLength: true,
+    regularSessionLengthHours: 8,
+    enforceIdleTimeout: true,
+    idleTimeoutMinutes: 30,
+    requireReauthenticationForSensitiveActions: true,
+    allowTraineeEmailChange: false,
+    updatedByOrganisationAdminId: actorAdminId,
+    createdAt: new Date('2026-07-01T08:00:00.000Z'),
+    updatedAt: new Date('2026-07-02T08:00:00.000Z'),
+    organisation: {
+      id: organisationId,
+      name: 'Example Organisation',
+      status: 'ACTIVE',
+    },
+    updatedByOrganisationAdmin: null,
+    ...overrides,
+  };
+}
+
+function validUpdateInput() {
+  return {
+    enforceRememberMePolicy: true,
+    allowRememberMe: true,
+    maxRememberedSessionHours: 72,
+    enforceRegularSessionLength: true,
+    regularSessionLengthHours: 4,
+    enforceIdleTimeout: true,
+    idleTimeoutMinutes: 15,
+    requireReauthenticationForSensitiveActions: false,
+    allowTraineeEmailChange: true,
+  };
+}
+
+describe('organisation security settings service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repositoryMock.findOrganisationSecuritySettingsActorAdmin.mockResolvedValue(createActor());
+    repositoryMock.findOrganisationSecuritySettingsByOrganisationId.mockResolvedValue(
+      createSettings(),
+    );
+    repositoryMock.runOrganisationSecuritySettingsTransaction.mockImplementation((action) =>
+      action('tx-client'),
+    );
+    repositoryMock.updateOrganisationSecuritySettings.mockResolvedValue({
+      oldSettings: createSettings(),
+      newSettings: createSettings(validUpdateInput()),
+    });
+    auditLogMock.recordAuditLog.mockResolvedValue({ id: 'audit-1' });
+  });
+
+  it('returns read-only capability metadata when the actor lacks update permission', async () => {
+    repositoryMock.findOrganisationSecuritySettingsActorAdmin.mockResolvedValue(createActor([]));
+
+    await expect(
+      getOrganisationSecuritySettings(actorUserId, organisationId),
+    ).resolves.toMatchObject({
+      organisationId,
+      capabilities: {
+        canView: true,
+        canEdit: false,
+        readOnlyReason: 'MISSING_PERMISSION',
+      },
+      platformLimits: {
+        rememberMe: {
+          maxRememberedSessionHours: {
+            max: 720,
+          },
+        },
+      },
+    });
+  });
+
+  it('updates settings and audit logs safe old and new values', async () => {
+    const input = validUpdateInput();
+
+    await expect(
+      patchOrganisationSecuritySettings(actorUserId, organisationId, input),
+    ).resolves.toMatchObject({
+      settings: {
+        maxRememberedSessionHours: 72,
+        regularSessionLengthHours: 4,
+        idleTimeoutMinutes: 15,
+        allowTraineeEmailChange: true,
+      },
+      effectivePolicy: {
+        organisationId,
+        regularSessionSeconds: 14400,
+        idleTimeoutMinutes: 15,
+        allowEmailChange: true,
+      },
+      capabilities: {
+        canEdit: true,
+        readOnlyReason: null,
+      },
+    });
+    expect(repositoryMock.updateOrganisationSecuritySettings).toHaveBeenCalledWith(
+      {
+        organisationId,
+        updatedByOrganisationAdminId: actorAdminId,
+        ...input,
+      },
+      'tx-client',
+    );
+    expect(auditLogMock.recordAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId,
+        actorType: 'ORGANISATION_ADMIN',
+        organisationId,
+        targetType: 'ORGANISATION_SECURITY_SETTINGS',
+        targetId: '44444444-4444-4444-8444-444444444444',
+        actionType: 'SETTINGS_CHANGED',
+        outcome: 'SUCCESS',
+        oldValues: expect.objectContaining({
+          maxRememberedSessionHours: 168,
+          updatedByOrganisationAdminId: actorAdminId,
+        }),
+        newValues: expect.objectContaining({
+          maxRememberedSessionHours: 72,
+          allowTraineeEmailChange: true,
+        }),
+      }),
+      'tx-client',
+    );
+  });
+
+  it('rejects updates without the required organisation permission', async () => {
+    repositoryMock.findOrganisationSecuritySettingsActorAdmin.mockResolvedValue(createActor([]));
+
+    await expect(
+      patchOrganisationSecuritySettings(actorUserId, organisationId, validUpdateInput()),
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      error: 'ORG_SECURITY_SETTINGS_PERMISSION_REQUIRED',
+    });
+    expect(repositoryMock.updateOrganisationSecuritySettings).not.toHaveBeenCalled();
+    expect(auditLogMock.recordAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates while the organisation is suspended', async () => {
+    repositoryMock.findOrganisationSecuritySettingsActorAdmin.mockResolvedValue({
+      ...createActor(['CHANGE_ORGANISATION_SECURITY_SETTINGS']),
+      organisation: {
+        id: organisationId,
+        name: 'Example Organisation',
+        status: 'SUSPENDED',
+      },
+    });
+
+    await expect(
+      patchOrganisationSecuritySettings(actorUserId, organisationId, validUpdateInput()),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      error: 'ORG_SECURITY_SETTINGS_READ_ONLY',
+    });
+    expect(repositoryMock.updateOrganisationSecuritySettings).not.toHaveBeenCalled();
+  });
+
+  it('returns field-specific validation errors for conflicting dependent values', async () => {
+    await expect(
+      patchOrganisationSecuritySettings(actorUserId, organisationId, {
+        ...validUpdateInput(),
+        enforceIdleTimeout: true,
+        idleTimeoutMinutes: null,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 422,
+      error: 'ORG_SECURITY_SETTINGS_VALIDATION_FAILED',
+      fieldErrors: [
+        {
+          field: 'idleTimeoutMinutes',
+          message: 'Idle timeout minutes is required when idle timeout is enforced',
+        },
+      ],
+    });
+    expect(repositoryMock.updateOrganisationSecuritySettings).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/tests/unit/swagger.spec.test.ts
+++ b/apps/backend/tests/unit/swagger.spec.test.ts
@@ -108,6 +108,13 @@ const expectedSchemas = [
   'QuizResultOption',
   'QuizAttempt',
   'AttemptAnswer',
+  'OrganisationSecuritySettings',
+  'OrganisationSecuritySettingsEffectivePolicy',
+  'OrganisationSecuritySettingsLimits',
+  'OrganisationSecuritySettingsChangesApply',
+  'OrganisationSecuritySettingsCapabilities',
+  'OrganisationSecuritySettingsResponse',
+  'OrganisationSecuritySettingsUpdateRequest',
   'QuestionType',
   'QuizAttemptStatus',
   'QuizStatus',
@@ -145,6 +152,7 @@ const expectedRequestBodies = [
   'AccountVerifyEmailChange',
   'AuthForgotPassword',
   'AuthResetPassword',
+  'OrganisationSecuritySettingsUpdate',
 ] as const;
 
 const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
@@ -178,6 +186,16 @@ const expectedRouteDocs: Array<[HttpMethod, string, string[]]> = [
   [
     'post',
     '/organisations/{organisationId}/admins/{adminId}/remove',
+    ['200', '400', '401', '403', '404', '409', '422', '429', '500'],
+  ],
+  [
+    'get',
+    '/organisations/{organisationId}/security-settings',
+    ['200', '400', '401', '403', '404', '429', '500'],
+  ],
+  [
+    'patch',
+    '/organisations/{organisationId}/security-settings',
     ['200', '400', '401', '403', '404', '409', '422', '429', '500'],
   ],
   ['get', '/trainee/campaigns', ['200', '401', '429', '500']],
@@ -339,6 +357,24 @@ describe('swaggerSpec', () => {
     expect(JSON.stringify(getPath('/organisation-registration-requests', 'post'))).toContain(
       '"security":[]',
     );
+  });
+
+  it('documents organisation security settings contract details', () => {
+    expectBearerAuth('/organisations/{organisationId}/security-settings', 'get');
+    expectBearerAuth('/organisations/{organisationId}/security-settings', 'patch');
+
+    const responseSchema = JSON.stringify(
+      spec.components?.schemas?.OrganisationSecuritySettingsResponse,
+    );
+    const updateRequest = JSON.stringify(
+      spec.components?.requestBodies?.OrganisationSecuritySettingsUpdate,
+    );
+
+    expect(responseSchema).toContain('settings');
+    expect(responseSchema).toContain('effectivePolicy');
+    expect(responseSchema).toContain('platformLimits');
+    expect(responseSchema).toContain('capabilities');
+    expect(updateRequest).toContain('OrganisationSecuritySettingsUpdateRequest');
   });
 
   it.each(inactiveRouteDocs)('does not document inactive route %s', (path) => {

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -7,3 +7,4 @@ export * from './quizzes.schemas.js';
 export * from './organisation-registration.schemas.js';
 export * from './email-template.schemas.js';
 export * from './organisation-admin.schemas.js';
+export * from './organisation-security-settings.schemas.js';

--- a/packages/shared/src/validation/organisation-security-settings.schemas.ts
+++ b/packages/shared/src/validation/organisation-security-settings.schemas.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+import type { OrganisationSecuritySettingsDto } from '../entities.js';
+
+export const ORGANISATION_SECURITY_SETTINGS_LIMITS = {
+  rememberMe: {
+    maxRememberedSessionHours: {
+      min: 1,
+      max: 720,
+      default: 168,
+      options: [24, 72, 168, 336, 720],
+    },
+  },
+  regularSession: {
+    regularSessionLengthHours: {
+      min: 1,
+      max: 24,
+      default: 8,
+      options: [4, 8, 12, 24],
+    },
+  },
+  idleTimeout: {
+    idleTimeoutMinutes: {
+      min: 5,
+      max: 480,
+      default: 30,
+      options: [15, 30, 60, 120, 240, 480],
+    },
+  },
+} as const;
+
+export type OrganisationSecuritySettingsLimitsDto = typeof ORGANISATION_SECURITY_SETTINGS_LIMITS;
+
+export type OrganisationSecuritySettingsReadOnlyReasonDto =
+  | 'MISSING_PERMISSION'
+  | 'ORGANISATION_SUSPENDED'
+  | 'ORGANISATION_DISABLED'
+  | null;
+
+export type OrganisationSecuritySettingsChangesApplyDto = {
+  rememberMePolicy: 'NEXT_REFRESH_OR_LOGIN';
+  regularSessionLength: 'NEXT_REFRESH_OR_LOGIN';
+  idleTimeout: 'NEXT_REFRESH';
+  requireReauthenticationForSensitiveActions: 'IMMEDIATE_FOR_NEW_ACTIONS';
+  allowTraineeEmailChange: 'IMMEDIATE_FOR_NEW_REQUESTS';
+};
+
+export type OrganisationSecuritySettingsCapabilitiesDto = {
+  canView: boolean;
+  canEdit: boolean;
+  readOnlyReason: OrganisationSecuritySettingsReadOnlyReasonDto;
+  changesApply: OrganisationSecuritySettingsChangesApplyDto;
+};
+
+export type OrganisationSecuritySettingsEffectivePolicyDto = {
+  organisationId: string | null;
+  rememberMeRequested: boolean;
+  rememberMeAllowed: boolean;
+  rememberMeApplied: boolean;
+  regularSessionSeconds: number;
+  rememberedSessionSeconds: number;
+  effectiveSessionSeconds: number;
+  idleTimeoutMinutes: number | null;
+  requireReauthenticationForSensitiveActions: boolean;
+  allowEmailChange: boolean;
+};
+
+export type OrganisationSecuritySettingsResponseDto = {
+  organisationId: string;
+  settings: OrganisationSecuritySettingsDto;
+  effectivePolicy: OrganisationSecuritySettingsEffectivePolicyDto;
+  platformLimits: OrganisationSecuritySettingsLimitsDto;
+  capabilities: OrganisationSecuritySettingsCapabilitiesDto;
+};
+
+function nullableIntegerField(input: {
+  fieldLabel: string;
+  min: number;
+  max: number;
+}): z.ZodNullable<z.ZodNumber> {
+  return z
+    .number({
+      invalid_type_error: `${input.fieldLabel} must be a number or null`,
+    })
+    .int(`${input.fieldLabel} must be a whole number`)
+    .min(input.min, `${input.fieldLabel} must be at least ${input.min}`)
+    .max(input.max, `${input.fieldLabel} must be at most ${input.max}`)
+    .nullable();
+}
+
+const maxRememberedSessionHoursSchema = nullableIntegerField({
+  fieldLabel: 'Maximum remembered session hours',
+  min: ORGANISATION_SECURITY_SETTINGS_LIMITS.rememberMe.maxRememberedSessionHours.min,
+  max: ORGANISATION_SECURITY_SETTINGS_LIMITS.rememberMe.maxRememberedSessionHours.max,
+});
+
+const regularSessionLengthHoursSchema = nullableIntegerField({
+  fieldLabel: 'Regular session length hours',
+  min: ORGANISATION_SECURITY_SETTINGS_LIMITS.regularSession.regularSessionLengthHours.min,
+  max: ORGANISATION_SECURITY_SETTINGS_LIMITS.regularSession.regularSessionLengthHours.max,
+});
+
+const idleTimeoutMinutesSchema = nullableIntegerField({
+  fieldLabel: 'Idle timeout minutes',
+  min: ORGANISATION_SECURITY_SETTINGS_LIMITS.idleTimeout.idleTimeoutMinutes.min,
+  max: ORGANISATION_SECURITY_SETTINGS_LIMITS.idleTimeout.idleTimeoutMinutes.max,
+});
+
+export const updateOrganisationSecuritySettingsRequestSchema = z
+  .object({
+    enforceRememberMePolicy: z.boolean({
+      required_error: 'Remember-me policy enforcement is required',
+      invalid_type_error: 'Remember-me policy enforcement must be true or false',
+    }),
+    allowRememberMe: z.boolean({
+      required_error: 'Remember-me allowance is required',
+      invalid_type_error: 'Remember-me allowance must be true or false',
+    }),
+    maxRememberedSessionHours: maxRememberedSessionHoursSchema,
+    enforceRegularSessionLength: z.boolean({
+      required_error: 'Regular session length enforcement is required',
+      invalid_type_error: 'Regular session length enforcement must be true or false',
+    }),
+    regularSessionLengthHours: regularSessionLengthHoursSchema,
+    enforceIdleTimeout: z.boolean({
+      required_error: 'Idle timeout enforcement is required',
+      invalid_type_error: 'Idle timeout enforcement must be true or false',
+    }),
+    idleTimeoutMinutes: idleTimeoutMinutesSchema,
+    requireReauthenticationForSensitiveActions: z.boolean({
+      required_error: 'Sensitive action reauthentication setting is required',
+      invalid_type_error: 'Sensitive action reauthentication setting must be true or false',
+    }),
+    allowTraineeEmailChange: z.boolean({
+      required_error: 'Trainee email-change setting is required',
+      invalid_type_error: 'Trainee email-change setting must be true or false',
+    }),
+  })
+  .strict()
+  .superRefine((settings, context) => {
+    if (
+      settings.enforceRememberMePolicy &&
+      settings.allowRememberMe &&
+      settings.maxRememberedSessionHours === null
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['maxRememberedSessionHours'],
+        message: 'Maximum remembered session hours is required when remember-me is allowed',
+      });
+    }
+
+    if (
+      (!settings.enforceRememberMePolicy || !settings.allowRememberMe) &&
+      settings.maxRememberedSessionHours !== null
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['maxRememberedSessionHours'],
+        message:
+          'Maximum remembered session hours must be null when remember-me is not enforced or not allowed',
+      });
+    }
+
+    if (settings.enforceRegularSessionLength && settings.regularSessionLengthHours === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['regularSessionLengthHours'],
+        message: 'Regular session length hours is required when regular session length is enforced',
+      });
+    }
+
+    if (!settings.enforceRegularSessionLength && settings.regularSessionLengthHours !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['regularSessionLengthHours'],
+        message: 'Regular session length hours must be null when it is not enforced',
+      });
+    }
+
+    if (settings.enforceIdleTimeout && settings.idleTimeoutMinutes === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['idleTimeoutMinutes'],
+        message: 'Idle timeout minutes is required when idle timeout is enforced',
+      });
+    }
+
+    if (!settings.enforceIdleTimeout && settings.idleTimeoutMinutes !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['idleTimeoutMinutes'],
+        message: 'Idle timeout minutes must be null when idle timeout is not enforced',
+      });
+    }
+  });
+
+export type UpdateOrganisationSecuritySettingsRequestDto = z.infer<
+  typeof updateOrganisationSecuritySettingsRequestSchema
+>;


### PR DESCRIPTION
PR Title: feat: add organisation security settings API

## Summary

Adds the backend API for UC-11 organisation security settings.

This implements endpoints for viewing and updating an organisation’s security settings, including remember-me policy, regular session length, idle timeout, sensitive-action reauthentication, and trainee email-change policy.

The implementation enforces active same-organisation admin access, requires `CHANGE_ORGANISATION_SECURITY_SETTINGS` for updates, validates settings against platform limits, returns frontend capability/read-only metadata, and audit logs settings changes with old and new values.

The response contract also exposes platform limits and save-application timing so the frontend can render disabled controls, validation messages, and notices about when changes apply to existing sessions.

This PR does not include database migrations, frontend implementation, or user account preference endpoints.

## Linked Issue

Closes #287

## Type of change

* [x] Feature
* [ ] Bug Fix
* [ ] Documentation
* [x] Chore/Maintenance

## Testing

Ran:

```bash
pnpm build:shared
pnpm --filter @insightful-phish/backend test -- security-settings
pnpm --filter @insightful-phish/backend test -- security-policy
pnpm --filter @insightful-phish/backend test -- swagger.spec.test.ts
pnpm --filter @insightful-phish/backend test
pnpm typecheck:backend
pnpm build:backend
pnpm lint:backend
git diff --check
```

Verified:

* `GET /organisations/:organisationId/security-settings` returns current settings, platform limits, edit capability metadata, and read-only reasons where applicable.
* `PATCH /organisations/:organisationId/security-settings` validates and persists allowed security setting changes.
* Active same-organisation admin access is required for security settings access.
* Updates require `CHANGE_ORGANISATION_SECURITY_SETTINGS`.
* Suspended or blocked organisation states are handled safely.
* Invalid ranges and conflicting setting combinations return field-specific `422` validation errors.
* Settings changes are audit logged with old and new values.
* Swagger/OpenAPI docs include request bodies, response bodies, validation errors, auth requirements, and expected status codes.

## Review Notes

Reviewers should focus on:

* same-organisation scope checks
* `CHANGE_ORGANISATION_SECURITY_SETTINGS` permission enforcement
* validation limits for remember-me, regular session length, and idle timeout
* conflicting-setting validation, especially enforced settings without valid values
* GET response frontend contract:

  * stored settings
  * platform limits
  * `canEdit`
  * read-only reason
  * application timing
* PATCH response returning saved settings and effective policy metadata
* audit logging old and new values for `SETTINGS_CHANGED`
* Swagger/OpenAPI consistency
* ensuring this PR does not introduce schema migrations or frontend changes

This intentionally does not include the frontend settings page, integration work, user account preference endpoints, or new database schema changes.

## Checklist

* [x] I tested the change locally
* [x] Accessibility impact was considered if applicable
* [x] No unrelated changes are included
* [x] Relevant tests were added or updated if applicable
* [x] Documentation was updated if needed
* [x] No secrets, credentials, or sensitive values were committed
