### PR TITLE
Feat/integrate registration/zoe

### DIFF
--- a/apps/frontend/src/pages/RegisterPage.tsx
+++ b/apps/frontend/src/pages/RegisterPage.tsx
@@ -15,23 +15,74 @@ import {
   authFormStyle,
   authPrimaryButtonStyle,
 } from '../components/auth/authStyles';
-import { authRegisterRequestSchema } from '@insightful-phish/shared';
+import { ApiError } from '../lib/apiClient';
+import { registerUser, resendVerification } from '../services/auth.service';
 
-function formatAlertMessage(message: string) {
-  // makes everything title case and removes the . from the end of the message
-  return message
-    .replace(/\.$/, '')
-    .replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+const duplicateEmailMessage =
+  'An account may already exist for this email. Please log in or request a new verification email.';
+const pendingVerificationMessage =
+  'Please chack your email to verify your account. You can request a new verification email below.';
+const passwordPolicyMesssage = 'Please choose a password that meets the password requirements.';
+const rateLimitMessage = 'Too many attempts. Please wait a moment and try again.';
+const genericErrorMessage = 'Something went wrong. Please try again.';
+
+function validateFrontendRegistrationForm(input: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}) {
+  const payload = {
+    firstName: input.firstName.trim(),
+    lastName: input.lastName.trim(),
+    email: input.email.trim().toLowerCase(),
+    password: input.password,
+    confirmPassword: input.confirmPassword,
+  };
+
+  if (!payload.firstName) return { success: false as const, message: 'PLease Enter A First Name' };
+  if (!payload.lastName) return { success: false as const, message: 'Please Enter A Last Name' };
+  if (!payload.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email)) {
+    return { success: false as const, message: 'PLease Enter A Valid Email Address' };
+  }
+  if (
+    payload.password.length < 12 ||
+    payload.password.length > 128 ||
+    !/[a-z]/.test(payload.password) ||
+    !/[A-Z]/.test(payload.password) ||
+    !/\d/.test(payload.password) ||
+    !/[^\sA-Za-z0-9]/.test(payload.password)
+  ) {
+    return { success: false as const, message: passwordPolicyMesssage };
+  }
+  if (!payload.confirmPassword) {
+    return { success: false as const, message: 'Please Confrim Your Password' };
+  }
+  if (payload.password !== payload.confirmPassword) {
+    return { success: false as const, message: 'Password Conrimation Must Match Password' };
+  }
+
+  return { success: true as const, data: payload };
+}
+
+function getRegistrationErrorMessage(error: unknown) {
+  if (!(error instanceof ApiError)) return genericErrorMessage;
+  if (error.status === 409) return duplicateEmailMessage;
+  if (error.status === 422) return passwordPolicyMesssage;
+  if (error.status === 429) return rateLimitMessage;
+  return genericErrorMessage;
 }
 
 function RegisterPage() {
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isResendingVerification, setIsResendingVerification] = useState(false);
+  const [registeredEmailForVerification, setRegisteredEmailForVerification] = useState('');
   const [alertMessage, setAlertMessage] = useState('');
   const [alertType, setAlertType] = useState<'success' | 'danger'>('danger');
   const [showEmailVerificationModal, setShowEmailVerificationModal] = useState(false);
