### PR TITLE
Feat/integrate org request/zoe

### DIFF
--- a/apps/frontend/src/components/layout/modals/SuccessfulRegistrationModal.tsx
+++ b/apps/frontend/src/components/layout/modals/SuccessfulRegistrationModal.tsx
@@ -6,6 +6,7 @@ type SuccessfulRegistrationModalProps = Readonly<{
   firstName: string;
   accountDescription: string;
   organisation: string;
+  confirmationEmailQueued?: boolean | null;
 }>;
 
 function SuccessfulRegistrationModal({
@@ -13,6 +14,7 @@ function SuccessfulRegistrationModal({
   firstName,
   accountDescription,
   organisation,
+  confirmationEmailQueued,
 }: SuccessfulRegistrationModalProps) {
   if (!isOpen) return null;
 
@@ -88,8 +90,10 @@ function SuccessfulRegistrationModal({
             {organisation && (
               <p className="font-jost text-left font-regular text-[1.1rem] tracking-wider text-purple mb-6">
                 Your request will be reviewed by an <em>Insightful Phish</em> platform
-                administrator. If approved, you will receive an email with instructions to setup
-                your <em>Organisation Administrator</em> account.
+                administrator.
+                {confirmationEmailQueued === false
+                  ? ' Confirmation email delivery may be delayed, but your request was received.'
+                  : ' If approved, you will receive an email with instructions to set up your Organisation Administrator account.'}
               </p>
             )}
 

--- a/apps/frontend/src/components/org-reg/OrganisationInformationForm.tsx
+++ b/apps/frontend/src/components/org-reg/OrganisationInformationForm.tsx
@@ -109,15 +109,15 @@ function OrganisationInformationForm({
         {/* Organisation URL*/}
         <div>
           <label
-            htmlFor="organisation-name"
+            htmlFor="organisation-website-url"
             className=" block mb-2 font-jost tracking-wide text-xl font-medium text-pink"
           >
             Organisation URL
           </label>
           <input
             type="text"
-            name="organisation-name"
-            id="organisation-name"
+            name="organisation-website-url"
+            id="organisation-website-url"
             value={orgWeb}
             onChange={(e) => setOrgWeb(e.target.value)}
             className="font-overpass text-[1.2rem] bg-gray-50 border border-gray-300 text-deep-purple focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"

--- a/apps/frontend/src/components/org-reg/RepresentativeInformationForm.tsx
+++ b/apps/frontend/src/components/org-reg/RepresentativeInformationForm.tsx
@@ -10,6 +10,7 @@ type RepresentativeInformationFormProps = Readonly<{
 
   onBack: () => void;
   onSubmit: () => void;
+  isSubmitting: boolean;
 }>;
 
 function RepresentativeInformationForm({
@@ -21,6 +22,7 @@ function RepresentativeInformationForm({
   setRepEmail,
   onBack,
   onSubmit,
+  isSubmitting,
 }: RepresentativeInformationFormProps) {
   return (
     <div className="-mt-5 -ml-4">
@@ -134,9 +136,10 @@ function RepresentativeInformationForm({
         <button
           type="button"
           onClick={onSubmit}
+          disabled={isSubmitting}
           className="cursor-pointer px-6 py-3 inline-flex gap-2 items-center justify-center text-white font-jost text-[1.2rem] font-regular tracking-wider bg-main-purple hover:bg-hover-purple box-border border border-transparent focus:ring-4 focus:ring-brand-medium shadow-xs leading-5 text-sm px-4 py-2.5 focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          <span> Complete Registration Request </span>
+          <span>{isSubmitting ? 'Submitting Request...' : 'Complete Registration Request'}</span>
         </button>
       </div>
     </div>

--- a/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
+++ b/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
@@ -2,8 +2,15 @@ import { useState } from 'react';
 import OrganisationInformationForm from '../components/org-reg/OrganisationInformationForm';
 import RepresentativeInformationForm from '../components/org-reg/RepresentativeInformationForm';
 import BasicAlert from '../components/alerts/BasicAlert';
-import { firstNameSchema, lastNameSchema, emailSchema } from '@insightful-phish/shared';
+import {
+  firstNameSchema,
+  lastNameSchema,
+  emailSchema,
+  type CreateOrganisationRegistrationRequestDto,
+} from '@insightful-phish/shared';
 import SuccessfulRegistrationModal from '../components/layout/modals/SuccessfulRegistrationModal';
+import { ApiError } from '../lib/apiClient';
+import { submitOrganisationRegistrationRequest } from '../services/organisation-registration-request.service';
 
 function formatAlertMessage(message: string) {
   // makes everything title case and removes the . from the end of the message
@@ -22,6 +29,8 @@ function OrganisationRegistrationRequestPage() {
 
   const [alertMessage, setAlertMessage] = useState('');
   const [alertType, setAlertType] = useState<'success' | 'danger'>('danger');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [confirmationEmailQueued, setConfirmationEmailQueued] = useState<boolean | null>(null);
 
   const [orgInfoValid, setOrgInfoValid] = useState(false);
 
@@ -65,10 +74,8 @@ function OrganisationRegistrationRequestPage() {
     if (url) {
       // INVALID URL
       try {
-        const normalURL =
-          url.startsWith('https://') || url.startsWith('http://') ? url : `https://${url}`;
-        const parsedURL = new URL(normalURL);
-        if (!parsedURL.hostname.includes('.')) {
+        const parsedURL = new URL(url);
+        if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:') {
           throw new Error('Invalid URL');
         }
       } catch {
@@ -108,6 +115,74 @@ function OrganisationRegistrationRequestPage() {
     }
 
     return true;
+  }
+
+  type SubmitErrorBody = {
+    error?: string;
+    details?: Array<{ field: string; message: string }>;
+  };
+
+  function buildRequestPayload(): CreateOrganisationRegistrationRequestDto {
+    const organisationDescription = orgDescrip.trim();
+    const organisationWebsiteUrl = orgWeb.trim();
+
+    return {
+      organisationName: orgName.trim(),
+      organisationSize: Number(orgSize),
+      representativeFirstName: repFName.trim(),
+      representativeLastName: repLName.trim(),
+      representativeEmail: repEmail.trim().toLowerCase(),
+      ...(organisationDescription ? { organisationDescription } : {}),
+      ...(organisationWebsiteUrl ? { organisationWebsiteUrl } : {}),
+    };
+  }
+
+  function getSafeSubmitErrorMessage(error: unknown) {
+    if (!(error instanceof ApiError)) {
+      return 'We could not submit the request right now. Please try again later.';
+    }
+
+    const body = error.body as SubmitErrorBody | undefined;
+
+    if (error.status === 409 && body?.error === 'ORGANISATION_REQUEST_CONFLICT') {
+      return 'A registration request already exists or conflicts with existing records. Please check the details or contact support.';
+    }
+
+    if (error.status === 422 && body?.error === 'VALIDATION_ERROR') {
+      return body.details?.[0]?.message ?? 'Please check the request details and try again.';
+    }
+
+    if (error.status === 429 && body?.error === 'TOO_MANY_REQUESTS') {
+      return 'Too many requests. Please wait and try again later.';
+    }
+
+    return 'We could not submit the request right now. Please try again later.';
+  }
+
+  async function handleSubmitRegistrationRequest() {
+    setAlertMessage('');
+
+    if (!validateOrgInfo()) {
+      setCurrentStep(1);
+      return;
+    }
+
+    if (!validateRepInfo()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await submitOrganisationRegistrationRequest(buildRequestPayload());
+      setConfirmationEmailQueued(response.confirmationEmailQueued);
+      setShowSuccessfulRegModal(true);
+    } catch (error) {
+      setAlertType('danger');
+      setAlertMessage(getSafeSubmitErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
@@ -151,6 +226,7 @@ function OrganisationRegistrationRequestPage() {
             firstName={repFName}
             accountDescription="Organisation Administrator"
             organisation={orgName}
+            confirmationEmailQueued={confirmationEmailQueued}
           />
 
           {/* TAB BUTTONS */}
@@ -220,11 +296,8 @@ function OrganisationRegistrationRequestPage() {
                   setCurrentStep(1);
                   setOrgInfoValid(false);
                 }}
-                onSubmit={() => {
-                  if (validateRepInfo()) {
-                    setShowSuccessfulRegModal(true);
-                  }
-                }}
+                onSubmit={handleSubmitRegistrationRequest}
+                isSubmitting={isSubmitting}
               />
             )}
           </div>

--- a/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
+++ b/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
@@ -72,7 +72,13 @@ function OrganisationRegistrationRequestPage() {
 
     const url = orgWeb.trim();
     if (url) {
-      // INVALID URL
+      if (url.length > 2048) {
+        setAlertType('danger');
+        setAlertMessage('Please Provide A Valid Website URL');
+        setOrgInfoValid(false);
+        return false;
+      }
+
       try {
         const parsedURL = new URL(url);
         if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:') {

--- a/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
+++ b/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
@@ -20,6 +20,19 @@ const organisationStepSchema = createOrganisationRegistrationRequestSchema.pick(
   organisationWebsiteUrl: true,
 });
 
+const ORGANISATION_STEP_VALIDATION_FIELDS = new Set([
+  'organisationName',
+  'organisationDescription',
+  'organisationSize',
+  'organisationWebsiteUrl',
+]);
+
+const REPRESENTATIVE_STEP_VALIDATION_FIELDS = new Set([
+  'representativeFirstName',
+  'representativeLastName',
+  'representativeEmail',
+]);
+
 function formatAlertMessage(message: string) {
   // makes everything title case and removes the . from the end of the message
   return message
@@ -143,6 +156,20 @@ function OrganisationRegistrationRequestPage() {
     return 'We could not submit the request right now. Please try again later.';
   }
 
+  function getBackendValidationField(error: unknown) {
+    if (!(error instanceof ApiError)) {
+      return undefined;
+    }
+
+    const body = error.body as SubmitErrorBody | undefined;
+
+    if (error.status !== 422 || body?.error !== 'VALIDATION_ERROR') {
+      return undefined;
+    }
+
+    return body.details?.[0]?.field;
+  }
+
   async function handleSubmitRegistrationRequest() {
     setAlertMessage('');
 
@@ -162,6 +189,17 @@ function OrganisationRegistrationRequestPage() {
       setConfirmationEmailQueued(response.confirmationEmailQueued);
       setShowSuccessfulRegModal(true);
     } catch (error) {
+      const validationField = getBackendValidationField(error);
+
+      if (validationField && ORGANISATION_STEP_VALIDATION_FIELDS.has(validationField)) {
+        setCurrentStep(1);
+        setOrgInfoValid(false);
+      }
+
+      if (validationField && REPRESENTATIVE_STEP_VALIDATION_FIELDS.has(validationField)) {
+        setCurrentStep(2);
+      }
+
       setAlertType('danger');
       setAlertMessage(getSafeSubmitErrorMessage(error));
     } finally {

--- a/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
+++ b/apps/frontend/src/pages/OrganisationRegistrationRequestPage.tsx
@@ -6,11 +6,19 @@ import {
   firstNameSchema,
   lastNameSchema,
   emailSchema,
+  createOrganisationRegistrationRequestSchema,
   type CreateOrganisationRegistrationRequestDto,
 } from '@insightful-phish/shared';
 import SuccessfulRegistrationModal from '../components/layout/modals/SuccessfulRegistrationModal';
 import { ApiError } from '../lib/apiClient';
 import { submitOrganisationRegistrationRequest } from '../services/organisation-registration-request.service';
+
+const organisationStepSchema = createOrganisationRegistrationRequestSchema.pick({
+  organisationName: true,
+  organisationDescription: true,
+  organisationSize: true,
+  organisationWebsiteUrl: true,
+});
 
 function formatAlertMessage(message: string) {
   // makes everything title case and removes the . from the end of the message
@@ -43,53 +51,23 @@ function OrganisationRegistrationRequestPage() {
   function validateOrgInfo() {
     setAlertMessage('');
 
-    if (!orgName.trim()) {
-      // NO ORGANISATION NAME
-      // Org Name is REQUIRED
+    const organisationDescription = orgDescrip.trim();
+    const organisationWebsiteUrl = orgWeb.trim();
+
+    const validationResult = organisationStepSchema.safeParse({
+      organisationName: orgName.trim(),
+      organisationSize: orgSize === '' ? undefined : Number(orgSize),
+      ...(organisationDescription ? { organisationDescription } : {}),
+      ...(organisationWebsiteUrl ? { organisationWebsiteUrl } : {}),
+    });
+
+    if (!validationResult.success) {
       setAlertType('danger');
-      setAlertMessage('Please Enter An Organisation Name');
+      setAlertMessage(
+        formatAlertMessage(validationResult.error.issues[0]?.message ?? 'Invalid Input'),
+      );
       setOrgInfoValid(false);
       return false;
-    }
-
-    if (orgSize === '') {
-      // NO ORGANISATION SIZE
-      // Org Size is REQUIRED
-      setAlertType('danger');
-      setAlertMessage('Please Provide An Organisation Size');
-      setOrgInfoValid(false);
-      return false;
-    }
-
-    if (orgSize < 1) {
-      // INVALID ORGANISATION SIZE
-      // Org Size is REQUIRED (must be valid too)
-      setAlertType('danger');
-      setAlertMessage('Please Provide A Valid Organisation Size');
-      setOrgInfoValid(false);
-      return false;
-    }
-
-    const url = orgWeb.trim();
-    if (url) {
-      if (url.length > 2048) {
-        setAlertType('danger');
-        setAlertMessage('Please Provide A Valid Website URL');
-        setOrgInfoValid(false);
-        return false;
-      }
-
-      try {
-        const parsedURL = new URL(url);
-        if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:') {
-          throw new Error('Invalid URL');
-        }
-      } catch {
-        setAlertType('danger');
-        setAlertMessage('Please Provide A Valid Website URL');
-        setOrgInfoValid(false);
-        return false;
-      }
     }
 
     setOrgInfoValid(true);

--- a/apps/frontend/src/pages/testing/OrganisationInformationForm.test.tsx
+++ b/apps/frontend/src/pages/testing/OrganisationInformationForm.test.tsx
@@ -40,7 +40,12 @@ describe('OrganisationInformationForm', () => {
 
     expect(screen.getByLabelText(/Organisation Name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Organisation Description/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Organisation URL/i)).toBeInTheDocument();
+
+    const websiteInput = screen.getByLabelText(/Organisation URL/i);
+
+    expect(websiteInput).toBeInTheDocument();
+    expect(websiteInput).toHaveAttribute('id', 'organisation-website-url');
+
     expect(screen.getByLabelText(/Organisation Size/i)).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/pages/testing/OrganisationRegistrationRequestApi.test.ts
+++ b/apps/frontend/src/pages/testing/OrganisationRegistrationRequestApi.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createJsonResponse,
+  setupHttpTest,
+  teardownHttpTest,
+} from '../../lib/testing/httpTestUtils';
+import { submitOrganisationRegistrationRequest } from '../../services/organisation-registration-request.service';
+
+const fetchMock = vi.fn();
+
+describe('submitOrganisationRegistrationRequest', () => {
+  beforeEach(() => {
+    setupHttpTest(fetchMock);
+  });
+
+  afterEach(() => {
+    teardownHttpTest();
+  });
+
+  it('sends POST /organisation-registration-requests with the request payload', async () => {
+    const payload = {
+      organisationName: 'CBELL Plumbing',
+      organisationDescription: 'Plumbing services',
+      organisationSize: 25,
+      organisationWebsiteUrl: 'https://cbell.example.com',
+      representativeFirstName: 'Casey',
+      representativeLastName: 'Bell',
+      representativeEmail: 'casey@example.com',
+    };
+
+    fetchMock.mockResolvedValue(
+      createJsonResponse(
+        {
+          requestId: 'request-1',
+          status: 'PENDING_REVIEW',
+          confirmationEmailQueued: true,
+        },
+        { status: 201 },
+      ),
+    );
+
+    await expect(submitOrganisationRegistrationRequest(payload)).resolves.toEqual({
+      requestId: 'request-1',
+      status: 'PENDING_REVIEW',
+      confirmationEmailQueued: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:4000/organisation-registration-requests',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+  });
+});

--- a/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
+++ b/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
@@ -218,6 +218,22 @@ describe('OrganisationRegistrationRequestPage', () => {
     });
   });
 
+  it('rejects website URLs longer than the backend maximum before submit', async () => {
+    const user = userEvent.setup();
+    const tooLongWebsiteUrl = `https://example.com/${'a'.repeat(2049)}`;
+
+    renderOrganisationRegistrationRequestPage();
+
+    await user.type(screen.getByLabelText(/Organisation Name/i), 'CBELL Plumbing');
+    await user.type(screen.getByLabelText(/Organisation Size/i), '25');
+    await user.click(screen.getByLabelText(/Organisation URL/i));
+    await user.paste(tooLongWebsiteUrl);
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    expect(screen.getByText('Please Provide A Valid Website URL')).toBeInTheDocument();
+    expect(submitOrganisationRegistrationRequestMock).not.toHaveBeenCalled();
+  });
+
   it('omits empty optional description and website values from the payload', async () => {
     const user = userEvent.setup();
 

--- a/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
+++ b/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
@@ -230,7 +230,68 @@ describe('OrganisationRegistrationRequestPage', () => {
     await user.paste(tooLongWebsiteUrl);
     await user.click(screen.getByRole('button', { name: /Next/i }));
 
-    expect(screen.getByText('Please Provide A Valid Website URL')).toBeInTheDocument();
+    expect(
+      screen.getByText('Organisation Website Url Must Be At Most 2048 Characters'),
+    ).toBeInTheDocument();
+    expect(submitOrganisationRegistrationRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects organisation names longer than the backend maximum before submit', async () => {
+    const user = userEvent.setup();
+
+    renderOrganisationRegistrationRequestPage();
+
+    await user.click(screen.getByLabelText(/Organisation Name/i));
+    await user.paste('A'.repeat(201));
+    await user.type(screen.getByLabelText(/Organisation Size/i), '25');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    expect(
+      screen.getByText('Organisation Name Must Be At Most 200 Characters'),
+    ).toBeInTheDocument();
+    expect(submitOrganisationRegistrationRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects organisation descriptions longer than the backend maximum before submit', async () => {
+    const user = userEvent.setup();
+
+    renderOrganisationRegistrationRequestPage();
+
+    await user.type(screen.getByLabelText(/Organisation Name/i), 'CBELL Plumbing');
+    await user.type(screen.getByLabelText(/Organisation Size/i), '25');
+    await user.click(screen.getByLabelText(/Organisation Description/i));
+    await user.paste('A'.repeat(2001));
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    expect(
+      screen.getByText('Organisation Description Must Be At Most 2000 Characters'),
+    ).toBeInTheDocument();
+    expect(submitOrganisationRegistrationRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-integer organisation sizes before submit', async () => {
+    const user = userEvent.setup();
+
+    renderOrganisationRegistrationRequestPage();
+
+    await user.type(screen.getByLabelText(/Organisation Name/i), 'CBELL Plumbing');
+    await user.type(screen.getByLabelText(/Organisation Size/i), '25.5');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    expect(screen.getByText('Organisation Size Must Be A Whole Number')).toBeInTheDocument();
+    expect(submitOrganisationRegistrationRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects organisation sizes over the shared maximum before submit', async () => {
+    const user = userEvent.setup();
+
+    renderOrganisationRegistrationRequestPage();
+
+    await user.type(screen.getByLabelText(/Organisation Name/i), 'CBELL Plumbing');
+    await user.type(screen.getByLabelText(/Organisation Size/i), '100001');
+    await user.click(screen.getByRole('button', { name: /Next/i }));
+
+    expect(screen.getByText('Organisation Size Must Be At Most 100000')).toBeInTheDocument();
     expect(submitOrganisationRegistrationRequestMock).not.toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
+++ b/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
@@ -347,6 +347,42 @@ describe('OrganisationRegistrationRequestPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('moves back to organisation information when backend validation rejects an organisation field', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockRejectedValue(
+      createOrganisationRequestApiError(422, 'VALIDATION_ERROR', {
+        error: 'VALIDATION_ERROR',
+        details: [{ field: 'organisationName', message: 'Organisation name is already in use.' }],
+      }),
+    );
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(await screen.findByText('Organisation name is already in use.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Step 1 of 2/i })).toBeInTheDocument();
+  });
+
+  it('keeps the representative step visible when backend validation rejects a representative field', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockRejectedValue(
+      createOrganisationRequestApiError(422, 'VALIDATION_ERROR', {
+        error: 'VALIDATION_ERROR',
+        details: [{ field: 'representativeEmail', message: 'Representative email is invalid.' }],
+      }),
+    );
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(await screen.findByText('Representative email is invalid.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Step 2 of 2/i })).toBeInTheDocument();
+  });
+
   it('shows delayed confirmation email copy when confirmation email is not queued', async () => {
     const user = userEvent.setup();
 

--- a/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
+++ b/apps/frontend/src/pages/testing/OrganisationRegistrationRequestPage.test.tsx
@@ -1,11 +1,116 @@
+import '@testing-library/jest-dom/vitest';
 import OrganisationRegistrationRequestPage from '../OrganisationRegistrationRequestPage';
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
+import { ApiError } from '../../lib/apiClient';
+
+const { submitOrganisationRegistrationRequestMock } = vi.hoisted(() => ({
+  submitOrganisationRegistrationRequestMock: vi.fn(),
+}));
+
+vi.mock('../../services/organisation-registration-request.service', () => ({
+  submitOrganisationRegistrationRequest: submitOrganisationRegistrationRequestMock,
+}));
+
+function renderOrganisationRegistrationRequestPage() {
+  return render(
+    <MemoryRouter>
+      <OrganisationRegistrationRequestPage />
+    </MemoryRouter>,
+  );
+}
+
+function createOrganisationRequestApiError(
+  status: number,
+  errorCode: string,
+  body: unknown = {
+    error: errorCode,
+    message: errorCode,
+  },
+) {
+  return new ApiError(errorCode, {
+    status,
+    statusText: 'Error',
+    method: 'POST',
+    url: 'http://localhost:4000/organisation-registration-requests',
+    body,
+  });
+}
+
+async function fillOrganisationStep(
+  user: ReturnType<typeof userEvent.setup>,
+  values: {
+    organisationName?: string;
+    organisationSize?: string;
+    organisationDescription?: string;
+    organisationWebsiteUrl?: string;
+  } = {},
+) {
+  await user.type(
+    screen.getByLabelText(/Organisation Name/i),
+    values.organisationName ?? ' CBELL Plumbing',
+  );
+  await user.type(screen.getByLabelText(/Organisation Size/i), values.organisationSize ?? '25');
+
+  if (values.organisationDescription !== undefined) {
+    await user.type(
+      screen.getByLabelText(/Organisation Description/i),
+      values.organisationDescription,
+    );
+  }
+
+  if (values.organisationWebsiteUrl !== undefined) {
+    await user.type(screen.getByLabelText(/Organisation URL/i), values.organisationWebsiteUrl);
+  }
+
+  await user.click(screen.getByRole('button', { name: /Next/i }));
+}
+
+async function fillRepresentativeStep(
+  user: ReturnType<typeof userEvent.setup>,
+  values: {
+    representativeFirstName?: string;
+    representativeLastName?: string;
+    representativeEmail?: string;
+  } = {},
+) {
+  await user.type(
+    screen.getByLabelText(/Representative First Name\(s\)/i),
+    values.representativeFirstName ?? ' Casey ',
+  );
+  await user.type(
+    screen.getByLabelText(/Representative Last Name/i),
+    values.representativeLastName ?? ' Bell ',
+  );
+  await user.type(
+    screen.getByLabelText(/Representative Email Address/i),
+    values.representativeEmail ?? ' CASEY@example.com',
+  );
+}
+
+async function submitValidOrganisationRequest(
+  user: ReturnType<typeof userEvent.setup>,
+  values: Parameters<typeof fillOrganisationStep>[1] &
+    Parameters<typeof fillRepresentativeStep>[1] = {},
+) {
+  await fillOrganisationStep(user, values);
+  await fillRepresentativeStep(user, values);
+  await user.click(screen.getByRole('button', { name: /Complete Registration Request/i }));
+}
 
 describe('OrganisationRegistrationRequestPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    submitOrganisationRegistrationRequestMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   // Test 1: Render the Page
   it('renders the organisation registration request page', () => {
     render(
@@ -80,5 +185,257 @@ describe('OrganisationRegistrationRequestPage', () => {
     expect(
       screen.getByRole('button', { name: /2\. Representative Information/i }),
     ).not.toBeDisabled();
+  });
+
+  it('submits the exact organisation registration request payload once', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockResolvedValue({
+      requestId: 'request-1',
+      status: 'PENDING_REVIEW',
+      confirmationEmailQueued: true,
+    });
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user, {
+      organisationDescription: ' Plumbing services ',
+      organisationWebsiteUrl: ' https://cbell.example.com ',
+    });
+
+    await waitFor(() => {
+      expect(submitOrganisationRegistrationRequestMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(submitOrganisationRegistrationRequestMock).toHaveBeenCalledWith({
+      organisationName: 'CBELL Plumbing',
+      organisationSize: 25,
+      organisationDescription: 'Plumbing services',
+      organisationWebsiteUrl: 'https://cbell.example.com',
+      representativeFirstName: 'Casey',
+      representativeLastName: 'Bell',
+      representativeEmail: 'casey@example.com',
+    });
+  });
+
+  it('omits empty optional description and website values from the payload', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockResolvedValue({
+      requestId: 'request-1',
+      status: 'PENDING_REVIEW',
+      confirmationEmailQueued: true,
+    });
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user, {
+      organisationDescription: '  ',
+      organisationWebsiteUrl: ' ',
+    });
+
+    await waitFor(() => {
+      expect(submitOrganisationRegistrationRequestMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(submitOrganisationRegistrationRequestMock).toHaveBeenCalledWith({
+      organisationName: 'CBELL Plumbing',
+      organisationSize: 25,
+      representativeFirstName: 'Casey',
+      representativeLastName: 'Bell',
+      representativeEmail: 'casey@example.com',
+    });
+  });
+
+  it('shows the approval email instruction when confirmation email is queued', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockResolvedValue({
+      requestId: 'request-1',
+      status: 'PENDING_REVIEW',
+      confirmationEmailQueued: true,
+    });
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(
+      await screen.findByRole('heading', { name: /Registration Request Submitted/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /If approved, you will receive an email with instructions to set up your Organisation Administrator account/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows delayed confirmation email copy when confirmation email is not queued', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockResolvedValue({
+      requestId: 'request-1',
+      status: 'PENDING_REVIEW',
+      confirmationEmailQueued: false,
+    });
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(
+      await screen.findByRole('heading', { name: /Registration Request Submitted/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Confirmation email delivery may be delayed, but your request was received/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the conflict message when the request conflicts with existing records', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockRejectedValue(
+      createOrganisationRequestApiError(409, 'ORGANISATION_REQUEST_CONFLICT'),
+    );
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(
+      await screen.findByText(
+        'A registration request already exists or conflicts with existing records. Please check the details or contact support.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the first validation detail when the backend returns validation errors', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockRejectedValue(
+      createOrganisationRequestApiError(422, 'VALIDATION_ERROR', {
+        error: 'VALIDATION_ERROR',
+        details: [{ field: 'representativeEmail', message: 'Representative email is invalid.' }],
+      }),
+    );
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(await screen.findByText('Representative email is invalid.')).toBeInTheDocument();
+  });
+
+  it('shows the rate-limit message when the backend rate limits submissions', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockRejectedValue(
+      createOrganisationRequestApiError(429, 'TOO_MANY_REQUESTS'),
+    );
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(
+      await screen.findByText('Too many requests. Please wait and try again later.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a generic fallback when submission fails unexpectedly', async () => {
+    const user = userEvent.setup();
+
+    submitOrganisationRegistrationRequestMock.mockRejectedValue(new Error('Network failure'));
+
+    renderOrganisationRegistrationRequestPage();
+
+    await submitValidOrganisationRequest(user);
+
+    expect(
+      await screen.findByText('We could not submit the request right now. Please try again later.'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the submit button while the request is pending', async () => {
+    const user = userEvent.setup();
+    let resolveSubmit: (value: {
+      requestId: string;
+      status: 'PENDING_REVIEW';
+      confirmationEmailQueued: boolean;
+    }) => void = () => {};
+
+    submitOrganisationRegistrationRequestMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSubmit = resolve;
+      }),
+    );
+
+    renderOrganisationRegistrationRequestPage();
+
+    await fillOrganisationStep(user);
+    await fillRepresentativeStep(user);
+
+    const submitButton = screen.getByRole('button', { name: /Complete Registration Request/i });
+
+    await user.click(submitButton);
+
+    expect(submitButton).toBeDisabled();
+    expect(submitButton).toHaveTextContent('Submitting Request...');
+
+    resolveSubmit({
+      requestId: 'request-1',
+      status: 'PENDING_REVIEW',
+      confirmationEmailQueued: true,
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: /Registration Request Submitted/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('clears the previous submit alert before retrying', async () => {
+    const user = userEvent.setup();
+    let resolveSecondSubmit: (value: {
+      requestId: string;
+      status: 'PENDING_REVIEW';
+      confirmationEmailQueued: boolean;
+    }) => void = () => {};
+
+    submitOrganisationRegistrationRequestMock
+      .mockRejectedValueOnce(createOrganisationRequestApiError(429, 'TOO_MANY_REQUESTS'))
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecondSubmit = resolve;
+        }),
+      );
+
+    renderOrganisationRegistrationRequestPage();
+
+    await fillOrganisationStep(user);
+    await fillRepresentativeStep(user);
+
+    await user.click(screen.getByRole('button', { name: /Complete Registration Request/i }));
+
+    expect(
+      await screen.findByText('Too many requests. Please wait and try again later.'),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Complete Registration Request/i }));
+
+    expect(
+      screen.queryByText('Too many requests. Please wait and try again later.'),
+    ).not.toBeInTheDocument();
+
+    resolveSecondSubmit({
+      requestId: 'request-1',
+      status: 'PENDING_REVIEW',
+      confirmationEmailQueued: true,
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: /Registration Request Submitted/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/testing/RepresentativeInformationForm.test.tsx
+++ b/apps/frontend/src/pages/testing/RepresentativeInformationForm.test.tsx
@@ -14,6 +14,7 @@ const defaultProps = {
   setRepEmail: vi.fn(),
   onBack: vi.fn(),
   onSubmit: vi.fn(),
+  isSubmitting: false,
 };
 
 describe('RepresentativeInformationForm', () => {

--- a/apps/frontend/src/services/organisation-registration-request.service.ts
+++ b/apps/frontend/src/services/organisation-registration-request.service.ts
@@ -1,0 +1,14 @@
+import type {
+  CreateOrganisationRegistrationRequestDto,
+  OrganisationRegistrationRequestResponseDto,
+} from '@insightful-phish/shared';
+import { apiClient } from '../lib/apiClient';
+
+export function submitOrganisationRegistrationRequest(
+  payload: CreateOrganisationRegistrationRequestDto,
+): Promise<OrganisationRegistrationRequestResponseDto> {
+  return apiClient.post<
+    OrganisationRegistrationRequestResponseDto,
+    CreateOrganisationRegistrationRequestDto
+  >('/organisation-registration-requests', payload);
+}


### PR DESCRIPTION
## Summary

- Connected the public organisation registration request flow to `POST /organisation-registration-requests`.
- Added safe submitted, delayed-confirmation-email, pending, retry, and backend-error states.
- Added focused frontend service/page/form tests for endpoint wiring, payload construction, optional-field omission, submit states, and website URL validation.

## Linked Issue

Closes #252 

## Type of change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Chore/Maintenance

## Testing

- `pnpm --filter @insightful-phish/frontend typecheck`
- `pnpm --filter @insightful-phish/frontend lint`
- `pnpm --filter @insightful-phish/frontend test`
- `pnpm --filter @insightful-phish/frontend build`

## Review Notes

- Backend currently exposes one `ORGANISATION_REQUEST_CONFLICT` code for duplicate organisation/request and representative-email conflicts, so the frontend intentionally uses one safe conflict message.
- Website URL validation now rejects values over the backend schema max of 2048 characters before submit.
- Local repo-wide `pnpm format:check` still reports a pre-existing formatting issue in `apps/frontend/.flowbite-react/class-list.json`, which is outside this branch diff.
- Local repo-wide backend checks were not clean because of local/backend Prisma/env issues, but the branch-specific frontend checks pass.

## Checklist

- [x] I tested the change locally
- [x] Accessibility impact was considered if applicable
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable
- [ ] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed