### PR TITLE
Fix/onboarding timeline audit/adriano

### DIFF
--- a/apps/backend/src/repositories/organisation.repository.ts
+++ b/apps/backend/src/repositories/organisation.repository.ts
@@ -3,24 +3,25 @@ import { prisma } from '../lib/prisma.js';
 
 type OrganisationClient = PrismaClient | Prisma.TransactionClient;
 
-// Allowlisted audit action types for the onboarding timeline
-const TIMELINE_AUDIT_ACTIONS = [
+const TIMELINE_REGISTRATION_REQUEST_ACTIONS = [
   'CREATED',
   'CONTACTED',
   'APPROVED',
   'REJECTED',
+] as const;
+
+const TIMELINE_INITIAL_ADMIN_INVITATION_ACTIONS = [
+  'CREATED',
   'RESENT',
   'ACCEPTED',
   'COMPLETED',
-  'SUSPENDED',
-  'REACTIVATED',
 ] as const;
 
-// Allowlisted audit target types for the onboarding timeline
-const TIMELINE_AUDIT_TARGETS = [
-  'ORGANISATION_REGISTRATION_REQUEST',
-  'ORGANISATION',
-  'INVITATION',
+const TIMELINE_ORGANISATION_LIFECYCLE_ACTIONS = [
+  'CREATED',
+  'ENABLED',
+  'SUSPENDED',
+  'REACTIVATED',
 ] as const;
 
 export function findOrganisationById(organisationId: string, client: OrganisationClient = prisma) {
@@ -125,8 +126,8 @@ export function findLatestEmailLogForInvitation(
 }
 
 /**
- * Finds audit logs for the onboarding timeline. Filters to allowed target types and action types
- * directly in the database query -- no in-memory filtering needed.
+ * Finds audit logs for the onboarding timeline. Each clause is scoped to the authoritative
+ * registration request, initial-admin invitation, or organisation lifecycle target.
  */
 export function findAuditLogsForTimeline(
   input: {
@@ -141,22 +142,23 @@ export function findAuditLogsForTimeline(
   if (input.organisationId) {
     orClauses.push({
       organisationId: input.organisationId,
-      targetType: { in: [...TIMELINE_AUDIT_TARGETS] },
-      actionType: { in: [...TIMELINE_AUDIT_ACTIONS] },
+      targetType: 'ORGANISATION',
+      targetId: input.organisationId,
+      actionType: { in: [...TIMELINE_ORGANISATION_LIFECYCLE_ACTIONS] },
     });
   }
   if (input.requestId) {
     orClauses.push({
       targetType: 'ORGANISATION_REGISTRATION_REQUEST',
       targetId: input.requestId,
-      actionType: { in: [...TIMELINE_AUDIT_ACTIONS] },
+      actionType: { in: [...TIMELINE_REGISTRATION_REQUEST_ACTIONS] },
     });
   }
   if (input.invitationId) {
     orClauses.push({
       targetType: 'INVITATION',
       targetId: input.invitationId,
-      actionType: { in: [...TIMELINE_AUDIT_ACTIONS] },
+      actionType: { in: [...TIMELINE_INITIAL_ADMIN_INVITATION_ACTIONS] },
     });
   }
 

--- a/apps/backend/src/services/platformOrganisation.service.ts
+++ b/apps/backend/src/services/platformOrganisation.service.ts
@@ -521,7 +521,7 @@ async function buildPlatformTimeline(
   timeline.sort((a, b) => {
     const timeDiff = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
     if (timeDiff !== 0) return timeDiff;
-    const sequenceDiff = a.timelineSequence - b.timelineSequence;
+    const sequenceDiff = b.timelineSequence - a.timelineSequence;
     if (sequenceDiff !== 0) return sequenceDiff;
     if (b.id > a.id) return 1;
     if (b.id < a.id) return -1;

--- a/apps/backend/src/services/platformOrganisation.service.ts
+++ b/apps/backend/src/services/platformOrganisation.service.ts
@@ -411,6 +411,61 @@ export async function resendInitialAdminSetup(actorUserId: string, organisationI
   };
 }
 
+type PlatformTimelineEvent = {
+  id: string;
+  type: 'AUDIT_LOG' | 'EMAIL_DELIVERY';
+  timestamp: string;
+  action: string;
+  summary: string;
+  actor: string | null;
+  outcome: string | null;
+  metadata: null;
+};
+
+type InternalPlatformTimelineEvent = PlatformTimelineEvent & {
+  timelineSequence: number;
+};
+
+function auditTimelineSequence(log: { actionType: string; targetType: string }) {
+  if (log.targetType === 'ORGANISATION_REGISTRATION_REQUEST') {
+    if (log.actionType === 'CREATED') return 10;
+    if (log.actionType === 'CONTACTED') return 20;
+    if (log.actionType === 'APPROVED' || log.actionType === 'REJECTED') return 30;
+  }
+
+  if (log.targetType === 'INVITATION') {
+    if (
+      log.actionType === 'CREATED' ||
+      log.actionType === 'RESENT' ||
+      log.actionType === 'ACCEPTED'
+    ) {
+      return 40;
+    }
+    if (log.actionType === 'COMPLETED') return 50;
+  }
+
+  if (log.targetType === 'ORGANISATION') {
+    if (log.actionType === 'CREATED') return 35;
+    if (log.actionType === 'ENABLED') return 60;
+    if (log.actionType === 'SUSPENDED' || log.actionType === 'REACTIVATED') return 70;
+  }
+
+  return 90;
+}
+
+function publicTimelineEvent(event: InternalPlatformTimelineEvent): PlatformTimelineEvent {
+  return {
+    id: event.id,
+    type: event.type,
+    timestamp: event.timestamp,
+    action: event.action,
+    summary: event.summary,
+    actor: event.actor,
+    outcome: event.outcome,
+    metadata: event.metadata,
+  };
+}
+
 async function buildPlatformTimeline(
   organisationId: string | null,
   requestId: string | null,
@@ -426,16 +481,7 @@ async function buildPlatformTimeline(
   // Email logs scoped to the authoritative initial-admin invitation only.
   const emailLogs = await OrganisationRepository.findEmailLogsForTimeline(invitationId);
 
-  const timeline: Array<{
-    id: string;
-    type: 'AUDIT_LOG' | 'EMAIL_DELIVERY';
-    timestamp: string;
-    action: string;
-    summary: string;
-    actor: string | null;
-    outcome: string | null;
-    metadata: null;
-  }> = [];
+  const timeline: InternalPlatformTimelineEvent[] = [];
 
   for (const log of auditLogs) {
     // Actor name uses firstName + lastName only -- no email fallback to avoid leaking addresses.
@@ -453,6 +499,7 @@ async function buildPlatformTimeline(
       actor: actorName,
       outcome: log.outcome,
       metadata: null,
+      timelineSequence: auditTimelineSequence(log),
     });
   }
 
@@ -467,19 +514,21 @@ async function buildPlatformTimeline(
       actor: 'System',
       outcome: log.deliveryStatus,
       metadata: null,
+      timelineSequence: 40,
     });
   }
 
   timeline.sort((a, b) => {
     const timeDiff = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
     if (timeDiff !== 0) return timeDiff;
-    // Secondary sort by id DESC for determinism when timestamps are equal
+    const sequenceDiff = a.timelineSequence - b.timelineSequence;
+    if (sequenceDiff !== 0) return sequenceDiff;
     if (b.id > a.id) return 1;
     if (b.id < a.id) return -1;
     return 0;
   });
 
-  return timeline;
+  return timeline.map(publicTimelineEvent);
 }
 
 /**

--- a/apps/backend/src/services/setup.service.ts
+++ b/apps/backend/src/services/setup.service.ts
@@ -103,11 +103,11 @@ async function seedInitialAdminPermissionsAndActivateOrg(
 
   let organisationActivated = false;
   if (org.status === 'PENDING_ONBOARDING' && 'organisation' in tx) {
-    await tx.organisation.update({
-      where: { id: org.id },
+    const activationResult = await tx.organisation.updateMany({
+      where: { id: org.id, status: 'PENDING_ONBOARDING' },
       data: { status: 'ACTIVE' },
     });
-    organisationActivated = true;
+    organisationActivated = activationResult.count === 1;
   }
 
   if (!('organisationAdminProfile' in tx)) {
@@ -256,7 +256,7 @@ export async function completeSetupWithToken(
           organisationId: freshToken.invitation.organisation.id,
           targetType: 'ORGANISATION',
           targetId: freshToken.invitation.organisation.id,
-          actionType: 'REACTIVATED',
+          actionType: 'ENABLED',
           outcome: 'SUCCESS',
           metadata: {
             milestone: 'ORGANISATION_ACTIVATED',

--- a/apps/backend/src/services/setup.service.ts
+++ b/apps/backend/src/services/setup.service.ts
@@ -94,22 +94,24 @@ async function seedInitialAdminPermissionsAndActivateOrg(
   tx: SetupTransaction,
 ) {
   if (freshToken.purpose !== 'INITIAL_ORGANISATION_ADMIN_SETUP') {
-    return;
+    return false;
   }
   const org = freshToken.invitation?.organisation;
   if (!org) {
-    return;
+    return false;
   }
 
+  let organisationActivated = false;
   if (org.status === 'PENDING_ONBOARDING' && 'organisation' in tx) {
     await tx.organisation.update({
       where: { id: org.id },
       data: { status: 'ACTIVE' },
     });
+    organisationActivated = true;
   }
 
   if (!('organisationAdminProfile' in tx)) {
-    return;
+    return organisationActivated;
   }
 
   const adminProfile = await tx.organisationAdminProfile.findFirst({
@@ -117,7 +119,7 @@ async function seedInitialAdminPermissionsAndActivateOrg(
   });
 
   if (!adminProfile) {
-    return;
+    return organisationActivated;
   }
 
   if ('organisationPermission' in tx && 'organisationAdminPermission' in tx) {
@@ -137,6 +139,7 @@ async function seedInitialAdminPermissionsAndActivateOrg(
       skipDuplicates: true,
     });
   }
+  return organisationActivated;
 }
 
 export async function completeSetupWithToken(
@@ -235,7 +238,35 @@ export async function completeSetupWithToken(
       );
     }
 
-    await seedInitialAdminPermissionsAndActivateOrg(user, freshToken, tx);
+    const organisationActivated = await seedInitialAdminPermissionsAndActivateOrg(
+      user,
+      freshToken,
+      tx,
+    );
+
+    if (
+      organisationActivated &&
+      freshToken.purpose === 'INITIAL_ORGANISATION_ADMIN_SETUP' &&
+      freshToken.invitation?.organisation
+    ) {
+      await recordAuditLog(
+        {
+          actorUserId: user.id,
+          actorType: 'ORGANISATION_ADMIN',
+          organisationId: freshToken.invitation.organisation.id,
+          targetType: 'ORGANISATION',
+          targetId: freshToken.invitation.organisation.id,
+          actionType: 'REACTIVATED',
+          outcome: 'SUCCESS',
+          metadata: {
+            milestone: 'ORGANISATION_ACTIVATED',
+            fromStatus: 'PENDING_ONBOARDING',
+            toStatus: 'ACTIVE',
+          },
+        },
+        tx,
+      );
+    }
 
     return user;
   });

--- a/apps/backend/src/services/setup.service.ts
+++ b/apps/backend/src/services/setup.service.ts
@@ -19,6 +19,7 @@ import {
   type SetupUserType,
 } from '../repositories/setup.repository.js';
 import { runWithConsumedActionToken, validateActionToken } from './action-token.service.js';
+import { recordAuditLog } from './audit-log.service.js';
 import { ensureActiveOrganisation } from './auth-status-guard.service.js';
 import { hashPassword } from './password.service.js';
 
@@ -214,6 +215,24 @@ export async function completeSetupWithToken(
 
     if (freshToken.invitationId) {
       await markInvitationAccepted(freshToken.invitationId, tx);
+    }
+
+    if (freshToken.purpose === 'INITIAL_ORGANISATION_ADMIN_SETUP' && freshToken.invitation) {
+      await recordAuditLog(
+        {
+          actorUserId: user.id,
+          actorType: 'ORGANISATION_ADMIN',
+          organisationId: freshToken.invitation.organisationId,
+          targetType: 'INVITATION',
+          targetId: freshToken.invitation.id,
+          actionType: 'COMPLETED',
+          outcome: 'SUCCESS',
+          metadata: {
+            milestone: 'INITIAL_ADMIN_SETUP_COMPLETED',
+          },
+        },
+        tx,
+      );
     }
 
     await seedInitialAdminPermissionsAndActivateOrg(user, freshToken, tx);

--- a/apps/backend/tests/unit/repositories/organisation.repository.test.ts
+++ b/apps/backend/tests/unit/repositories/organisation.repository.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { findAuditLogsForTimeline } from '../../../src/repositories/organisation.repository.js';
+
+const prismaMock = vi.hoisted(() => ({
+  auditLogEntry: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
+
+describe('organisation repository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scopes onboarding timeline audit logs to authoritative targets', async () => {
+    prismaMock.auditLogEntry.findMany.mockResolvedValue([]);
+
+    await findAuditLogsForTimeline({
+      organisationId: 'org-1',
+      requestId: 'request-1',
+      invitationId: 'initial-admin-invitation-1',
+    });
+
+    expect(prismaMock.auditLogEntry.findMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          {
+            organisationId: 'org-1',
+            targetType: 'ORGANISATION',
+            targetId: 'org-1',
+            actionType: { in: ['CREATED', 'ENABLED', 'SUSPENDED', 'REACTIVATED'] },
+          },
+          {
+            targetType: 'ORGANISATION_REGISTRATION_REQUEST',
+            targetId: 'request-1',
+            actionType: { in: ['CREATED', 'CONTACTED', 'APPROVED', 'REJECTED'] },
+          },
+          {
+            targetType: 'INVITATION',
+            targetId: 'initial-admin-invitation-1',
+            actionType: { in: ['CREATED', 'RESENT', 'ACCEPTED', 'COMPLETED'] },
+          },
+        ],
+      },
+      include: {
+        actorUser: {
+          select: {
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: 50,
+    });
+  });
+});

--- a/apps/backend/tests/unit/services/platformOrganisation.service.test.ts
+++ b/apps/backend/tests/unit/services/platformOrganisation.service.test.ts
@@ -275,8 +275,8 @@ describe('platformOrganisation service', () => {
       expect(response.admins[0].isInitialAdmin).toBe(false);
       expect(response.timeline).toHaveLength(4);
       expect(response.timeline.map((event) => event.action)).toEqual([
-        'COMPLETED',
         'ENABLED',
+        'COMPLETED',
         'INITIAL_ORGANISATION_ADMIN_SETUP',
         'APPROVED',
       ]);

--- a/apps/backend/tests/unit/services/platformOrganisation.service.test.ts
+++ b/apps/backend/tests/unit/services/platformOrganisation.service.test.ts
@@ -202,7 +202,7 @@ describe('platformOrganisation service', () => {
       const mockAuditLogs = [
         {
           id: 'audit-3',
-          actionType: 'REACTIVATED',
+          actionType: 'ENABLED',
           targetType: 'ORGANISATION',
           createdAt: new Date('2026-07-01T08:45:00Z'),
           outcome: 'SUCCESS',
@@ -215,7 +215,7 @@ describe('platformOrganisation service', () => {
           id: 'audit-2',
           actionType: 'COMPLETED',
           targetType: 'INVITATION',
-          createdAt: new Date('2026-07-01T08:40:00Z'),
+          createdAt: new Date('2026-07-01T08:45:00Z'),
           outcome: 'SUCCESS',
           actorUser: {
             firstName: 'Bob',
@@ -275,8 +275,8 @@ describe('platformOrganisation service', () => {
       expect(response.admins[0].isInitialAdmin).toBe(false);
       expect(response.timeline).toHaveLength(4);
       expect(response.timeline.map((event) => event.action)).toEqual([
-        'REACTIVATED',
         'COMPLETED',
+        'ENABLED',
         'INITIAL_ORGANISATION_ADMIN_SETUP',
         'APPROVED',
       ]);

--- a/apps/backend/tests/unit/services/platformOrganisation.service.test.ts
+++ b/apps/backend/tests/unit/services/platformOrganisation.service.test.ts
@@ -201,6 +201,28 @@ describe('platformOrganisation service', () => {
 
       const mockAuditLogs = [
         {
+          id: 'audit-3',
+          actionType: 'REACTIVATED',
+          targetType: 'ORGANISATION',
+          createdAt: new Date('2026-07-01T08:45:00Z'),
+          outcome: 'SUCCESS',
+          actorUser: {
+            firstName: 'Bob',
+            lastName: 'Builder',
+          },
+        },
+        {
+          id: 'audit-2',
+          actionType: 'COMPLETED',
+          targetType: 'INVITATION',
+          createdAt: new Date('2026-07-01T08:40:00Z'),
+          outcome: 'SUCCESS',
+          actorUser: {
+            firstName: 'Bob',
+            lastName: 'Builder',
+          },
+        },
+        {
           id: 'audit-1',
           actionType: 'APPROVED',
           targetType: 'ORGANISATION_REGISTRATION_REQUEST',
@@ -251,14 +273,33 @@ describe('platformOrganisation service', () => {
       expect(response.admins).toHaveLength(1);
       expect(response.admins[0].email).toBe('alice@target.com');
       expect(response.admins[0].isInitialAdmin).toBe(false);
-      expect(response.timeline).toHaveLength(2); // 1 audit log + 1 email log
-      expect(response.timeline[0].type).toBe('EMAIL_DELIVERY'); // sorted by desc timestamp
-      expect(response.timeline[0].outcome).toBe('SENT');
-      expect(response.timeline[0].actor).toBe('System');
-      expect(response.timeline[1].type).toBe('AUDIT_LOG');
-      expect(response.timeline[1].outcome).toBe('SUCCESS');
-      expect(response.timeline[1].actor).toBe('Patricia Platform');
-      expect(response.timeline[1].metadata).toBeNull();
+      expect(response.timeline).toHaveLength(4);
+      expect(response.timeline.map((event) => event.action)).toEqual([
+        'REACTIVATED',
+        'COMPLETED',
+        'INITIAL_ORGANISATION_ADMIN_SETUP',
+        'APPROVED',
+      ]);
+      expect(response.timeline[0]).toEqual(
+        expect.objectContaining({
+          type: 'AUDIT_LOG',
+          outcome: 'SUCCESS',
+          actor: 'Bob Builder',
+          metadata: null,
+        }),
+      );
+      expect(response.timeline[1]).toEqual(
+        expect.objectContaining({
+          type: 'AUDIT_LOG',
+          outcome: 'SUCCESS',
+          actor: 'Bob Builder',
+          metadata: null,
+        }),
+      );
+      expect(response.timeline[2].type).toBe('EMAIL_DELIVERY');
+      expect(response.timeline[2].outcome).toBe('SENT');
+      expect(response.timeline[2].actor).toBe('System');
+      expect(response.timeline[3].actor).toBe('Patricia Platform');
     });
 
     it('throws 404 error if organisation is not found', async () => {

--- a/apps/backend/tests/unit/setup.service.test.ts
+++ b/apps/backend/tests/unit/setup.service.test.ts
@@ -23,6 +23,10 @@ const actionTokenServiceMock = vi.hoisted(() => ({
   validateActionToken: vi.fn(),
 }));
 
+const auditLogServiceMock = vi.hoisted(() => ({
+  recordAuditLog: vi.fn(),
+}));
+
 const authEmailHookServiceMock = vi.hoisted(() => ({
   requestAuthEmailSend: vi.fn(),
 }));
@@ -33,6 +37,7 @@ const passwordServiceMock = vi.hoisted(() => ({
 
 vi.mock('../../src/repositories/setup.repository.js', () => setupRepositoryMock);
 vi.mock('../../src/services/action-token.service.js', () => actionTokenServiceMock);
+vi.mock('../../src/services/audit-log.service.js', () => auditLogServiceMock);
 vi.mock('../../src/services/auth-email-hook.service.js', () => authEmailHookServiceMock);
 vi.mock('../../src/services/password.service.js', () => passwordServiceMock);
 
@@ -140,6 +145,7 @@ describe('setup service', () => {
     setupRepositoryMock.findSetupUserByEmail.mockResolvedValue(null);
     setupRepositoryMock.createOrganisationTraineeUser.mockResolvedValue(publicUser);
     setupRepositoryMock.markInvitationAccepted.mockResolvedValue({ id: 'invitation-1' });
+    auditLogServiceMock.recordAuditLog.mockResolvedValue({ id: 'audit-1' });
 
     passwordServiceMock.hashPassword.mockResolvedValue('hashed-password');
     authEmailHookServiceMock.requestAuthEmailSend.mockResolvedValue({
@@ -346,10 +352,54 @@ describe('setup service', () => {
 
     await completeSetupWithToken(rawSetupValue, completeSetupInput);
 
+    expect(auditLogServiceMock.recordAuditLog).toHaveBeenCalledWith(
+      {
+        actorUserId: publicAdminUser.id,
+        actorType: 'ORGANISATION_ADMIN',
+        organisationId: 'org-1',
+        targetType: 'INVITATION',
+        targetId: 'initial-admin-invitation-1',
+        actionType: 'COMPLETED',
+        outcome: 'SUCCESS',
+        metadata: {
+          milestone: 'INITIAL_ADMIN_SETUP_COMPLETED',
+        },
+      },
+      customTx,
+    );
     expect(organisationUpdateMock).toHaveBeenCalledWith({
       where: { id: 'org-1' },
       data: { status: 'ACTIVE' },
     });
+    expect(auditLogServiceMock.recordAuditLog).toHaveBeenCalledWith(
+      {
+        actorUserId: publicAdminUser.id,
+        actorType: 'ORGANISATION_ADMIN',
+        organisationId: 'org-1',
+        targetType: 'ORGANISATION',
+        targetId: 'org-1',
+        actionType: 'REACTIVATED',
+        outcome: 'SUCCESS',
+        metadata: {
+          milestone: 'ORGANISATION_ACTIVATED',
+          fromStatus: 'PENDING_ONBOARDING',
+          toStatus: 'ACTIVE',
+        },
+      },
+      customTx,
+    );
+    expect(auditLogServiceMock.recordAuditLog).toHaveBeenCalledTimes(2);
+
+    const auditMetadataText = JSON.stringify(
+      auditLogServiceMock.recordAuditLog.mock.calls.map(([entry]) => entry.metadata ?? {}),
+    );
+    expect(auditMetadataText).not.toContain('@');
+    expect(auditMetadataText).not.toContain(rawSetupValue);
+    expect(auditMetadataText).not.toContain('tokenHash');
+    expect(auditMetadataText).not.toContain('permission');
+    expect(auditLogServiceMock.recordAuditLog.mock.invocationCallOrder[0]).toBeLessThan(
+      organisationUpdateMock.mock.invocationCallOrder[0],
+    );
     expect(adminProfileFindFirstMock).toHaveBeenCalledWith({
       where: { userId: publicAdminUser.id, organisationId: 'org-1' },
     });
@@ -433,5 +483,17 @@ describe('setup service', () => {
     );
 
     expect(authEmailHookServiceMock.requestAuthEmailSend).not.toHaveBeenCalled();
+  });
+
+  it('does not record setup success milestones when the action-token claim is stale', async () => {
+    actionTokenServiceMock.runWithConsumedActionToken.mockResolvedValue({
+      claimed: false,
+    });
+
+    await expect(completeSetupWithToken(rawSetupValue, completeSetupInput)).rejects.toBeInstanceOf(
+      SetupFlowError,
+    );
+
+    expect(auditLogServiceMock.recordAuditLog).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/tests/unit/setup.service.test.ts
+++ b/apps/backend/tests/unit/setup.service.test.ts
@@ -329,7 +329,7 @@ describe('setup service', () => {
     );
     setupRepositoryMock.createOrganisationAdminUser.mockResolvedValue(publicAdminUser);
 
-    const organisationUpdateMock = vi.fn();
+    const organisationUpdateManyMock = vi.fn().mockResolvedValue({ count: 1 });
     const adminProfileFindFirstMock = vi.fn().mockResolvedValue({ id: 'admin-profile-1' });
     const organisationPermissionFindManyMock = vi
       .fn()
@@ -337,7 +337,7 @@ describe('setup service', () => {
     const organisationAdminPermissionCreateManyMock = vi.fn();
 
     const customTx = {
-      organisation: { update: organisationUpdateMock },
+      organisation: { updateMany: organisationUpdateManyMock },
       organisationAdminProfile: { findFirst: adminProfileFindFirstMock },
       organisationPermission: { findMany: organisationPermissionFindManyMock },
       organisationAdminPermission: { createMany: organisationAdminPermissionCreateManyMock },
@@ -367,8 +367,8 @@ describe('setup service', () => {
       },
       customTx,
     );
-    expect(organisationUpdateMock).toHaveBeenCalledWith({
-      where: { id: 'org-1' },
+    expect(organisationUpdateManyMock).toHaveBeenCalledWith({
+      where: { id: 'org-1', status: 'PENDING_ONBOARDING' },
       data: { status: 'ACTIVE' },
     });
     expect(auditLogServiceMock.recordAuditLog).toHaveBeenCalledWith(
@@ -378,7 +378,7 @@ describe('setup service', () => {
         organisationId: 'org-1',
         targetType: 'ORGANISATION',
         targetId: 'org-1',
-        actionType: 'REACTIVATED',
+        actionType: 'ENABLED',
         outcome: 'SUCCESS',
         metadata: {
           milestone: 'ORGANISATION_ACTIVATED',
@@ -398,7 +398,7 @@ describe('setup service', () => {
     expect(auditMetadataText).not.toContain('tokenHash');
     expect(auditMetadataText).not.toContain('permission');
     expect(auditLogServiceMock.recordAuditLog.mock.invocationCallOrder[0]).toBeLessThan(
-      organisationUpdateMock.mock.invocationCallOrder[0],
+      organisationUpdateManyMock.mock.invocationCallOrder[0],
     );
     expect(adminProfileFindFirstMock).toHaveBeenCalledWith({
       where: { userId: publicAdminUser.id, organisationId: 'org-1' },
@@ -417,6 +417,72 @@ describe('setup service', () => {
       ],
       skipDuplicates: true,
     });
+  });
+
+  it('does not record organisation activation when the conditional status update does not match', async () => {
+    setupRepositoryMock.findSetupActionTokenById.mockResolvedValue(
+      setupToken({
+        purpose: 'INITIAL_ORGANISATION_ADMIN_SETUP',
+        targetEmail: 'admin@example.com',
+        invitationId: 'initial-admin-invitation-1',
+        invitation: {
+          ...setupToken().invitation,
+          id: 'initial-admin-invitation-1',
+          recipientEmail: 'admin@example.com',
+          organisation: {
+            id: 'org-1',
+            name: 'Acme Security',
+            status: 'PENDING_ONBOARDING',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        },
+      }),
+    );
+    setupRepositoryMock.createOrganisationAdminUser.mockResolvedValue(publicAdminUser);
+
+    const organisationUpdateManyMock = vi.fn().mockResolvedValue({ count: 0 });
+    const adminProfileFindFirstMock = vi.fn().mockResolvedValue({ id: 'admin-profile-1' });
+    const organisationPermissionFindManyMock = vi.fn().mockResolvedValue([]);
+    const organisationAdminPermissionCreateManyMock = vi.fn();
+
+    const customTx = {
+      organisation: { updateMany: organisationUpdateManyMock },
+      organisationAdminProfile: { findFirst: adminProfileFindFirstMock },
+      organisationPermission: { findMany: organisationPermissionFindManyMock },
+      organisationAdminPermission: { createMany: organisationAdminPermissionCreateManyMock },
+    } as unknown as PrismaClient;
+
+    actionTokenServiceMock.runWithConsumedActionToken.mockImplementation(
+      async (_input, action) => ({
+        claimed: true,
+        result: await action(customTx),
+      }),
+    );
+
+    await completeSetupWithToken(rawSetupValue, completeSetupInput);
+
+    expect(organisationUpdateManyMock).toHaveBeenCalledWith({
+      where: { id: 'org-1', status: 'PENDING_ONBOARDING' },
+      data: { status: 'ACTIVE' },
+    });
+    expect(auditLogServiceMock.recordAuditLog).toHaveBeenCalledTimes(1);
+    expect(auditLogServiceMock.recordAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetType: 'INVITATION',
+        targetId: 'initial-admin-invitation-1',
+        actionType: 'COMPLETED',
+      }),
+      customTx,
+    );
+    expect(auditLogServiceMock.recordAuditLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetType: 'ORGANISATION',
+        targetId: 'org-1',
+        actionType: 'ENABLED',
+      }),
+      expect.anything(),
+    );
   });
 
   it.each(['FAILED_TO_SEND', 'ACCEPTED', 'EXPIRED', 'REVOKED'])(

--- a/packages/shared/src/validation/organisation.ts
+++ b/packages/shared/src/validation/organisation.ts
@@ -84,6 +84,7 @@ export const timelineAuditActionSchema = z.enum([
   'RESENT',
   'ACCEPTED',
   'COMPLETED',
+  'ENABLED',
   'SUSPENDED',
   'REACTIVATED',
 ]);


### PR DESCRIPTION
## Summary

Adds the missing onboarding audit milestones for successful initial organisation-admin setup completion and organisation activation.

This PR updates the setup-completion flow so that, when an `INITIAL_ORGANISATION_ADMIN_SETUP` token is completed successfully, the backend records compact audit entries for:

- the initial-admin setup invitation being completed
- the organisation moving from onboarding into its active state

These audit writes happen inside the same successful setup transaction as token consumption, invitation acceptance, user/profile creation, and organisation activation. Failed, stale, invalid, or repeated setup attempts do not create success milestones.

The timeline allowlist/expectations are also aligned so the platform onboarding timeline can display the new compact entries without introducing a broader audit-log viewer.

## Linked Issue

Closes #339

## Type of change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [x] Chore/Maintenance

## Testing

Ran:

- `pnpm --filter @insightful-phish/backend test -- setup.service`
- `pnpm --filter @insightful-phish/backend test -- platformOrganisation`
- `pnpm --filter @insightful-phish/backend test`
- `pnpm --filter @insightful-phish/backend test:integration`
- `pnpm typecheck:backend`
- `pnpm build:backend`
- `pnpm lint:backend`
- `git diff --check`

Verified:

- successful initial-admin setup records the setup-completion audit milestone
- successful initial-admin setup records the organisation-activation audit milestone
- audit entries are scoped to the correct organisation
- failed or stale setup attempts do not create duplicate success milestones
- repeated use of a consumed setup token does not create duplicate onboarding milestones
- platform organisation timeline includes the new compact onboarding entries under the existing allowlist
- audit metadata does not include names, email addresses, raw tokens, token hashes, permission sets, request bodies, or raw provider/database details

## Review Notes

Reviewers should focus on:

- the `completeSetupWithToken` transaction path
- audit writes only happening for `INITIAL_ORGANISATION_ADMIN_SETUP`
- setup completion and organisation activation milestones being recorded atomically with setup completion
- timeline visibility for the new entries
- idempotency for stale/repeated token attempts
- metadata minimisation in the new audit entries

This PR intentionally does not add a general audit-log viewer, broader audit coverage, frontend changes, migrations, queue/retry work, or onboarding timeline features beyond the missing milestone entries.

## Checklist

- [x] I tested the change locally
- [x] Accessibility impact was considered if applicable
- [x] No unrelated changes are included
- [x] Relevant tests were added or updated if applicable
- [ ] Documentation was updated if needed
- [x] No secrets, credentials, or sensitive values were committed