@@ -41,7 +92,7 @@ function RegisterPage() {
     event.preventDefault();
     setAlertMessage('');
     // setShowSuccessfulRegistrationModal(true); // SHOW THE SUCCESSFULL REGISTRATION MODAL
-    const validationResult = authRegisterRequestSchema.safeParse({
+    const validationResult = validateFrontendRegistrationForm({
       firstName,
       lastName,
       email,
@@ -51,36 +102,50 @@ function RegisterPage() {
 
     if (!validationResult.success) {
       setAlertType('danger');
-      setAlertMessage(
-        formatAlertMessage(validationResult.error.issues[0]?.message) || 'Invalid Input',
-      );
+      setAlertMessage(validationResult.message);
       return;
     }
 
+    const { confirmPassword: _confirmPassword, ...payload } = validationResult.data;
+    void _confirmPassword;
+
     try {
       setIsLoading(true);
-      const response = await fetch(`${API_BASE_URL}/auth/register`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(validationResult.data),
-      });
 
-      const data = await response.json();
+      await registerUser(payload);
 
-      if (!response.ok) {
-        setAlertType('danger');
-        setAlertMessage(formatAlertMessage(data.message) || 'Registration Failed');
-        return;
-      }
-
+      setRegisteredEmailForVerification(payload.email);
+      setAlertType('success');
+      setAlertMessage(pendingVerificationMessage);
       setShowEmailVerificationModal(true);
-    } catch {
+    } catch (error) {
       setAlertType('danger');
-      setAlertMessage('Unable To Connect To The Server');
+      setAlertMessage(getRegistrationErrorMessage(error));
     } finally {
       setIsLoading(false);
+    }
+  }
+
+  async function handleResendVerification() {
+    if (!registeredEmailForVerification || isResendingVerification) {
+      return;
+    }
+
+    setIsResendingVerification(true);
+    setAlertMessage('');
+
+    try {
+      await resendVerification({ email: registeredEmailForVerification });
+
+      setAlertType('success');
+      setAlertMessage(pendingVerificationMessage);
+    } catch (error) {
+      setAlertType('danger');
+      setAlertMessage(
+        error instanceof ApiError && error.status === 429 ? rateLimitMessage : genericErrorMessage,
+      );
+    } finally {
+      setIsResendingVerification(false);
     }
   }
 
@@ -145,9 +210,9 @@ function RegisterPage() {
           {/* EMAIL VERIFICATION MODAL  */}
           <EmailVerificationModal
             isOpen={showEmailVerificationModal}
-            email={email}
+            email={registeredEmailForVerification}
             accountDescription="Individual Trainee"
-            onResend={() => {}}
+            onResend={handleResendVerification}
           />
 
           {/* SUCCESSFUL REGISTRATION MODAL */}

--- a/apps/frontend/src/pages/RegisterPage.tsx
+++ b/apps/frontend/src/pages/RegisterPage.tsx
@@ -43,7 +43,7 @@ function validateFrontendRegistrationForm(input: {
 
   if (!payload.firstName) return { success: false as const, message: 'Please Enter A First Name' };
   if (!payload.lastName) return { success: false as const, message: 'Please Enter A Last Name' };
-  if (!payload.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email)) {
+  if (!payload.email || !payload.email.includes('@') || !payload.email.includes('.')) {
     return { success: false as const, message: 'Please Enter A Valid Email Address' };
   }
   if (

--- a/apps/frontend/src/pages/RegisterPage.tsx
+++ b/apps/frontend/src/pages/RegisterPage.tsx
@@ -106,8 +106,7 @@ function RegisterPage() {
       return;
     }
 
-    const { confirmPassword: _confirmPassword, ...payload } = validationResult.data;
-    void _confirmPassword;
+    const payload = validationResult.data;
 
     try {
       setIsLoading(true);

--- a/apps/frontend/src/pages/RegisterPage.tsx
+++ b/apps/frontend/src/pages/RegisterPage.tsx
@@ -21,7 +21,7 @@ import { registerUser, resendVerification } from '../services/auth.service';
 const duplicateEmailMessage =
   'An account may already exist for this email. Please log in or request a new verification email.';
 const pendingVerificationMessage =
-  'Please chack your email to verify your account. You can request a new verification email below.';
+  'Please check your email to verify your account. You can request a new verification email below.';
 const passwordPolicyMesssage = 'Please choose a password that meets the password requirements.';
 const rateLimitMessage = 'Too many attempts. Please wait a moment and try again.';
 const genericErrorMessage = 'Something went wrong. Please try again.';
@@ -41,10 +41,10 @@ function validateFrontendRegistrationForm(input: {
     confirmPassword: input.confirmPassword,
   };
 
-  if (!payload.firstName) return { success: false as const, message: 'PLease Enter A First Name' };
+  if (!payload.firstName) return { success: false as const, message: 'Please Enter A First Name' };
   if (!payload.lastName) return { success: false as const, message: 'Please Enter A Last Name' };
   if (!payload.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email)) {
-    return { success: false as const, message: 'PLease Enter A Valid Email Address' };
+    return { success: false as const, message: 'Please Enter A Valid Email Address' };
   }
   if (
     payload.password.length < 12 ||
@@ -57,10 +57,10 @@ function validateFrontendRegistrationForm(input: {
     return { success: false as const, message: passwordPolicyMesssage };
   }
   if (!payload.confirmPassword) {
-    return { success: false as const, message: 'Please Confrim Your Password' };
+    return { success: false as const, message: 'Please Confirm Your Password' };
   }
   if (payload.password !== payload.confirmPassword) {
-    return { success: false as const, message: 'Password Conrimation Must Match Password' };
+    return { success: false as const, message: 'Password Confirmation Must Match Password' };
   }
 
   return { success: true as const, data: payload };

--- a/apps/frontend/src/pages/SetupPage.tsx
+++ b/apps/frontend/src/pages/SetupPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { FormEvent } from 'react';
+import type { FormEvent, ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import type { SetupTokenContextResponseDto } from '@insightful-phish/shared';
 import BasicAlert from '../components/alerts/BasicAlert';
@@ -14,11 +14,16 @@ import { completeSetupWithToken, getSetupTokenContext } from '../services/auth.s
 
 const invalidTokenMessage = 'This setup link is invalid. Please request a new invitation.';
 const expiredTokenMessage = 'This setup link has expired. Please request a new invitation.';
+const staleTokenMessage = 'This setup link is no longer valid. Please request a new invitation.';
 const usedTokenMessage = 'This setup link has already been used. Please log in instead.';
+const invitationNotAcceptableMessage =
+  'This invitation can no longer be used. Please request a new invitation.';
 const suspendedOrganisationMessage =
   'This organisation is not currently accepting setup requests. Please contact support.';
 const roleConflictMessage =
   'This invitation cannot be completed because the account already has a conflicting role.';
+const setupCannotBeCompletedMessage =
+  'This setup cannot be completed. Please request a new invitation or contact support.';
 const passwordPolicyMessage = 'Please choose a password that meets the password requirements.';
 const rateLimitMessage = 'Too many attempts. Please wait a moment and try again.';
 const genericErrorMessage = 'Something went wrong. Please try again.';
@@ -74,20 +79,44 @@ function getSetupErrorCode(error: ApiError): string | null {
 function getSetupErrorMessage(error: unknown) {
   if (!(error instanceof ApiError)) return genericErrorMessage;
 
-  const errorCode = getSetupErrorCode(error);
+  const codedMessage = getSetupErrorMessageForCode(getSetupErrorCode(error));
+  if (codedMessage) return codedMessage;
 
-  if (errorCode === 'SETUP_TOKEN_EXPIRED') return expiredTokenMessage;
-  if (errorCode === 'SETUP_TOKEN_USED') return usedTokenMessage;
-  if (errorCode === 'SETUP_ROLE_CONFLICT') return roleConflictMessage;
-  if (errorCode?.startsWith('ORGANISATION')) return suspendedOrganisationMessage;
   if (error.status === 401) return invalidTokenMessage;
   if (error.status === 403) return suspendedOrganisationMessage;
   if (error.status === 404) return invalidTokenMessage;
-  if (error.status === 409) return roleConflictMessage;
+  if (error.status === 409) return setupCannotBeCompletedMessage;
   if (error.status === 422) return passwordPolicyMessage;
   if (error.status === 429) return rateLimitMessage;
 
   return genericErrorMessage;
+}
+
+function getSetupErrorMessageForCode(errorCode: string | null) {
+  if (!errorCode) return null;
+  if (errorCode.startsWith('ORGANISATION')) return suspendedOrganisationMessage;
+
+  switch (errorCode) {
+    case 'SETUP_ROLE_CONFLICT':
+      return roleConflictMessage;
+    case 'SETUP_INVITATION_EXPIRED':
+    case 'SETUP_TOKEN_EXPIRED':
+      return expiredTokenMessage;
+    case 'SETUP_TOKEN_STALE':
+      return staleTokenMessage;
+    case 'SETUP_INVITATION_NOT_ACCEPTABLE':
+      return invitationNotAcceptableMessage;
+    case 'SETUP_INVITATION_MISSING':
+    case 'SETUP_TARGET_EMAIL_MISSING':
+    case 'SETUP_TOKEN_PURPOSE_UNSUPPORTED':
+      return invalidTokenMessage;
+    case 'SETUP_ORGANISATION_MISSING':
+      return suspendedOrganisationMessage;
+    case 'SETUP_TOKEN_USED':
+      return usedTokenMessage;
+    default:
+      return null;
+  }
 }
 
 function tokenStateMessafe(state?: string) {
@@ -210,6 +239,89 @@ function SetupPage() {
     }
   }
 
+  let setupContent: ReactNode = null;
+
+  if (isLoadingContext) {
+    setupContent = <p style={{ color: 'white', fontFamily: 'Overpass' }}>Loading setup link...</p>;
+  } else if (isComplete) {
+    setupContent = (
+      <Link to="/login" style={{ color: '#cca7ff', fontFamily: 'Jost', fontSize: '1.3rem' }}>
+        Go to login
+      </Link>
+    );
+  } else if (context?.token.state === 'VALID') {
+    setupContent = (
+      <form onSubmit={handleCompleteSetup} noValidate style={authFormStyle}>
+        <div style={{ ...authFieldRowStyle, marginBottom: '1.8rem' }}>
+          <AuthFormField
+            label="First Name(s)"
+            type="text"
+            disabled={isBusy}
+            value={firstName}
+            onChange={(event) => setFirstName(event.target.value)}
+            autoComplete="given-name"
+            wrapperStyle={{ flex: 1 }}
+          />
+          <AuthFormField
+            label="Last Name"
+            type="text"
+            value={lastName}
+            disabled={isBusy}
+            onChange={(event) => setLastName(event.target.value)}
+            autoComplete="family-name"
+            wrapperStyle={{ flex: 1 }}
+          />
+        </div>
+
+        <AuthFormField
+          label="Email Address"
+          type="email"
+          value={email}
+          disabled
+          onChange={() => {}}
+          autoComplete="email"
+          wrapperStyle={{ marginBottom: '1.8rem' }}
+        />
+
+        <div style={{ ...authFieldRowStyle, marginBottom: '2.5rem' }}>
+          <AuthFormField
+            label="Password"
+            type="password"
+            value={password}
+            disabled={isBusy}
+            onChange={(event) => setPassword(event.target.value)}
+            autoComplete="new-password"
+            wrapperStyle={{ flex: 1 }}
+          />
+          <AuthFormField
+            label="Confirm Password"
+            type="password"
+            value={confirmPassword}
+            disabled={isBusy}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            autoComplete="new-password"
+            wrapperStyle={{ flex: 1 }}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isBusy}
+          style={{
+            ...authPrimaryButtonStyle,
+            width: '48%',
+            height: '60px',
+            fontSize: '1.7rem',
+            cursor: isBusy ? 'not-allowed' : 'pointer',
+            opacity: isBusy ? 0.6 : 1,
+          }}
+        >
+          {isSubmitting ? 'Completing Setup...' : 'Complete Setup'}
+        </button>
+      </form>
+    );
+  }
+
   return (
     <AuthPageFrame
       leftWidth="78%"
@@ -230,82 +342,7 @@ function SetupPage() {
             </BasicAlert>
           )}
 
-          {isLoadingContext ? (
-            <p style={{ color: 'white', fontFamily: 'Overpass' }}>Loading setup link...</p>
-          ) : isComplete ? (
-            <Link to="/login" style={{ color: '#cca7ff', fontFamily: 'Jost', fontSize: '1.3rem' }}>
-              Go to login
-            </Link>
-          ) : context?.token.state === 'VALID' ? (
-            <form onSubmit={handleCompleteSetup} noValidate style={authFormStyle}>
-              <div style={{ ...authFieldRowStyle, marginBottom: '1.8rem' }}>
-                <AuthFormField
-                  label="First Name(s)"
-                  type="text"
-                  disabled={isBusy}
-                  value={firstName}
-                  onChange={(event) => setFirstName(event.target.value)}
-                  autoComplete="given-name"
-                  wrapperStyle={{ flex: 1 }}
-                />
-                <AuthFormField
-                  label="Last Name"
-                  type="text"
-                  value={lastName}
-                  disabled={isBusy}
-                  onChange={(event) => setLastName(event.target.value)}
-                  autoComplete="family-name"
-                  wrapperStyle={{ flex: 1 }}
-                />
-              </div>
-
-              <AuthFormField
-                label="Email Address"
-                type="email"
-                value={email}
-                disabled
-                onChange={() => {}}
-                autoComplete="email"
-                wrapperStyle={{ marginBottom: '1.8rem' }}
-              />
-
-              <div style={{ ...authFieldRowStyle, marginBottom: '2.5rem' }}>
-                <AuthFormField
-                  label="Password"
-                  type="password"
-                  value={password}
-                  disabled={isBusy}
-                  onChange={(event) => setPassword(event.target.value)}
-                  autoComplete="new-password"
-                  wrapperStyle={{ flex: 1 }}
-                />
-                <AuthFormField
-                  label="Confirm Password"
-                  type="password"
-                  value={confirmPassword}
-                  disabled={isBusy}
-                  onChange={(event) => setConfirmPassword(event.target.value)}
-                  autoComplete="new-password"
-                  wrapperStyle={{ flex: 1 }}
-                />
-              </div>
-
-              <button
-                type="submit"
-                disabled={isBusy}
-                style={{
-                  ...authPrimaryButtonStyle,
-                  width: '48%',
-                  height: '60px',
-                  fontSize: '1.7rem',
-                  cursor: isBusy ? 'not-allowed' : 'pointer',
-                  opacity: isBusy ? 0.6 : 1,
-                }}
-              >
-                {isSubmitting ? 'Completing Setup...' : 'Complete Setup'}
-              </button>
-            </form>
-          ) : null}
+          {setupContent}
         </>
       }
       rightChildren={

--- a/apps/frontend/src/pages/SetupPage.tsx
+++ b/apps/frontend/src/pages/SetupPage.tsx
@@ -1,0 +1,319 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { SetupTokenContextResponseDto } from '@insightful-phish/shared';
+import BasicAlert from '../components/alerts/BasicAlert';
+import { AuthFormField, AuthPageFrame, AuthPageIntro } from '../components/auth/AuthPrimitives';
+import {
+  authFieldRowStyle,
+  authFormStyle,
+  authPrimaryButtonStyle,
+} from '../components/auth/authStyles';
+import { ApiError } from '../lib/apiClient';
+import { completeSetupWithToken, getSetupTokenContext } from '../services/auth.service';
+
+const invalidTokenMessage = 'This setup link is invalid. Please request a new invitation.';
+const expiredTokenMessage = 'This setup link has expired. Please request a new invitation.';
+const usedTokenMessage = 'This setup link has already been used. Please log in instead.';
+const suspendedOrganisationMessage =
+  'This organisation is not currently accepting setup requests. Please contact support.';
+const roleConflictMessage =
+  'This invitation cannot be completed because the account already has a conflicting role.';
+const passwordPolicyMessage = 'Please choose a password that meets the password requirements.';
+const rateLimitMessage = 'Too many attempts. Please wait a moment and try again.';
+const genericErrorMessage = 'Something went wrong. Please try again.';
+
+function validateSetupForm(input: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}) {
+  const data = {
+    firstName: input.firstName.trim(),
+    lastName: input.lastName.trim(),
+    email: input.email.trim().toLowerCase(),
+    password: input.password,
+    confirmPassword: input.confirmPassword,
+  };
+
+  if (!data.firstName) return { success: false as const, message: 'PLease Enter A First Name ' };
+  if (!data.lastName) return { success: false as const, message: 'PLease Enter A Last Name ' };
+  if (!data.email) return { success: false as const, message: invalidTokenMessage };
+  if (
+    data.password.length < 12 ||
+    data.password.length > 128 ||
+    !/[a-z]/.test(data.password) ||
+    !/[A-Z]/.test(data.password) ||
+    !/\d/.test(data.password) ||
+    !/[^\sA-Za-z0-9]/.test(data.password)
+  ) {
+    return { success: false as const, message: passwordPolicyMessage };
+  }
+  if (!data.confirmPassword) {
+    return { success: false as const, message: 'Please Confrim Your Password' };
+  }
+  if (data.password !== data.confirmPassword) {
+    return { success: false as const, message: 'Password Conrimation Must Match Password' };
+  }
+
+  return { success: true as const, data };
+}
+
+function getSetupErrorCode(error: ApiError): string | null {
+  const body = error.body;
+
+  if (body && typeof body === 'object' && 'error' in body) {
+    const code = (body as { error?: unknown }).error;
+    return typeof code === 'string' ? code : null;
+  }
+  return null;
+}
+
+function getSetupErrorMessage(error: unknown) {
+  if (!(error instanceof ApiError)) return genericErrorMessage;
+
+  const errorCode = getSetupErrorCode(error);
+
+  if (errorCode === 'SETUP_TOKEN_EXPIRED') return expiredTokenMessage;
+  if (errorCode === 'SETUP_TOKEN_USED') return usedTokenMessage;
+  if (errorCode === 'SETUP_ROLE_CONFLICT') return roleConflictMessage;
+  if (errorCode?.startsWith('ORGANISATION')) return suspendedOrganisationMessage;
+  if (error.status === 401) return invalidTokenMessage;
+  if (error.status === 403) return suspendedOrganisationMessage;
+  if (error.status === 404) return invalidTokenMessage;
+  if (error.status === 409) return roleConflictMessage;
+  if (error.status === 422) return passwordPolicyMessage;
+  if (error.status === 429) return rateLimitMessage;
+
+  return genericErrorMessage;
+}
+
+function tokenStateMessafe(state?: string) {
+  if (state === 'EXPIRED') return expiredTokenMessage;
+  if (state === 'USED') return usedTokenMessage;
+  if (state === 'REVOKED' || state === 'INVALID') return invalidTokenMessage;
+  return genericErrorMessage;
+}
+
+function roleLabel(role?: string) {
+  if (role === 'ORGANISATION_ADMIN') return 'Organisation Admin';
+  if (role == 'ORGANISATION_TRAINEE') return 'Organisation Trainee';
+  if (role === 'IP_ADMIN') return 'Platform Admin';
+  return 'Invited User';
+}
+
+function SetupPage() {
+  const { token } = useParams<{ token: string }>();
+  const [context, setContext] = useState<SetupTokenContextResponseDto | null>(null);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [alertMessage, setAlertMessage] = useState('');
+  const [alertType, setAlertType] = useState<'success' | 'danger'>('danger');
+  const [isLoadingContext, setIsLoadingContext] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+
+  const email = context?.targetEmail ?? '';
+  const isBusy = isLoadingContext || isSubmitting;
+  const contextMessage = useMemo(() => {
+    if (!context) return null;
+    const role = roleLabel(context.role);
+    return context.organisationName ? `${role} for ${context.organisationName}` : role;
+  }, [context]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadContext() {
+      if (!token) {
+        setAlertType('danger');
+        setAlertMessage(invalidTokenMessage);
+        setIsLoadingContext(false);
+        return;
+      }
+
+      try {
+        const data = await getSetupTokenContext(token);
+        if (!isMounted) return;
+
+        setContext(data);
+
+        if (data.token.state !== 'VALID') {
+          setAlertType('danger');
+          setAlertMessage(tokenStateMessafe(data.token.state));
+          return;
+        }
+
+        setFirstName(data.targetFirstName ?? '');
+        setLastName(data.targetLastName ?? '');
+      } catch (error) {
+        if (!isMounted) return;
+        setAlertMessage(getSetupErrorMessage(error));
+      } finally {
+        if (!isMounted) setIsLoadingContext(false);
+      }
+    }
+
+    void loadContext();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [token]);
+
+  async function handleCompleteSetup(event: FormEvent) {
+    event.preventDefault();
+    setAlertMessage('');
+
+    const validationResult = validateSetupForm({
+      firstName,
+      lastName,
+      email,
+      password,
+      confirmPassword,
+    });
+
+    if (!validationResult.success) {
+      setAlertType('danger');
+      setAlertMessage(validationResult.message);
+      return;
+    }
+
+    if (!token || context?.token.state !== 'VALID') {
+      setAlertType('danger');
+      setAlertMessage(invalidTokenMessage);
+      return;
+    }
+
+    const { confirmPassword: _confirmPassword, email: _email, ...payload } = validationResult.data;
+    void _confirmPassword;
+    void _email;
+
+    try {
+      setIsSubmitting(true);
+      await completeSetupWithToken(token, payload);
+      setAlertType('success');
+      setAlertMessage('Setup complete. you can now log in.');
+      setIsComplete(true);
+    } catch (error) {
+      setAlertType('danger');
+      setAlertMessage(getSetupErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthPageFrame
+      leftWidth="78%"
+      rightWidth="22%"
+      rightPanelStyle={{ padding: '2rem' }}
+      leftChildren={
+        <>
+          <AuthPageIntro
+            title="Complete Setup"
+            message={contextMessage}
+            dividerStyle={{ marginBottom: '1rem' }}
+            messageStyle={{ marginBottom: '1rem' }}
+          />
+
+          {alertMessage && (
+            <BasicAlert variant={alertType} onClose={() => setAlertMessage('')}>
+              {alertMessage}
+            </BasicAlert>
+          )}
+
+          {isLoadingContext ? (
+            <p style={{ color: 'white', fontFamily: 'Overpass' }}>Loading setup link...</p>
+          ) : isComplete ? (
+            <Link to="/login" style={{ color: '#cca7ff', fontFamily: 'Jost', fontSize: '1.3rem' }}>
+              Go to login
+            </Link>
+          ) : context?.token.state === 'VALID' ? (
+            <form onSubmit={handleCompleteSetup} noValidate style={authFormStyle}>
+              <div style={{ ...authFieldRowStyle, marginBottom: '1.8rem' }}>
+                <AuthFormField
+                  label="First Name(s)"
+                  type="text"
+                  disabled={isBusy}
+                  value={firstName}
+                  onChange={(event) => setFirstName(event.target.value)}
+                  autoComplete="given-name"
+                  wrapperStyle={{ flex: 1 }}
+                />
+                <AuthFormField
+                  label="Last Name"
+                  type="text"
+                  value={lastName}
+                  disabled={isBusy}
+                  onChange={(event) => setLastName(event.target.value)}
+                  autoComplete="family-name"
+                  wrapperStyle={{ flex: 1 }}
+                />
+              </div>
+
+              <AuthFormField
+                label="Email Address"
+                type="email"
+                value={email}
+                disabled
+                onChange={() => {}}
+                autoComplete="email"
+                wrapperStyle={{ marginBottom: '1.8rem' }}
+              />
+
+              <div style={{ ...authFieldRowStyle, marginBottom: '2.5rem' }}>
+                <AuthFormField
+                  label="Password"
+                  type="password"
+                  value={password}
+                  disabled={isBusy}
+                  onChange={(event) => setPassword(event.target.value)}
+                  autoComplete="new-password"
+                  wrapperStyle={{ flex: 1 }}
+                />
+                <AuthFormField
+                  label="Confirm Password"
+                  type="password"
+                  value={confirmPassword}
+                  disabled={isBusy}
+                  onChange={(event) => setConfirmPassword(event.target.value)}
+                  autoComplete="new-password"
+                  wrapperStyle={{ flex: 1 }}
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={isBusy}
+                style={{
+                  ...authPrimaryButtonStyle,
+                  width: '48%',
+                  height: '60px',
+                  fontSize: '1.7rem',
+                  cursor: isBusy ? 'not-allowed' : 'pointer',
+                  opacity: isBusy ? 0.6 : 1,
+                }}
+              >
+                {isSubmitting ? 'Completing Setup...' : 'Complete Setup'}
+              </button>
+            </form>
+          ) : null}
+        </>
+      }
+      rightChildren={
+        <img
+          src="/logo-motto.png"
+          alt="Insightful Phish Logo"
+          style={{ width: '100%', maxWidth: '300px' }}
+        />
+      }
+    />
+  );
+}
+
+export default SetupPage;

--- a/apps/frontend/src/pages/SetupPage.tsx
+++ b/apps/frontend/src/pages/SetupPage.tsx
@@ -189,9 +189,12 @@ function SetupPage() {
       return;
     }
 
-    const { confirmPassword: _confirmPassword, email: _email, ...payload } = validationResult.data;
-    void _confirmPassword;
-    void _email;
+    const payload = {
+      firstName: validationResult.data.firstName,
+      lastName: validationResult.data.lastName,
+      password: validationResult.data.password,
+      confirmPassword: validationResult.data.confirmPassword,
+    };
 
     try {
       setIsSubmitting(true);

--- a/apps/frontend/src/pages/SetupPage.tsx
+++ b/apps/frontend/src/pages/SetupPage.tsx
@@ -38,8 +38,8 @@ function validateSetupForm(input: {
     confirmPassword: input.confirmPassword,
   };
 
-  if (!data.firstName) return { success: false as const, message: 'PLease Enter A First Name ' };
-  if (!data.lastName) return { success: false as const, message: 'PLease Enter A Last Name ' };
+  if (!data.firstName) return { success: false as const, message: 'Please Enter A First Name ' };
+  if (!data.lastName) return { success: false as const, message: 'Please Enter A Last Name ' };
   if (!data.email) return { success: false as const, message: invalidTokenMessage };
   if (
     data.password.length < 12 ||
@@ -52,10 +52,10 @@ function validateSetupForm(input: {
     return { success: false as const, message: passwordPolicyMessage };
   }
   if (!data.confirmPassword) {
-    return { success: false as const, message: 'Please Confrim Your Password' };
+    return { success: false as const, message: 'Please Confirm Your Password' };
   }
   if (data.password !== data.confirmPassword) {
-    return { success: false as const, message: 'Password Conrimation Must Match Password' };
+    return { success: false as const, message: 'Password Confirmation Must Match Password' };
   }
 
   return { success: true as const, data };
@@ -154,7 +154,7 @@ function SetupPage() {
         if (!isMounted) return;
         setAlertMessage(getSetupErrorMessage(error));
       } finally {
-        if (!isMounted) setIsLoadingContext(false);
+        if (isMounted) setIsLoadingContext(false);
       }
     }
 
@@ -197,7 +197,7 @@ function SetupPage() {
       setIsSubmitting(true);
       await completeSetupWithToken(token, payload);
       setAlertType('success');
-      setAlertMessage('Setup complete. you can now log in.');
+      setAlertMessage('Setup complete. You can now log in.');
       setIsComplete(true);
     } catch (error) {
       setAlertType('danger');

--- a/apps/frontend/src/pages/testing/RegisterPage.test.tsx
+++ b/apps/frontend/src/pages/testing/RegisterPage.test.tsx
@@ -1,12 +1,17 @@
 import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '../../lib/apiClient';
+import { registerUser, resendVerification } from '../../services/auth.service';
 import RegisterPage from '../RegisterPage';
 
-const navigateMock = vi.fn();
-const fetchMock = vi.fn();
+const { navigateMock, registerUserMock, resendVerificationMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  registerUserMock: vi.fn(),
+  resendVerificationMock: vi.fn(),
+}));
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -16,6 +21,11 @@ vi.mock('react-router-dom', async () => {
     useNavigate: () => navigateMock,
   };
 });
+
+vi.mock('../../services/auth.service', () => ({
+  registerUser: registerUserMock,
+  resendVerification: resendVerificationMock,
+}));
 
 function renderRegisterPage() {
   return render(
@@ -34,13 +44,14 @@ async function fillRegistrationForm(user: ReturnType<typeof userEvent.setup>) {
 describe('RegisterPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    fetchMock.mockReset();
-    vi.stubGlobal('fetch', fetchMock);
+    registerUserMock.mockReset();
+    resendVerificationMock.mockReset();
+    registerUserMock.mockResolvedValue({ message: 'Registration accepted' });
+    resendVerificationMock.mockResolvedValue({ success: true });
   });
 
   afterEach(() => {
     cleanup();
-    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -57,7 +68,7 @@ describe('RegisterPage', () => {
     await user.click(screen.getByRole('button', { name: /register/i }));
 
     expect(screen.getByText('Please Enter A Valid Email Address')).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(registerUser).not.toHaveBeenCalled();
   });
 
   it('blocks submission when the confirmation password does not match', async () => {
@@ -71,58 +82,56 @@ describe('RegisterPage', () => {
     await user.click(screen.getByRole('button', { name: /register/i }));
 
     expect(screen.getByText('Password Confirmation Must Match Password')).toBeInTheDocument();
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(registerUser).not.toHaveBeenCalled();
   });
 
   it('submits the registration details and shows the email verification modal on success', async () => {
     const user = userEvent.setup();
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        user: {
-          id: 'user-1',
-        },
-      }),
-    });
 
     renderRegisterPage();
 
     await fillRegistrationForm(user);
-    await user.type(screen.getByLabelText(/^password$/i), 'ThisIsA$Gang$StrongPassword!42069');
-    await user.type(
-      screen.getByLabelText(/confirm password/i),
-      'ThisIsA$Gang$StrongPassword!42069',
-    );
+    await user.type(screen.getByLabelText(/^password$/i), 'ThisIsA$StrongPassword!301301!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'ThisIsA$StrongPassword!301301!');
 
     await user.click(screen.getByRole('button', { name: /Register/i }));
 
+    expect(registerUser).toHaveBeenCalledWith({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'trainee@example.com',
+      password: 'ThisIsA$StrongPassword!301301!',
+    });
+    expect(registerUserMock.mock.calls[0][0]).not.toHaveProperty('confirmPassword');
     expect(
       await screen.findByRole('heading', { name: /Check your Email Inbox/i }),
     ).toBeInTheDocument();
   });
 
-  it('shows the backend error message when registration fails', async () => {
+  it('shows a safe message when registration fails with a duplicate email conflict', async () => {
     const user = userEvent.setup();
-    fetchMock.mockResolvedValue({
-      ok: false,
-      json: async () => ({ message: 'registration failed' }),
-    });
+    registerUserMock.mockRejectedValue(
+      new ApiError('Conflict', {
+        status: 409,
+        statusText: 'Conflict',
+        method: 'POST',
+        url: '/auth/register',
+      }),
+    );
+
     renderRegisterPage();
     await fillRegistrationForm(user);
 
-    await user.type(screen.getByLabelText(/^password$/i), 'ThisIsA$Gang$StrongPassword!42069!');
-    await user.type(
-      screen.getByLabelText(/confirm password/i),
-      'ThisIsA$Gang$StrongPassword!42069!',
-    );
+    await user.type(screen.getByLabelText(/^password$/i), 'ThisIsA$StrongPassword!301301!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'ThisIsA$StrongPassword!301301!');
     await user.click(screen.getByRole('button', { name: /Register/i }));
 
-    expect(await screen.findByText('Registration Failed')).toBeInTheDocument();
+    expect(await screen.findByText(/An account may already exist/i)).toBeInTheDocument();
   });
 
   it('shows an error when the server cannot be reached', async () => {
     const user = userEvent.setup();
-    fetchMock.mockRejectedValue(new Error('Network Error'));
+    registerUserMock.mockRejectedValue(new Error('Network Error'));
 
     renderRegisterPage();
     await fillRegistrationForm(user);
@@ -133,18 +142,18 @@ describe('RegisterPage', () => {
     );
     await user.click(screen.getByRole('button', { name: /Register/i }));
 
-    expect(await screen.findByText('Unable To Connect To The Server')).toBeInTheDocument();
+    expect(await screen.findByText('Something went wrong. Please try again.')).toBeInTheDocument();
   });
 
   it('shows a loading state while the registration request is in progress', async () => {
     const user = userEvent.setup();
 
-    let resolveFetch!: (value: unknown) => void;
+    let resolveRegister!: (value: unknown) => void;
 
-    fetchMock.mockImplementation(
+    registerUserMock.mockImplementation(
       () =>
         new Promise((resolve) => {
-          resolveFetch = resolve;
+          resolveRegister = resolve;
         }),
     );
 
@@ -159,12 +168,7 @@ describe('RegisterPage', () => {
 
     expect(screen.getByRole('button', { name: /Creating Account.../i })).toBeDisabled();
 
-    resolveFetch({
-      ok: true,
-      json: async () => ({
-        user: { id: 'user-1' },
-      }),
-    });
+    resolveRegister({ message: 'Registration accepted' });
 
     await screen.findByRole('heading', { name: /Check your Email Inbox/i });
   });
@@ -172,12 +176,12 @@ describe('RegisterPage', () => {
   it('disables the form fields while the registration request is in progress', async () => {
     const user = userEvent.setup();
 
-    let resolveFetch!: (value: unknown) => void;
+    let resolveRegister!: (value: unknown) => void;
 
-    fetchMock.mockImplementation(
+    registerUserMock.mockImplementation(
       () =>
         new Promise((resolve) => {
-          resolveFetch = resolve;
+          resolveRegister = resolve;
         }),
     );
 
@@ -196,13 +200,68 @@ describe('RegisterPage', () => {
     expect(screen.getByLabelText(/^password$/i)).toBeDisabled();
     expect(screen.getByLabelText(/confirm password/i)).toBeDisabled();
 
-    resolveFetch({
-      ok: true,
-      json: async () => ({
-        user: { id: 'user-1' },
-      }),
-    });
+    resolveRegister({ message: 'Registration accepted' });
 
     await screen.findByRole('heading', { name: /Check your Email Inbox/i });
+  });
+
+  it('resend verification using the normalised registered email', async () => {
+    const user = userEvent.setup();
+
+    renderRegisterPage();
+    await fillRegistrationForm(user);
+    await user.type(screen.getByLabelText(/^password$/i), 'ThisIsA$Gang$StrongPassword!42069!');
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      'ThisIsA$Gang$StrongPassword!42069!',
+    );
+    await user.click(screen.getByRole('button', { name: /Register/i }));
+
+    await user.click(
+      await screen.findByRole('button', { name: /Resend Email Verification Link/i }),
+    );
+
+    await waitFor(
+      () => {
+        expect(resendVerification).toHaveBeenCalledWith({
+          email: 'trainee@example.com',
+        });
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it('shows a rate-limit message wehn resend verification is rate limited', async () => {
+    const user = userEvent.setup();
+
+    resendVerificationMock.mockRejectedValue(
+      new ApiError('Too many attempts', {
+        status: 429,
+        statusText: 'Too Many Requests',
+        method: 'POST',
+        url: '/auth/resend-verification',
+      }),
+    );
+
+    renderRegisterPage();
+    await fillRegistrationForm(user);
+    await user.type(screen.getByLabelText(/^password$/i), 'ThisIsA$Gang$StrongPassword!42069!');
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      'ThisIsA$Gang$StrongPassword!42069!',
+    );
+    await user.click(screen.getByRole('button', { name: /Register/i }));
+
+    await user.click(
+      await screen.findByRole('button', { name: /Resend Email Verification Link/i }),
+    );
+
+    expect(
+      await screen.findByText(
+        'Too many attempts. Please wait a moment and try again.',
+        {},
+        { timeout: 3000 },
+      ),
+    ).toBeInTheDocument();
   });
 }); //describe

--- a/apps/frontend/src/pages/testing/RegisterPage.test.tsx
+++ b/apps/frontend/src/pages/testing/RegisterPage.test.tsx
@@ -101,8 +101,12 @@ describe('RegisterPage', () => {
       lastName: 'Doe',
       email: 'trainee@example.com',
       password: 'ThisIsA$StrongPassword!301301!',
+      confirmPassword: 'ThisIsA$StrongPassword!301301!',
     });
-    expect(registerUserMock.mock.calls[0][0]).not.toHaveProperty('confirmPassword');
+    expect(registerUserMock.mock.calls[0][0]).toHaveProperty(
+      'confirmPassword',
+      'ThisIsA$StrongPassword!301301!',
+    );
     expect(
       await screen.findByRole('heading', { name: /Check your Email Inbox/i }),
     ).toBeInTheDocument();

--- a/apps/frontend/src/pages/testing/SetupPage.test.tsx
+++ b/apps/frontend/src/pages/testing/SetupPage.test.tsx
@@ -1,0 +1,141 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '../../lib/apiClient';
+import { renderWithRouter } from '../../testing/render';
+import { completeSetupWithToken, getSetupTokenContext } from '../../services/auth.service';
+import SetupPage from '../SetupPage';
+
+const { getSetupTokenContextMock, completeSetupWithTokenMock } = vi.hoisted(() => ({
+  getSetupTokenContextMock: vi.fn(),
+  completeSetupWithTokenMock: vi.fn(),
+}));
+
+vi.mock('../../services/auth.service', () => ({
+  getSetupTokenContext: getSetupTokenContextMock,
+  completeSetupWithToken: completeSetupWithTokenMock,
+}));
+
+const setupToken = 'exampleSetupTokenValuewithAtLeast32Chars';
+const strongPassword = 'ThisIsA$StrongPassword!301301!';
+
+function renderSetupPage() {
+  return renderWithRouter(<SetupPage />, {
+    initialEntry: `/setup/token/${setupToken}`,
+    routePath: '/setup/token/:token',
+  });
+}
+
+describe('SetupPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getSetupTokenContextMock.mockResolvedValue({
+      token: {
+        state: 'VALID',
+        purpose: 'ORGANISATION_TRAINEE_INVITE',
+      },
+      targetEmail: 'invitee@example.com',
+      targetFirstName: 'Jane',
+      targetLastName: 'Doe',
+      role: 'ORGANISATION_TRAINEE',
+      organisationName: 'Example Organisation',
+    });
+
+    completeSetupWithTokenMock.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'invitee@example.com',
+        userType: 'ORGANISATION_TRAINEE',
+        authStatus: 'ACTIVE',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('loads setup token context and disable the authoritative email input', async () => {
+    renderSetupPage();
+
+    expect(getSetupTokenContext).toHaveBeenCalledWith(setupToken);
+    expect(await screen.findByDisplayValue('invitee@example.com')).toBeDisabled();
+    expect(screen.getByText('Organisation Trainee for Example Organisation')).toBeInTheDocument();
+  });
+
+  it('blocks submit when password and confirm password do not match', async () => {
+    const user = userEvent.setup();
+
+    renderSetupPage();
+
+    await screen.findByDisplayValue('invitee@example.com');
+    await user.type(screen.getByLabelText(/^password$/i), strongPassword);
+    await user.type(screen.getByLabelText(/confirm password/i), 'DifferentPass123!');
+    await user.click(screen.getByRole('button', { name: /complete setup/i }));
+
+    expect(screen.getByText('Password Confirmation Must Match Password')).toBeInTheDocument();
+    expect(completeSetupWithToken).not.toHaveBeenCalled();
+  });
+
+  it('completes setup without sending email or confirmPassword', async () => {
+    const user = userEvent.setup();
+
+    renderSetupPage();
+
+    await screen.findByDisplayValue('invitee@example.com');
+    await user.clear(screen.getByLabelText(/first name\(s\)/i));
+    await user.type(screen.getByLabelText(/first name\(s\)/i), 'Janet');
+    await user.clear(screen.getByLabelText(/last name/i));
+    await user.type(screen.getByLabelText(/last name/i), 'Doe');
+    await user.type(screen.getByLabelText(/^password$/i), strongPassword);
+    await user.type(screen.getByLabelText(/confirm password/i), strongPassword);
+    await user.click(screen.getByRole('button', { name: /complete setup/i }));
+
+    expect(completeSetupWithToken).toHaveBeenCalledWith(setupToken, {
+      firstName: 'Janet',
+      lastName: 'Doe',
+      password: strongPassword,
+    });
+    expect(completeSetupWithTokenMock.mock.calls[0][1]).not.toHaveProperty('email');
+    expect(completeSetupWithTokenMock.mock.calls[0][1]).not.toHaveProperty('confirmPassword');
+    expect(await screen.findByText('Setup complete. You can now log in.')).toBeInTheDocument();
+  });
+
+  it.each([
+    [401, 'This setup link is invalid. Please request a new invitation.'],
+    [403, 'This organisation is not currently accepting setup requests. Please contact support.'],
+    [404, 'This setup link is invalid. Please request a new invitation.'],
+    [
+      409,
+      'This invitation cannot be completed because the account already has a conflicting role.',
+    ],
+    [422, 'Please choose a password that meets the password requirements.'],
+    [429, 'Too many attempts. Please wait a moment and try again.'],
+  ])('shows a safe setup error for status %s', async (status, message) => {
+    getSetupTokenContextMock.mockRejectedValue(
+      new ApiError('Setup failed', {
+        status,
+        statusText: 'Error',
+        method: 'GET',
+        url: 'setup/toke/context',
+      }),
+    );
+
+    renderSetupPage();
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+
+  it('shows a safe generic setup message for network failures', async () => {
+    getSetupTokenContextMock.mockRejectedValue(new Error('Network failure'));
+
+    renderSetupPage();
+
+    expect(await screen.findByText('Something went wrong. Please try again.')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/testing/SetupPage.test.tsx
+++ b/apps/frontend/src/pages/testing/SetupPage.test.tsx
@@ -82,7 +82,7 @@ describe('SetupPage', () => {
     expect(completeSetupWithToken).not.toHaveBeenCalled();
   });
 
-  it('completes setup without sending email or confirmPassword', async () => {
+  it('completes setup without sending email and with confirmPassword', async () => {
     const user = userEvent.setup();
 
     renderSetupPage();
@@ -100,9 +100,13 @@ describe('SetupPage', () => {
       firstName: 'Janet',
       lastName: 'Doe',
       password: strongPassword,
+      confirmPassword: strongPassword,
     });
     expect(completeSetupWithTokenMock.mock.calls[0][1]).not.toHaveProperty('email');
-    expect(completeSetupWithTokenMock.mock.calls[0][1]).not.toHaveProperty('confirmPassword');
+    expect(completeSetupWithTokenMock.mock.calls[0][1]).toHaveProperty(
+      'confirmPassword',
+      strongPassword,
+    );
     expect(await screen.findByText('Setup complete. You can now log in.')).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/pages/testing/SetupPage.test.tsx
+++ b/apps/frontend/src/pages/testing/SetupPage.test.tsx
@@ -114,10 +114,6 @@ describe('SetupPage', () => {
     [401, 'This setup link is invalid. Please request a new invitation.'],
     [403, 'This organisation is not currently accepting setup requests. Please contact support.'],
     [404, 'This setup link is invalid. Please request a new invitation.'],
-    [
-      409,
-      'This invitation cannot be completed because the account already has a conflicting role.',
-    ],
     [422, 'Please choose a password that meets the password requirements.'],
     [429, 'Too many attempts. Please wait a moment and try again.'],
   ])('shows a safe setup error for status %s', async (status, message) => {
@@ -133,6 +129,92 @@ describe('SetupPage', () => {
     renderSetupPage();
 
     expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'SETUP_ROLE_CONFLICT',
+      'This invitation cannot be completed because the account already has a conflicting role.',
+    ],
+    ['SETUP_INVITATION_EXPIRED', 'This setup link has expired. Please request a new invitation.'],
+    ['SETUP_TOKEN_STALE', 'This setup link is no longer valid. Please request a new invitation.'],
+    [
+      'ORGANISATION_SUSPENDED',
+      'This organisation is not currently accepting setup requests. Please contact support.',
+    ],
+  ])('shows a safe setup error for code %s', async (errorCode, message) => {
+    getSetupTokenContextMock.mockRejectedValue(
+      new ApiError('Setup failed', {
+        status: 409,
+        statusText: 'Conflict',
+        method: 'GET',
+        url: 'setup/toke/context',
+        body: {
+          error: errorCode,
+          message: 'Backend message',
+        },
+      }),
+    );
+
+    renderSetupPage();
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+
+  it('does not show the role-conflict message for stale setup tokens', async () => {
+    getSetupTokenContextMock.mockRejectedValue(
+      new ApiError('Setup failed', {
+        status: 409,
+        statusText: 'Conflict',
+        method: 'GET',
+        url: 'setup/toke/context',
+        body: {
+          error: 'SETUP_TOKEN_STALE',
+          message: 'Backend message',
+        },
+      }),
+    );
+
+    renderSetupPage();
+
+    expect(
+      await screen.findByText(
+        'This setup link is no longer valid. Please request a new invitation.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'This invitation cannot be completed because the account already has a conflicting role.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show the role-conflict message for unknown setup tokens', async () => {
+    getSetupTokenContextMock.mockRejectedValue(
+      new ApiError('Setup failed', {
+        status: 409,
+        statusText: 'Conflict',
+        method: 'GET',
+        url: 'setup/toke/context',
+        body: {
+          error: 'SETUP_UNKNOWN_CONFLICT',
+          message: 'Backend message',
+        },
+      }),
+    );
+
+    renderSetupPage();
+
+    expect(
+      await screen.findByText(
+        'This setup cannot be completed. Please request a new invitation or contact support.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'This invitation cannot be completed because the account already has a conflicting role.',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it('shows a safe generic setup message for network failures', async () => {

--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -12,12 +12,14 @@ import CampaignsPage from '../pages/CampaignsPage';
 import LandingPage from '../pages/LandingPage';
 import ForgotPasswordPage from '../pages/ForgotPasswordPage';
 import ResetPasswordPage from '../pages/ResetPasswordPage';
+import SetupPage from '../pages/SetupPage';
 
 function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
+      <Route path="/setup/token/:token" element={<SetupPage />} />
       <Route path="/status" element={<StatusPage />} />
       <Route element={<ProtectedRoute />}>
         <Route

--- a/apps/frontend/src/routes/AppRoutes.tsx
+++ b/apps/frontend/src/routes/AppRoutes.tsx
@@ -11,6 +11,7 @@ import ProtectedRoute from './ProtectedRoute';
 import CampaignsPage from '../pages/CampaignsPage';
 import LandingPage from '../pages/LandingPage';
 import ForgotPasswordPage from '../pages/ForgotPasswordPage';
+import ResetPasswordPage from '../pages/ResetPasswordPage';
 import OrganisationRegistrationRequestPage from '../pages/OrganisationRegistrationRequestPage';
 import AccountManagementPage from '../pages/AccountManagementPage';
 import SetupPage from '../pages/SetupPage';

--- a/apps/frontend/src/routes/testing/AppRoutes.test.tsx
+++ b/apps/frontend/src/routes/testing/AppRoutes.test.tsx
@@ -75,6 +75,10 @@ vi.mock('../../pages/ResultsPage', () => ({
   default: () => <h1>Quiz Results</h1>,
 }));
 
+vi.mock('../../pages/SetupPage', () => ({
+  default: () => <h1>Complete Setup</h1>,
+}));
+
 vi.mock('../../lib/campaignsApi', () => ({
   getTraineeCampaigns: vi.fn(),
   getTraineeCampaignDetail: vi.fn(),
@@ -176,6 +180,17 @@ describe('AppRoutes', () => {
 
     expect(
       await screen.findByRole('heading', { level: 1, name: /^Get Started$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the setup screen at /setup/token/:token', async () => {
+    renderAppRoutes({
+      initialEntry: '/setup/token/exampleSetupTokenValueWithAtLeast32Chars',
+      isAuthenticated: false,
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /complete setup/i }),
     ).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -13,12 +13,14 @@ export type RegisterUserPayload = {
   lastName: string;
   email: string;
   password: string;
+  confirmPassword: string;
 };
 
 export type CompleteSetupPayload = {
   firstName: string;
   lastName: string;
   password: string;
+  confirmPassword: string;
 };
 
 export function loginUser(payload: AuthLoginRequestDto): Promise<AuthLoginResponseDto> {

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -2,8 +2,24 @@ import type {
   AuthLoginRequestDto,
   AuthLoginResponseDto,
   AuthMeResponseDto,
+  AuthRegisterResponseDto,
+  SetupCompleteResponseDto,
+  SetupTokenContextResponseDto,
 } from '@insightful-phish/shared';
 import { apiClient } from '../lib/apiClient';
+
+export type RegisterUserPayload = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+};
+
+export type CompleteSetupPayload = {
+  firstName: string;
+  lastName: string;
+  password: string;
+};
 
 export function loginUser(payload: AuthLoginRequestDto): Promise<AuthLoginResponseDto> {
   return apiClient.post<AuthLoginResponseDto, AuthLoginRequestDto>('/auth/login', payload, {
@@ -23,11 +39,39 @@ export function logoutSession(): Promise<{ success: boolean }> {
   });
 }
 
+export function registerUser(payload: RegisterUserPayload): Promise<AuthRegisterResponseDto> {
+  return apiClient.post<AuthRegisterResponseDto, RegisterUserPayload>('/auth/register', payload, {
+    credentials: 'include',
+  });
+}
+
 export function resendVerification(payload: {
   email: string;
 }): Promise<{ message?: string; success?: boolean }> {
   return apiClient.post<{ message?: string; success?: boolean }, { email: string }>(
     '/auth/resend-verification',
+    payload,
+    {
+      credentials: 'include',
+    },
+  );
+}
+
+export function getSetupTokenContext(token: string): Promise<SetupTokenContextResponseDto> {
+  return apiClient.get<SetupTokenContextResponseDto>(
+    `/setup/token/${encodeURIComponent(token)}/context`,
+    {
+      credentials: 'include',
+    },
+  );
+}
+
+export function completeSetupWithToken(
+  token: string,
+  payload: CompleteSetupPayload,
+): Promise<SetupCompleteResponseDto> {
+  return apiClient.post<SetupCompleteResponseDto, CompleteSetupPayload>(
+    `/setup/token/${encodeURIComponent(token)}/complete`,
     payload,
     {
       credentials: 'include',


### PR DESCRIPTION
## Summary

* Wired public registration through the frontend auth service and shared API client.
* Added the invite setup flow at `/setup/token/:token`.
* Added setup token context loading, disabled authoritative invite email handling, setup completion, and safe error messaging.
* Kept `confirmPassword` validated on the frontend and sent to the backend to match the current shared/backend contract.
* Added focused frontend tests for registration payloads, resend verification, setup payloads, setup context loading, and setup routing.

## Linked Issue

Closes #237 

## Type of change

* [x] Feature
* [x] Bug Fix
* [ ] Documentation
* [ ] Chore/Maintenance

## Testing

* `pnpm --filter @insightful-phish/frontend test -- src/pages/testing/RegisterPage.test.tsx src/pages/testing/SetupPage.test.tsx src/routes/testing/AppRoutes.test.tsx`
* `pnpm --filter @insightful-phish/frontend typecheck`
* `pnpm --filter @insightful-phish/frontend lint`
* `pnpm --filter @insightful-phish/frontend build`

Root-level checks noted:

* `pnpm typecheck` and `pnpm build` currently fail in `apps/backend/src/repositories/organisation-security-settings.repository.ts` due to Prisma generated-client types.
* This branch does not modify backend, shared, Prisma schema, or generated-client files, so that failure appears unrelated to this frontend PR.

## Review Notes

* Please focus on the frontend registration/setup flow wiring, especially the public registration payload, setup token context loading, disabled invite email handling, and setup completion payload.
* `confirmPassword` is validated on the frontend and also sent to the backend because the current shared/backend request contract expects it.
* Invite setup keeps the invite email authoritative from token context and does not send editable email during setup completion.
* Safe error messages are used for expected auth/setup failure states.
* No backend, shared, Prisma schema, or generated-client changes are included.

## Checklist

* [x] I tested the change locally
* [x] Accessibility impact was considered if applicable
* [x] No unrelated changes are included
* [x] Relevant tests were added or updated if applicable
* [x] Documentation was updated if needed
* [x] No secrets, credentials, or sensitive values were committed
